### PR TITLE
Deploy-time fixes from §5 smoke test

### DIFF
--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -40,15 +40,18 @@ export interface GamesEnv extends SessionEnv {
 	SHARE_BUCKET: R2Bucket;
 	SHARE_DB: D1Database;
 	ALLOWED_ORIGINS: string;
+	// Upload-bucket rate limits (apply to uploads + reimports together).
+	// Strings because wrangler.toml `[vars]` are always strings at runtime;
+	// parsed with parseInt at the call site.
+	PER_USER_UPLOADS_PER_HOUR: string;
+	PER_IP_UPLOADS_PER_HOUR: string;
+	GLOBAL_UPLOADS_PER_HOUR: string;
 }
 
-// Size + rate limits (spec §4)
+// Size limits (spec §4)
 const MAX_BLOB_COMPRESSED = 10 * 1024 * 1024; // 10 MB
 const MAX_BLOB_DECOMPRESSED = 50 * 1024 * 1024; // 50 MB
 const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB
-const PER_USER_UPLOADS_PER_HOUR = 20;
-const PER_IP_UPLOADS_PER_HOUR = 30;
-const GLOBAL_UPLOADS_PER_HOUR = 500;
 
 // Anonymous public-game read limit (per-IP, global via D1 `events` table).
 const ANON_READS_PER_HOUR = 200;
@@ -707,7 +710,7 @@ export async function handleGameUpload(
 			UPLOAD_EVENT_TYPES,
 			"user_id",
 			userId,
-		)) >= PER_USER_UPLOADS_PER_HOUR
+		)) >= parseInt(env.PER_USER_UPLOADS_PER_HOUR)
 	) {
 		return errorResponse(
 			"Per-user upload limit exceeded",
@@ -723,7 +726,7 @@ export async function handleGameUpload(
 			UPLOAD_EVENT_TYPES,
 			"ip_address",
 			ip,
-		)) >= PER_IP_UPLOADS_PER_HOUR
+		)) >= parseInt(env.PER_IP_UPLOADS_PER_HOUR)
 	) {
 		return errorResponse(
 			"Per-IP upload limit exceeded",
@@ -734,7 +737,7 @@ export async function handleGameUpload(
 	}
 	if (
 		(await countEventsSince(env.SHARE_DB, UPLOAD_EVENT_TYPES, null, null)) >=
-		GLOBAL_UPLOADS_PER_HOUR
+		parseInt(env.GLOBAL_UPLOADS_PER_HOUR)
 	) {
 		return errorResponse(
 			"Global upload limit exceeded",

--- a/cloud/src/session.ts
+++ b/cloud/src/session.ts
@@ -98,6 +98,26 @@ export async function sessionFromRequest(
 	return { token, data };
 }
 
+// Pick the cookie Domain attribute for the session cookie.
+//
+// In prod the API runs on api.per-ankh.app but the SSR frontend runs on
+// per-ankh.app. Without an explicit Domain, the cookie is scoped to
+// api.per-ankh.app only, which means the browser never sends it to
+// per-ankh.app — so SSR loads of authenticated pages see no auth and
+// have to redirect to /login on every hard refresh.
+//
+// Setting Domain=per-ankh.app shares the cookie across both subdomains.
+// The SSR Worker can then read it on hard refresh and forward it to the
+// API via the handleFetch hook in src/hooks.server.ts.
+//
+// Returns null in dev (localhost) where ports differ but host is shared,
+// so no Domain attribute is needed.
+function sessionCookieDomain(request: Request): string | null {
+	const host = new URL(request.url).host;
+	if (host.endsWith("per-ankh.app")) return "per-ankh.app";
+	return null;
+}
+
 // Build a Set-Cookie value for the session token. Secure flag conditional
 // on the request being HTTPS so localhost dev (HTTP) works.
 export function sessionCookie(token: string, request: Request): string {
@@ -108,10 +128,14 @@ export function sessionCookie(token: string, request: Request): string {
 		"Path=/",
 		`Max-Age=${SESSION_TTL_SECONDS}`,
 	];
+	const domain = sessionCookieDomain(request);
+	if (domain) parts.push(`Domain=${domain}`);
 	if (isSecureRequest(request)) parts.push("Secure");
 	return parts.join("; ");
 }
 
+// Domain must match the original Set-Cookie or the browser treats this
+// as a different cookie and won't clear the real one.
 export function clearSessionCookie(request: Request): string {
 	const parts = [
 		`${SESSION_COOKIE}=`,
@@ -120,6 +144,8 @@ export function clearSessionCookie(request: Request): string {
 		"Path=/",
 		"Max-Age=0",
 	];
+	const domain = sessionCookieDomain(request);
+	if (domain) parts.push(`Domain=${domain}`);
 	if (isSecureRequest(request)) parts.push("Secure");
 	return parts.join("; ");
 }

--- a/cloud/src/util.ts
+++ b/cloud/src/util.ts
@@ -36,6 +36,13 @@ export function parseCookies(
 }
 
 // CORS for legacy /v1/share/* — single allowed origin, no credentials.
+//
+// Vary: Origin is needed because /v1/share/:id is publicly cached
+// (Cache-Control: public, max-age=3600). Without it, the CDN and
+// browser disk cache key by URL alone and serve one response across
+// all origins — so a CORS-config change can leave the wrong ACL
+// header cached for up to an hour. Same value works as a shield for
+// OPTIONS preflight responses too.
 export function legacyCorsHeaders(
 	env: Pick<CommonEnv, "ALLOWED_ORIGIN">,
 ): Record<string, string> {
@@ -44,6 +51,7 @@ export function legacyCorsHeaders(
 		"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
 		"Access-Control-Allow-Headers": "Content-Type, X-App-Key, X-Delete-Token",
 		"Access-Control-Max-Age": "86400",
+		Vary: "Origin",
 	};
 }
 

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -45,8 +45,12 @@ preview_id = "e4725d2a3a324ec98580f6d6cae1f209"
 MAX_COMPRESSED_SIZE = "5242880"
 # Max decompressed payload size (20 MB) — gzip bomb protection
 MAX_DECOMPRESSED_SIZE = "20971520"
-# CORS for legacy /v1/share/*: single origin only
-ALLOWED_ORIGIN = "https://per-ankh.app"
+# CORS for legacy /v1/share/*: single origin only. The legacy share viewer
+# now lives at legacy.per-ankh.app (post-cutover), so its browser fetches
+# come from that origin. Desktop v0.2.0 (Tauri) is a native HTTP client
+# and doesn't enforce CORS, so it's unaffected by this value. The new
+# SSR app on per-ankh.app does not call /v1/share/* at all.
+ALLOWED_ORIGIN = "https://legacy.per-ankh.app"
 # Rate limit: max uploads per app key per hour
 RATE_LIMIT_PER_HOUR = "10"
 # Rate limit: max downloads per IP per hour (via Cache API)

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -58,6 +58,19 @@ GLOBAL_UPLOAD_LIMIT_PER_HOUR = "200"
 # Kill switch: set to "false" via `wrangler secret put` to disable uploads without redeploying
 UPLOADS_ENABLED = "true"
 
+# === Cloud rewrite upload limits ===
+# Apply to uploads + reimports together (same R2/D1 work). Set generous —
+# reimports are forced by parser-version bumps (BulkReparseModal), so
+# anything tight breaks legitimate workflows. Tighten reactively if abuse
+# signal appears.
+PER_USER_UPLOADS_PER_HOUR = "100"
+# 2x PER_USER gives real headroom for shared IPs (households, offices, NAT)
+# while still catching single-IP abuse rotating across accounts.
+PER_IP_UPLOADS_PER_HOUR = "200"
+# Global circuit breaker. Saturates around 50 concurrently-active users —
+# a real "something is wrong" threshold, not a normal-growth ceiling.
+GLOBAL_UPLOADS_PER_HOUR = "5000"
+
 # === Cloud rewrite (/v1/auth/*, /v1/games/*) ===
 # CORS allowlist for new routes — comma-separated origins. Cookie-based
 # auth requires Access-Control-Allow-Credentials: true, which forbids the

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -5,7 +5,7 @@
 // hardening — XFO, Referrer-Policy, Permissions-Policy, X-Content-Type-
 // Options — applies regardless of the request type.
 
-import type { Handle } from "@sveltejs/kit";
+import type { Handle, HandleFetch } from "@sveltejs/kit";
 import { dev } from "$app/environment";
 
 // Headers from server-side fetches in load() that we need to read in
@@ -35,6 +35,28 @@ const reportToHeader = JSON.stringify({
 		},
 	],
 });
+
+// Cross-origin SSR fetch to the API needs the incoming request's Cookie
+// header forwarded by hand — SvelteKit's `event.fetch` does not forward
+// cookies cross-origin (browser-like security). Without this, hard
+// refreshes of authenticated pages (e.g. /games/[id], /dashboard) call
+// the API server-side with no auth and get 401, redirecting to /login
+// despite the user having a valid session cookie.
+//
+// Pairs with cloud/src/session.ts setting Domain=per-ankh.app on the
+// session cookie — that's what makes the cookie visible on per-ankh.app
+// (where SSR reads it) in the first place.
+export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
+	const target = new URL(request.url);
+	const isApi =
+		target.hostname === "api.per-ankh.app" ||
+		(dev && target.hostname === "localhost" && target.port === "8787");
+	if (isApi) {
+		const cookie = event.request.headers.get("cookie");
+		if (cookie) request.headers.set("cookie", cookie);
+	}
+	return fetch(request);
+};
 
 export const handle: Handle = async ({ event, resolve }) => {
 	// Legacy share URLs (minted by desktop v0.2.0 as

--- a/src/lib/CloudHeader.svelte
+++ b/src/lib/CloudHeader.svelte
@@ -175,11 +175,18 @@
 		when the two overlap at narrow widths; pointer-events-auto on the
 		anchor itself so the wordmark stays clickable.
 	-->
+	<!--
+		Logged-out viewers (anonymous on a public game share) get the
+		marketing landing; logged-in users get their dashboard. Sending
+		anon users to /dashboard would trigger SvelteKit's hover-preload
+		of its load function, hitting /v1/stats, /v1/games, /v1/collections
+		and producing 401s in the console — visible noise with no UX win.
+	-->
 	<div class="pointer-events-none absolute left-1/2 -translate-x-1/2">
 		<a
-			href={resolve("/dashboard")}
+			href={resolve(user ? "/dashboard" : "/")}
 			class="pointer-events-auto block cursor-pointer transition-opacity hover:opacity-80"
-			aria-label="Per Ankh — go to dashboard"
+			aria-label={user ? "Per Ankh — go to dashboard" : "Per Ankh — home"}
 		>
 			<div
 				class="border-b-2 border-orange pb-1 text-3xl font-bold text-gray-200"

--- a/src/lib/CloudHeader.svelte
+++ b/src/lib/CloudHeader.svelte
@@ -3,7 +3,6 @@
 	// the deleted desktop Header.svelte: hamburger menu left, centered
 	// hieroglyph wordmark, search right. Auth-aware via the `user` prop.
 
-	import { goto, invalidateAll } from "$app/navigation";
 	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 	import SearchInput from "$lib/SearchInput.svelte";
@@ -47,12 +46,19 @@
 		try {
 			await cloudApi.logout();
 		} catch (err) {
-			// Worst case the cookie is still valid server-side; next
+			// Worst case the cookie is still valid server-side; the next
 			// request will surface that. Don't strand the user.
 			console.warn("Logout request failed:", err);
 		}
-		await invalidateAll();
-		await goto(resolve("/"), { replaceState: true });
+		// Full page reload, not invalidateAll + goto. Reasons:
+		//   1. CloudHeader lives in the layout and stays mounted across
+		//      same-app navigations, so `signingOut` would never reset.
+		//   2. `/+page.ts` redirects authenticated users to /dashboard,
+		//      so a soft navigation to / can bounce right back if the
+		//      cookie clear hasn't fully propagated to the next fetch.
+		// A hard reload re-runs SSR from scratch with whatever cookies
+		// the browser jar actually contains, destroying this component.
+		window.location.assign(resolve("/"));
 	}
 
 	function handleClickOutside(event: MouseEvent) {

--- a/src/lib/GameActions.svelte
+++ b/src/lib/GameActions.svelte
@@ -9,8 +9,9 @@
 	// closes the first.
 	//
 	//   - Public/Private lock: owner-only.
-	//   - Download: always rendered (anonymous viewers of public games
-	//     get bounced to /login on 401).
+	//   - Download: any signed-in user (owner or not). Hidden for anonymous
+	//     viewers — the API rejects unauthenticated downloads anyway, and
+	//     surfacing a button that immediately bounces to /login is noise.
 	//   - Delete: owner-only.
 
 	import { goto } from "$app/navigation";
@@ -208,6 +209,7 @@
 		</div>
 	{/if}
 
+	{#if page.data.user}
 	<div class="relative">
 		<button
 			type="button"
@@ -284,6 +286,7 @@
 			</div>
 		{/if}
 	</div>
+	{/if}
 
 	{#if isOwner}
 		<div class="relative">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,7 @@
 	import type { Snippet } from "svelte";
 	import { page } from "$app/state";
 	import CloudHeader from "$lib/CloudHeader.svelte";
-	import { PUBLIC_ORIGIN } from "$lib/page-meta";
+	import { PUBLIC_ORIGIN, type PageMeta } from "$lib/page-meta";
 	import type { LayoutData } from "./$types";
 
 	let { data, children }: { data: LayoutData; children: Snippet } = $props();
@@ -21,7 +21,11 @@
 	// returning `{ meta: PageMeta }` from their +page.ts load; otherwise
 	// they inherit DEFAULT_META from +layout.ts. Rendering once here
 	// avoids duplicate <meta> tags that crawlers handle inconsistently.
-	const meta = $derived(data.meta);
+	//
+	// Read from `page.data` (merged parent+child, child wins), not from
+	// the layout's own `data` prop (which is only LayoutData and would
+	// always be DEFAULT_META, losing per-page overrides).
+	const meta = $derived(page.data.meta as PageMeta);
 	const ogImage = $derived(meta.image ?? `${PUBLIC_ORIGIN}/og-default.png`);
 	const ogUrl = $derived(`${PUBLIC_ORIGIN}${page.url.pathname}`);
 </script>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,12 @@
+// Marketing landing is for signed-out visitors. A logged-in user
+// hitting / would see a "Login" CTA and assume they're signed out —
+// instead, bounce them straight to /dashboard. Parent's load already
+// fetched `user` via cloudApi.getMe, so this is free.
+import { redirect } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = async ({ parent }) => {
+	const { user } = await parent();
+	if (user) throw redirect(303, "/dashboard");
+	return {};
+};

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -13,8 +13,19 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 // http://localhost:8787 and the frontend on http://localhost:1420 — two
 // different origins, so client-side fetches need it whitelisted in
 // connect-src. Production CSP stays tight (only api.per-ankh.app).
+//
+// `cloudflareinsights.com` is the POST target for the Cloudflare Web
+// Analytics beacon (the script itself loads from
+// `static.cloudflareinsights.com`, allowed in script-src below).
+// Cloudflare auto-injects the beacon when Web Analytics is enabled on
+// the Worker; without both directives the script loads-and-blocks and
+// the beacon submission fails.
 const isDev = process.env.NODE_ENV !== "production";
-const connectSrc = ["self", "https://api.per-ankh.app"];
+const connectSrc = [
+	"self",
+	"https://api.per-ankh.app",
+	"https://cloudflareinsights.com",
+];
 if (isDev) connectSrc.push("http://localhost:8787");
 
 // Violation reports go to the API Worker. Sending to both the legacy
@@ -35,7 +46,7 @@ const config = {
 			mode: "hash",
 			directives: {
 				"default-src": ["self"],
-				"script-src": ["self"],
+				"script-src": ["self", "https://static.cloudflareinsights.com"],
 				"style-src": ["self", "unsafe-inline"],
 				"img-src": ["self", "data:", "https://cdn.discordapp.com"],
 				"connect-src": connectSrc,

--- a/web/src/lib/api-web.ts
+++ b/web/src/lib/api-web.ts
@@ -83,6 +83,24 @@ async function getSharedData(shareId: string): Promise<SharedGameData> {
 		throw "CORRUPT_DATA" as ShareError;
 	}
 
+	// Backward-compat: older desktop versions (pre-v0.2.0) didn't write
+	// every array field. The render gate in +page.svelte requires all 14
+	// fields truthy, so a missing field would leave the page blank with
+	// no error. Default missing arrays to [] — every consuming component
+	// handles empty arrays. We only default arrays; objects and required
+	// fields (game_details, version) are validated above.
+	data.player_history ??= [];
+	data.yield_history ??= [];
+	data.event_logs ??= [];
+	data.law_adoption_history ??= [];
+	data.current_laws ??= [];
+	data.tech_discovery_history ??= [];
+	data.completed_techs ??= [];
+	data.units_produced ??= [];
+	data.game_religions ??= [];
+	data.player_wonders ??= [];
+	data.map_tiles ??= [];
+
 	cache.set(shareId, data);
 	return data;
 }


### PR DESCRIPTION
## Summary

Ten atomic fixes uncovered while running the §5 smoke test against the live cutover. Each was deployed live during the smoke test and is already in production; this PR brings `main` in sync with the deployed state.

## Commits

- `f25db39` fix(cloud): share session cookie across per-ankh.app subdomains
- `674a4aa` fix(cloud): read meta from merged page data, not layout data
- `dedeef1` feat(cloud): redirect signed-in visitors at / to /dashboard
- `698fd78` fix(csp): allow Cloudflare Web Analytics beacon
- `14c1bb3` fix(cloud): hide download action for anonymous viewers
- `00e83d3` fix(web): default missing array fields in older share blobs
- `b19004e` fix(cloud): bump upload rate limits and promote to wrangler vars
- `161d91c` fix(cloud): point legacy CORS at legacy.per-ankh.app + Vary: Origin
- `c7389c2` fix(cloud): point header wordmark to / for anonymous viewers
- `f295d20` fix(cloud): hard-reload on logout to avoid stuck state

## Test plan

- [x] §5 smoke test steps 1–8 against https://per-ankh.app — all pass post-fix
- [x] Anonymous public share view in incognito — no console 401s, no download icon
- [x] Hard refresh on authenticated pages keeps the user signed in
- [x] Logout returns the user to / and signs them out cleanly
- [x] Old `/share/[id]` URL renders via the legacy SPA on legacy.per-ankh.app

## Merge

Use **merge commit** (not squash) to preserve the per-fix history — matches the pattern from #35 and keeps each fix bisectable.