### PR TITLE
fix(tournament): let a deliberately added blank part survive save

### DIFF
--- a/src/lib/tournament/SchedulePartEditor.svelte
+++ b/src/lib/tournament/SchedulePartEditor.svelte
@@ -29,6 +29,12 @@
 		time: Time | undefined;
 		casters: EditCaster[];
 		streams: EditStream[];
+		// True when the user explicitly clicked "+ Add part" (vs the blank row
+		// the editor seeds for a never-scheduled match). A deliberately added
+		// part saves even while still blank — "this match is going to a Part 2,
+		// time TBD" is real state — while the pristine seeded row stays a
+		// throwaway that saving won't persist.
+		added?: boolean;
 	}
 
 	// Mirror of the Worker's StreamUrlSchema host allow-list. The cloud schema is

--- a/src/lib/tournament/SchedulePopover.svelte
+++ b/src/lib/tournament/SchedulePopover.svelte
@@ -134,40 +134,44 @@
 	);
 
 	async function save() {
+		// Pair each source part with its request payload so the blank-part filter
+		// can read both the editor-only state (added? / temp id) and the computed
+		// payload, then project down to just the payloads.
 		const payload = parts
 			.map((p) => ({
-				// Threads through for the blank-part filter below; stripped before
-				// the request.
-				keepIfBlank: p.added === true || !p.id?.startsWith("tmp-"),
-				// Temp (client-key) ids are stripped; the server mints real ones.
-				id: p.id?.startsWith("tmp-") ? undefined : p.id,
-				scheduled_at: partToIso(p.date, p.time, tz),
-				// Keep caster order (streamer first); drop rows left blank.
-				casters: p.casters
-					.map((c) => ({
-						user_id: c.userId,
-						name: c.value.trim() ? c.value.trim() : null,
-					}))
-					.filter((c) => c.user_id !== null || c.name !== null),
-				streams: p.streams
-					.filter((v) => v.url.trim())
-					.map((v) => ({
-						url: v.url.trim(),
-						label: v.label.trim() ? v.label.trim() : null,
-					})),
+				part: p,
+				payload: {
+					// Temp (client-key) ids are stripped; the server mints real ones.
+					id: p.id?.startsWith("tmp-") ? undefined : p.id,
+					scheduled_at: partToIso(p.date, p.time, tz),
+					// Keep caster order (streamer first); drop rows left blank.
+					casters: p.casters
+						.map((c) => ({
+							user_id: c.userId,
+							name: c.value.trim() ? c.value.trim() : null,
+						}))
+						.filter((c) => c.user_id !== null || c.name !== null),
+					streams: p.streams
+						.filter((v) => v.url.trim())
+						.map((v) => ({
+							url: v.url.trim(),
+							label: v.label.trim() ? v.label.trim() : null,
+						})),
+				},
 			}))
 			// Drop a blank part only when it's the pristine seeded row (a
 			// never-scheduled match opens with one) — an explicitly added part, or
 			// one that already exists server-side, is a deliberate "Part N, time
 			// TBD" and must survive the save.
 			.filter(
-				(p) =>
-					p.keepIfBlank ||
-					p.scheduled_at !== null ||
-					p.casters.length > 0 ||
-					p.streams.length > 0,
+				({ part, payload }) =>
+					part.added === true ||
+					!part.id?.startsWith("tmp-") ||
+					payload.scheduled_at !== null ||
+					payload.casters.length > 0 ||
+					payload.streams.length > 0,
 			)
-			.map(({ keepIfBlank: _keep, ...p }) => p);
+			.map(({ payload }) => payload);
 		const ok = await runAction(
 			() =>
 				cloudApi.patchMatchSchedule(tournament.tournament_id, match.match_id, {

--- a/src/lib/tournament/SchedulePopover.svelte
+++ b/src/lib/tournament/SchedulePopover.svelte
@@ -63,8 +63,9 @@
 		return { value: "", userId: null, linkedName: null };
 	}
 
-	function emptyPart(): EditPart {
+	function emptyPart(added = false): EditPart {
 		return {
+			added,
 			// Client-side key only — stripped on save so the server mints the
 			// real id. A stable key (vs index) keeps each editor's local UI state
 			// (open calendar, focused segment) with its part when one is removed.
@@ -135,6 +136,9 @@
 	async function save() {
 		const payload = parts
 			.map((p) => ({
+				// Threads through for the blank-part filter below; stripped before
+				// the request.
+				keepIfBlank: p.added === true || !p.id?.startsWith("tmp-"),
 				// Temp (client-key) ids are stripped; the server mints real ones.
 				id: p.id?.startsWith("tmp-") ? undefined : p.id,
 				scheduled_at: partToIso(p.date, p.time, tz),
@@ -152,14 +156,18 @@
 						label: v.label.trim() ? v.label.trim() : null,
 					})),
 			}))
-			// Drop parts the editor left entirely blank so an accidental empty row
-			// doesn't persist as a phantom sitting.
+			// Drop a blank part only when it's the pristine seeded row (a
+			// never-scheduled match opens with one) — an explicitly added part, or
+			// one that already exists server-side, is a deliberate "Part N, time
+			// TBD" and must survive the save.
 			.filter(
 				(p) =>
+					p.keepIfBlank ||
 					p.scheduled_at !== null ||
 					p.casters.length > 0 ||
 					p.streams.length > 0,
-			);
+			)
+			.map(({ keepIfBlank: _keep, ...p }) => p);
 		const ok = await runAction(
 			() =>
 				cloudApi.patchMatchSchedule(tournament.tournament_id, match.match_id, {
@@ -260,7 +268,7 @@
 		<button
 			type="button"
 			class="self-start rounded border border-input px-2.5 py-1 text-xs text-tan/80 hover:border-orange hover:text-orange"
-			onclick={() => parts.push(emptyPart())}
+			onclick={() => parts.push(emptyPart(true))}
 			disabled={busy}
 		>
 			+ Add part


### PR DESCRIPTION
Found in live use on the deployed parts editor (#81): a match ran long and is heading into a second sitting — the admin clicks **+ Add part** to record "Part 2, time TBD", hits Save, and the new part silently vanishes.

Cause: the save path drops parts left entirely blank, which is right for the **auto-seeded** row (a never-scheduled match opens with one blank part; saving without filling it shouldn't persist a phantom sitting) but wrong for a row the user explicitly added — an unscheduled Part 2 is real state.

Fix: `EditPart.added` marks rows created via "+ Add part"; the blank-row filter now only drops the pristine seeded row (blank + tmp id + not added). Blank parts that were explicitly added, or that already exist server-side, survive the save. The read side already handles them ("Not yet scheduled").
