### PR TITLE
feat(tournament): copy button for matches still needing casters

### DIFF
--- a/src/lib/tournament/CastView.svelte
+++ b/src/lib/tournament/CastView.svelte
@@ -17,7 +17,7 @@
 		matchSlotDisplayName,
 		matchupLabel,
 	} from "$lib/tournament/match-occupant";
-	import { upcomingScheduledParts } from "$lib/tournament/parts";
+	import { upcomingScheduledParts, CAST_GRACE_MS } from "$lib/tournament/parts";
 	import type { ScheduleZone } from "$lib/tournament/schedule";
 	import {
 		atlasMapUrl,
@@ -52,10 +52,9 @@
 	let needsOnly = $state(true);
 	let busyKey = $state<string | null>(null);
 
-	// Upcoming scheduled parts (shared definition), with a 2h grace so a match
-	// that began minutes ago is still claimable by a late caster.
-	const GRACE_MS = 2 * 60 * 60 * 1000;
-	const upcoming = $derived(upcomingScheduledParts(matches, GRACE_MS));
+	// Upcoming scheduled parts (shared definition), with the shared cast grace
+	// so a match that began minutes ago is still claimable by a late caster.
+	const upcoming = $derived(upcomingScheduledParts(matches, CAST_GRACE_MS));
 	// Header counts are per MATCH (a split match with two upcoming sittings
 	// shouldn't count twice); the rows themselves stay per part.
 	const upcomingMatchCount = $derived(

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -139,11 +139,17 @@ export function partToIso(
 	return dt.toDate(tz).toISOString();
 }
 
+// The grace window the caster-facing surfaces use: a sitting stays "upcoming"
+// (and so still claimable / still listed as needing a caster) for 2h past its
+// start time, because a caster can still hop on to cast a match that began a
+// little while ago. Shared so every cast surface uses the identical window.
+export const CAST_GRACE_MS = 2 * 60 * 60 * 1000;
+
 // Upcoming scheduled parts of still-pending, non-bye matches, soonest first.
-// graceMs keeps a just-started sitting visible (e.g. the cast surfaces use a
-// 2h grace so a match that began 20 minutes ago is still claimable); 0 means
-// strictly future. The one definition of "upcoming" shared by every surface
-// that lists it (sesh export, caster sign-up), so they can't drift apart.
+// graceMs keeps a just-started sitting visible (e.g. the cast surfaces pass
+// CAST_GRACE_MS so a match that began 20 minutes ago is still claimable); 0
+// means strictly future. The one definition of "upcoming" shared by every
+// surface that lists it (sesh export, caster sign-up), so they can't drift.
 export function upcomingScheduledParts(
 	matches: TournamentMatch[],
 	graceMs = 0,

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -479,7 +479,7 @@
 			<div class="mx-auto max-w-screen-2xl">
 				<Breadcrumb {crumbs} class="mb-4 min-w-0" />
 
-				<!-- Controls card: title + sesh-copy on the left, zone + view toggles on the right. -->
+				<!-- Controls card: title + copy tools on the left (sesh always; needs-casters in the Cast view), zone + view toggles on the right. -->
 				<div
 					class="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg px-3 py-2"
 					style="background-color: rgb(var(--color-surface-raised));"

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -86,7 +86,7 @@
 	// post. `<t:UNIX:F>` renders the full local date; `<t:UNIX:R>` the relative
 	// "in X hours/days". A split match contributes one line per scheduled part,
 	// tagged "(Part N)"; single-session matches read as just "Match NNN".
-	function seshText(): string {
+	function seshText(scope: "all" | "needs-casters" = "all"): string {
 		const num = (m: TournamentMatch) =>
 			m.match_number != null ? padMatchNumber(m.match_number) : "?";
 		// Each side prefers a real Discord `<@id>` mention (pings the player) when
@@ -102,13 +102,21 @@
 
 		// Only parts still ahead — "Upcoming" shouldn't list a sitting that has
 		// already passed (no grace: this is a forward-looking schedule post).
-		const scheduled = upcomingScheduledParts(data.matches).map(
-			({ match, part, partNumber, split }) => {
+		// The needs-casters scope (the Cast tab's copy) keeps only sittings with
+		// no caster signed up — same rule as the tab's "needs a caster" flag.
+		const scheduled = upcomingScheduledParts(data.matches)
+			.filter(({ part }) => scope === "all" || part.casters.length === 0)
+			.map(({ match, part, partNumber, split }) => {
 				const unix = Math.floor(Date.parse(part.scheduled_at as string) / 1000);
 				const partTag = split ? `(Part ${partNumber}) ` : "";
 				return `Match ${num(match)} ${partTag}- ${vs(match)} - <t:${unix}:F> (<t:${unix}:R>)`;
-			},
-		);
+			});
+		if (scope === "needs-casters") {
+			return (
+				"Matches needing casters\n\n" +
+				(scheduled.length ? scheduled.join("\n") : "(none — all covered)")
+			);
+		}
 		// "To be scheduled" = genuinely unscheduled matches only; a match that has
 		// already started (in progress, awaiting result) doesn't belong here.
 		const unscheduled = data.matches
@@ -510,6 +518,50 @@
 												stroke-linecap="round"
 												stroke-linejoin="round"
 												d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"
+											/>
+										</svg>
+									{/if}
+								{/snippet}
+							</CopyButton>
+						{/if}
+						{#if isAdmin && view === "cast"}
+							<CopyButton
+								text={() => seshText("needs-casters")}
+								label="Copy matches needing casters"
+								title="Copy upcoming matches that still need a caster (soonest first) with Discord timestamps"
+								class="inline-flex items-center justify-center rounded border border-surface p-1 text-tan transition-colors hover:bg-surface-hover hover:text-orange"
+							>
+								{#snippet children(copied)}
+									{#if copied}
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											class="h-4 w-4"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+											stroke-width="2"
+											aria-hidden="true"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="M5 13l4 4L19 7"
+											/>
+										</svg>
+									{:else}
+										<svg
+											xmlns="http://www.w3.org/2000/svg"
+											class="h-4 w-4"
+											fill="none"
+											viewBox="0 0 24 24"
+											stroke="currentColor"
+											stroke-width="2"
+											aria-hidden="true"
+										>
+											<path
+												stroke-linecap="round"
+												stroke-linejoin="round"
+												d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"
 											/>
 										</svg>
 									{/if}

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -51,6 +51,7 @@
 		matchParts,
 		matchDisplayStatus,
 		upcomingScheduledParts,
+		CAST_GRACE_MS,
 		type NumberedPart,
 	} from "$lib/tournament/parts";
 	import { padMatchNumber } from "$lib/tournament/match-numbers";
@@ -100,11 +101,16 @@
 					: (matchSlotDisplayName(m, side, slotMaps.labels) ?? "?");
 			});
 
-		// Only parts still ahead — "Upcoming" shouldn't list a sitting that has
-		// already passed (no grace: this is a forward-looking schedule post).
-		// The needs-casters scope (the Cast tab's copy) keeps only sittings with
-		// no caster signed up — same rule as the tab's "needs a caster" flag.
-		const scheduled = upcomingScheduledParts(data.matches)
+		// The "all" (sesh) scope lists only parts still ahead — a forward-looking
+		// schedule post shouldn't name a sitting whose time has passed, so no
+		// grace. The needs-casters scope (the Cast tab's copy) instead mirrors the
+		// tab exactly: same "no caster signed up" rule AND the same CAST_GRACE_MS
+		// window, so a just-started casterless sitting the tab still flags as
+		// needing a caster also shows up in the copied recruit list.
+		const scheduled = upcomingScheduledParts(
+			data.matches,
+			scope === "needs-casters" ? CAST_GRACE_MS : 0,
+		)
 			.filter(({ part }) => scope === "all" || part.casters.length === 0)
 			.map(({ match, part, partNumber, split }) => {
 				const unix = Math.floor(Date.parse(part.scheduled_at as string) / 1000);


### PR DESCRIPTION
From tonight's casting session: the sesh copy exports **every** upcoming match; recruiting casters wants just the uncovered ones.

On the **Cast tab**, a second icon CopyButton (camera glyph, admin-only, beside the existing sesh clipboard) copies the same sesh-style lines — `Match NNN (Part N) - @A v @B - <t:…:F> (<t:…:R>)` — filtered to sittings with **no caster signed up** (the same rule as the tab's "needs a caster" flag), under a "Matches needing casters" heading.

Kept single-sourced per the app-fit lens (#95): it's a `scope` parameter on the existing `seshText` builder (no second line-formatter), rendered through `CopyButton`'s existing icon snippet.

Deliberately covers upcoming **scheduled** casterless sittings only (matching what the Cast tab shows): a caster needs a concrete time to commit to, so matches without one stay in the sesh export's "To be scheduled" until they get scheduled.
