### PR TITLE
fix(tournament): casting-session fixes — open parts in "To be scheduled", autofill guard

### DIFF
--- a/src/lib/tournament/UserAutocomplete.svelte
+++ b/src/lib/tournament/UserAutocomplete.svelte
@@ -182,6 +182,11 @@
 </script>
 
 <div class="relative">
+	<!-- The data-* attributes below suppress password-manager autofill: Chrome
+	     and the managers ignore autocomplete="off" on name-like fields and
+	     inject the viewer's own name (surfaced as admins finding themselves set
+	     as caster on their own match). They're the documented opt-outs for
+	     1Password / LastPass / Bitwarden / Dashlane respectively. -->
 	<input
 		type="text"
 		{value}
@@ -196,6 +201,10 @@
 		class="block w-full rounded {inputClass} p-1.5 text-xs text-tan"
 		{...inputAttrs}
 		autocomplete="off"
+		data-1p-ignore
+		data-lpignore="true"
+		data-bwignore
+		data-form-type="other"
 		use:maybeAutofocus
 	/>
 

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -109,17 +109,30 @@
 				return `Match ${num(match)} ${partTag}- ${vs(match)} - <t:${unix}:F> (<t:${unix}:R>)`;
 			},
 		);
-		// "To be scheduled" = genuinely unscheduled matches only; a match that has
-		// already started (in progress, awaiting result) doesn't belong here.
+		// "To be scheduled" = matches still owing a time: never scheduled at all,
+		// or carrying a part without one yet (a split match heading into "Part 2,
+		// time TBD" — see #91). A match that has fully started (in progress,
+		// awaiting result, no open part) doesn't belong here. The part tag mirrors
+		// the "Upcoming" lines: shown only when the match is actually split.
 		const unscheduled = data.matches
-			.filter(
-				(m) =>
-					m.status === "pending" &&
-					m.slot_b_id != null &&
-					matchDisplayStatus(m) === "unscheduled",
-			)
+			.filter((m) => m.status === "pending" && m.slot_b_id != null)
 			.sort((a, b) => (a.match_number ?? 0) - (b.match_number ?? 0))
-			.map((m) => `Match ${num(m)} - ${vs(m)}`);
+			.flatMap((m) => {
+				const parts = matchParts(m);
+				if (parts.length === 0) {
+					return matchDisplayStatus(m) === "unscheduled"
+						? [`Match ${num(m)} - ${vs(m)}`]
+						: [];
+				}
+				const split = parts.length >= 2;
+				return parts
+					.map((part, i) => ({ part, partNumber: i + 1 }))
+					.filter(({ part }) => part.scheduled_at == null)
+					.map(({ partNumber }) => {
+						const partTag = split ? `(Part ${partNumber}) ` : "";
+						return `Match ${num(m)} ${partTag}- ${vs(m)}`;
+					});
+			});
 
 		const blocks = [
 			"Upcoming matches\n\n" +


### PR DESCRIPTION
Two small fixes from tonight's casting session (one commit each):

**1. "To be scheduled" misses split matches with an open part.** After #91 an admin can add "Part 2, time TBD" — but the sesh export's "To be scheduled" block only listed matches whose *display status* was unscheduled, and Part 1 makes such a match read scheduled/in-progress. It now lists every pending match's time-less parts, tagged "(Part N)" when the match is split, alongside never-scheduled matches (repro: the fiddlers25 v ant match).

**2. Admins kept getting set as caster on their own match.** No code path writes the session user as caster outside the explicit endpoints — the entry point is the schedule editor's caster box: it's a name-like text input, and Chrome/password managers ignore `autocomplete="off"` on those, injecting the viewer's own name via a real `input` event that the editor then saves as a free-text caster. Added the vendor opt-out attributes (`data-1p-ignore`, `data-lpignore`, `data-bwignore`, `data-form-type="other"`) on `UserAutocomplete`'s input — one place, covers every flow embedding it. (If you still see it recur after this, that theory's wrong and I'll dig again — but it matches "keeps happening on *my own* match", since the autofilled name is always the viewer's.)
