### PR TITLE
feat(tournament): "copy caster post" button on the match popover

### DIFF
--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -37,10 +37,9 @@
 		matchSlotAvatarUrl,
 		matchSlotNation,
 		matchSlotDisplayName,
-		matchupLabel,
 	} from "$lib/tournament/match-occupant";
 	import { upcomingScheduledParts } from "$lib/tournament/parts";
-	import { seshMatchLine } from "$lib/tournament/sesh";
+	import { seshMatchLine, seshVersus } from "$lib/tournament/sesh";
 	import { mapScriptLabel } from "$lib/tournament/map-scripts";
 	import {
 		atlasMapUrl,
@@ -235,13 +234,7 @@
 	const casterPostText = $derived.by(() => {
 		const parts = upcomingScheduledParts([match]);
 		if (parts.length === 0) return null;
-		const versus = matchupLabel(match, (side) => {
-			const id =
-				side === "a" ? match.slot_a_discord_id : match.slot_b_discord_id;
-			return id
-				? `<@${id}>`
-				: (matchSlotDisplayName(match, side, slotLabels) ?? "?");
-		});
+		const versus = seshVersus(match, slotLabels);
 		const lines = parts.map(({ part, partNumber, split }) =>
 			seshMatchLine({
 				matchNumber: match.match_number,

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -37,7 +37,10 @@
 		matchSlotAvatarUrl,
 		matchSlotNation,
 		matchSlotDisplayName,
+		matchupLabel,
 	} from "$lib/tournament/match-occupant";
+	import { upcomingScheduledParts } from "$lib/tournament/parts";
+	import { seshMatchLine } from "$lib/tournament/sesh";
 	import { mapScriptLabel } from "$lib/tournament/map-scripts";
 	import {
 		atlasMapUrl,
@@ -219,6 +222,40 @@
 						"We want to cast as many matches as we can!",
 					]
 				: []),
+		].join("\n");
+	});
+
+	// "Just scheduled — appreciate a caster!" post for the casters channel: this
+	// match's still-upcoming scheduled sittings, each as a sesh line, with a
+	// caster nudge when any of them still needs one. Open to any viewer (a
+	// player announcing their own match, or a TO) — it's all public info, and
+	// player mentions fall back to display names when discord_id isn't exposed
+	// (admin-only). Null (button hidden) when nothing's scheduled ahead —
+	// there's nothing to announce or cast.
+	const casterPostText = $derived.by(() => {
+		const parts = upcomingScheduledParts([match]);
+		if (parts.length === 0) return null;
+		const versus = matchupLabel(match, (side) => {
+			const id =
+				side === "a" ? match.slot_a_discord_id : match.slot_b_discord_id;
+			return id
+				? `<@${id}>`
+				: (matchSlotDisplayName(match, side, slotLabels) ?? "?");
+		});
+		const lines = parts.map(({ part, partNumber, split }) =>
+			seshMatchLine({
+				matchNumber: match.match_number,
+				versus,
+				partNumber,
+				split,
+				scheduledAt: part.scheduled_at,
+			}),
+		);
+		const needsCaster = parts.some(({ part }) => part.casters.length === 0);
+		return [
+			"Just scheduled:",
+			...lines,
+			...(needsCaster ? ["Appreciate a caster!"] : []),
 		].join("\n");
 	});
 
@@ -696,6 +733,24 @@
 	</svg>
 {/snippet}
 
+{#snippet iconMegaphone()}
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		class="h-3.5 w-3.5"
+		fill="none"
+		viewBox="0 0 24 24"
+		stroke="currentColor"
+		stroke-width="2"
+		aria-hidden="true"
+	>
+		<path
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			d="M11 5.882V19.24a1.76 1.76 0 01-3.417.592l-2.147-6.15M18 13a3 3 0 100-6M5.436 13.683A4.001 4.001 0 017 6h1.832c4.1 0 7.625-1.234 9.168-3v14c-1.543-1.766-5.067-3-9.168-3H7a3.988 3.988 0 01-1.564-.317z"
+		/>
+	</svg>
+{/snippet}
+
 <!-- Header styled like the bracket section bar (e.g. the "West" / "Championship"
      headers): a surface-raised rounded bar carrying the matchup, the status badge to
      its right, the controls far-right, and bracket · round on a second line. -->
@@ -768,6 +823,18 @@
 					>
 						{#snippet children(copied)}
 							{#if copied}{@render iconCheck()}{:else}{@render iconChat()}{/if}
+						{/snippet}
+					</CopyButton>
+				{/if}
+				{#if casterPostText}
+					<CopyButton
+						text={() => casterPostText}
+						label="Copy caster post"
+						title="Copy a 'just scheduled — appreciate a caster!' post for the casters channel"
+						class="inline-flex items-center justify-center rounded border border-surface p-1 text-tan transition-colors hover:bg-surface-hover hover:text-orange"
+					>
+						{#snippet children(copied)}
+							{#if copied}{@render iconCheck()}{:else}{@render iconMegaphone()}{/if}
 						{/snippet}
 					</CopyButton>
 				{/if}

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -159,11 +159,14 @@ export const LIVE_WINDOW_MS = 4 * 60 * 60 * 1000;
 // CAST_GRACE_MS so a match that began 20 minutes ago is still claimable); 0
 // means strictly future. The one definition of "upcoming" shared by every
 // surface that lists it (sesh export, caster sign-up), so they can't drift.
+// Reads the shared reactive clock (nowMs), like its sibling helpers here, so a
+// $derived that lists these (the Cast view, the popover's caster post) drops a
+// sitting as its time passes instead of waiting for the next data refetch.
 export function upcomingScheduledParts(
 	matches: TournamentMatch[],
 	graceMs = 0,
 ): NumberedPart[] {
-	const cutoff = Date.now() - graceMs;
+	const cutoff = nowMs() - graceMs;
 	const pending = matches.filter(
 		(m) => m.status === "pending" && m.slot_b_id != null,
 	);

--- a/src/lib/tournament/sesh.ts
+++ b/src/lib/tournament/sesh.ts
@@ -1,3 +1,5 @@
+import type { TournamentMatch } from "$lib/api-cloud";
+import { matchSlotDisplayName, matchupLabel } from "./match-occupant";
 import { padMatchNumber } from "./match-numbers";
 
 // A single "sesh.fyi"-style match line for a Discord post:
@@ -24,4 +26,22 @@ export function seshMatchLine(opts: {
 		line += ` - <t:${unix}:F> (<t:${unix}:R>)`;
 	}
 	return line;
+}
+
+// The "A v B" matchup for a sesh post: each side prefers a real Discord `<@id>`
+// mention (pings the player) when we have the id — an admin-only field, so posts
+// carry mentions for admins and plain display names for everyone else — and
+// falls back to the slot's display name (then "?") when there's no id. The bye
+// rule lives in `matchupLabel`. Shared by the matches-page sesh export and the
+// popover's caster post so this mention/fallback logic isn't a second copy.
+export function seshVersus(
+	match: TournamentMatch,
+	slotLabels: Record<string, string>,
+): string {
+	return matchupLabel(match, (side) => {
+		const id = side === "a" ? match.slot_a_discord_id : match.slot_b_discord_id;
+		return id
+			? `<@${id}>`
+			: (matchSlotDisplayName(match, side, slotLabels) ?? "?");
+	});
 }

--- a/src/lib/tournament/sesh.ts
+++ b/src/lib/tournament/sesh.ts
@@ -1,0 +1,27 @@
+import { padMatchNumber } from "./match-numbers";
+
+// A single "sesh.fyi"-style match line for a Discord post:
+//   "Match NNN (Part Y) - <versus> - <t:UNIX:F> (<t:UNIX:R>)"
+// `<t:UNIX:F>` renders the full local date, `<t:UNIX:R>` the relative
+// "in X hours/days". The "(Part Y)" tag shows only for split matches; the
+// timestamp is omitted when the sitting has no time yet (a "to be scheduled"
+// line). `versus` is the caller's already-built "A v B" (matchupLabel) — a
+// mention in the admin posts, a plain name otherwise. Shared by the
+// matches-page sesh export and the match popover's caster post so the line
+// format lives in exactly one place.
+export function seshMatchLine(opts: {
+	matchNumber: number | null;
+	versus: string;
+	partNumber: number;
+	split: boolean;
+	scheduledAt?: string | null;
+}): string {
+	const num = opts.matchNumber != null ? padMatchNumber(opts.matchNumber) : "?";
+	const partTag = opts.split ? `(Part ${opts.partNumber}) ` : "";
+	let line = `Match ${num} ${partTag}- ${opts.versus}`;
+	if (opts.scheduledAt) {
+		const unix = Math.floor(Date.parse(opts.scheduledAt) / 1000);
+		line += ` - <t:${unix}:F> (<t:${unix}:R>)`;
+	}
+	return line;
+}

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -54,7 +54,7 @@
 		type NumberedPart,
 	} from "$lib/tournament/parts";
 	import { nowMs } from "$lib/stores/now.svelte";
-	import { seshMatchLine } from "$lib/tournament/sesh";
+	import { seshMatchLine, seshVersus } from "$lib/tournament/sesh";
 	import CastView from "$lib/tournament/CastView.svelte";
 	import CopyButton from "$lib/tournament/CopyButton.svelte";
 	import { buildSlotMaps } from "$lib/tournament/slot-identity";
@@ -97,16 +97,7 @@
 	// "[cast by X]" (with any stream links) or "[needs a caster]" — so the post
 	// doubles as a watch-and-recruit announcement.
 	function seshText(scope: "all" | "needs-casters" = "all"): string {
-		// Each side prefers a real Discord `<@id>` mention (pings the player) when
-		// the slot is a claimed account whose id we have (admin-only field), and
-		// falls back to the display name for unclaimed slots.
-		const vs = (m: TournamentMatch) =>
-			matchupLabel(m, (side) => {
-				const id = side === "a" ? m.slot_a_discord_id : m.slot_b_discord_id;
-				return id
-					? `<@${id}>`
-					: (matchSlotDisplayName(m, side, slotMaps.labels) ?? "?");
-			});
+		const vs = (m: TournamentMatch) => seshVersus(m, slotMaps.labels);
 
 		// Caster status suffix for a scheduled part in the "all" post: the
 		// streamer (first caster) and any co-casters, plus their stream links, or

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -54,7 +54,7 @@
 		type NumberedPart,
 	} from "$lib/tournament/parts";
 	import { nowMs } from "$lib/stores/now.svelte";
-	import { padMatchNumber } from "$lib/tournament/match-numbers";
+	import { seshMatchLine } from "$lib/tournament/sesh";
 	import CastView from "$lib/tournament/CastView.svelte";
 	import CopyButton from "$lib/tournament/CopyButton.svelte";
 	import { buildSlotMaps } from "$lib/tournament/slot-identity";
@@ -97,8 +97,6 @@
 	// "[cast by X]" (with any stream links) or "[needs a caster]" — so the post
 	// doubles as a watch-and-recruit announcement.
 	function seshText(scope: "all" | "needs-casters" = "all"): string {
-		const num = (m: TournamentMatch) =>
-			m.match_number != null ? padMatchNumber(m.match_number) : "?";
 		// Each side prefers a real Discord `<@id>` mention (pings the player) when
 		// the slot is a claimed account whose id we have (admin-only field), and
 		// falls back to the display name for unclaimed slots.
@@ -136,12 +134,18 @@
 		)
 			.filter(({ part }) => scope === "all" || part.casters.length === 0)
 			.map(({ match, part, partNumber, split }) => {
-				const unix = Math.floor(Date.parse(part.scheduled_at as string) / 1000);
-				const partTag = split ? `(Part ${partNumber}) ` : "";
 				// The needs-casters scope is already filtered to casterless parts,
 				// so the "[needs a caster]" tag there would just be noise.
 				const tag = scope === "all" ? casterTag(part) : "";
-				return `Match ${num(match)} ${partTag}- ${vs(match)} - <t:${unix}:F> (<t:${unix}:R>)${tag}`;
+				return (
+					seshMatchLine({
+						matchNumber: match.match_number,
+						versus: vs(match),
+						partNumber,
+						split,
+						scheduledAt: part.scheduled_at,
+					}) + tag
+				);
 			});
 		if (scope === "needs-casters") {
 			return (
@@ -161,17 +165,28 @@
 				const parts = matchParts(m);
 				if (parts.length === 0) {
 					return matchDisplayStatus(m) === "unscheduled"
-						? [`Match ${num(m)} - ${vs(m)}`]
+						? [
+								seshMatchLine({
+									matchNumber: m.match_number,
+									versus: vs(m),
+									partNumber: 1,
+									split: false,
+								}),
+							]
 						: [];
 				}
 				const split = parts.length >= 2;
 				return parts
 					.map((part, i) => ({ part, partNumber: i + 1 }))
 					.filter(({ part }) => part.scheduled_at == null)
-					.map(({ partNumber }) => {
-						const partTag = split ? `(Part ${partNumber}) ` : "";
-						return `Match ${num(m)} ${partTag}- ${vs(m)}`;
-					});
+					.map(({ partNumber }) =>
+						seshMatchLine({
+							matchNumber: m.match_number,
+							versus: vs(m),
+							partNumber,
+							split,
+						}),
+					);
 			});
 
 		const blocks = [


### PR DESCRIPTION
Right after scheduling a session, a TO wants to drop a quick "just scheduled — appreciate a caster!" note in the casters channel with proper Discord timestamps, without hand-converting times on sesh.fyi or screenshotting the schedule editor.

Adds a **megaphone CopyButton** to the match popover header, beside *Copy thread title* / *Copy DM*. Open to any viewer — a player announcing their own match, or a TO. It copies this match's still-upcoming scheduled sittings:

```
Just scheduled:
Match 018 (Part 2) - @A v @B - <t:…:F> (<t:…:R>)
Appreciate a caster!
```

- `<t:…:F>` = full local date, `<t:…:R>` = "in X hours". Player mentions ping via `<@id>` for admins; for everyone else they fall back to display names (discord_id is admin-only) — everything in the post is public info.
- The "Appreciate a caster!" line appears only when a listed sitting still needs one — if it's already covered, you get just the "just scheduled" announcement.
- Hidden when there's nothing scheduled ahead (byes, placeholders, a fully-past match).

**App-fit (per `src/lib/tournament/CLAUDE.md`):** the `Match NNN (Part Y) - A v B - <t:…>` line was inline in the matches-page sesh export and would have been a second copy here — so **commit 1** extracts it to `seshMatchLine()` (new `sesh.ts`) and points the sesh export at it (byte-identical output, verified), and **commit 2** adds the button on top. Reuses `matchupLabel`, `upcomingScheduledParts`, and `CopyButton` rather than re-inlining any of them.
