### PR TITLE
feat(tournament): remember casters' stream links and auto-attach on cast

### DIFF
--- a/cloud/migrations/0033_user_stream_url.sql
+++ b/cloud/migrations/0033_user_stream_url.sql
@@ -1,6 +1,20 @@
--- Per-user casting stream link (twitch.tv / youtube.com, validated in the
+-- Per-user casting stream link (youtube.com / twitch.tv, validated in the
 -- Worker). Set from account preferences or remembered from the first cast
 -- signup that provides one; when a user takes the streamer slot on a match
 -- part, this URL is auto-attached to the part's streams so "I'll cast"
 -- doesn't leave the sitting streamless. NULL = no auto-attach.
 ALTER TABLE users ADD COLUMN stream_url TEXT;
+
+-- Backfill from casting history: for each user, the first stream URL on the
+-- most recent part where they held the streamer slot (casters[0]). Streams
+-- aren't attributed to users in the parts data, so this is a heuristic — in
+-- practice the first stream on a cast sitting is the streamer's channel —
+-- and it only seeds a default the user can change or clear in preferences.
+UPDATE users SET stream_url = (
+	SELECT json_extract(p.value, '$.streams[0].url')
+	FROM tournament_matches m, json_each(m.parts) AS p
+	WHERE m.parts IS NOT NULL AND json_valid(m.parts)
+		AND json_extract(p.value, '$.casters[0].user_id') = users.user_id
+		AND json_extract(p.value, '$.streams[0].url') IS NOT NULL
+	ORDER BY m.rowid DESC LIMIT 1
+) WHERE stream_url IS NULL;

--- a/cloud/migrations/0033_user_stream_url.sql
+++ b/cloud/migrations/0033_user_stream_url.sql
@@ -1,0 +1,6 @@
+-- Per-user casting stream link (twitch.tv / youtube.com, validated in the
+-- Worker). Set from account preferences or remembered from the first cast
+-- signup that provides one; when a user takes the streamer slot on a match
+-- part, this URL is auto-attached to the part's streams so "I'll cast"
+-- doesn't leave the sitting streamless. NULL = no auto-attach.
+ALTER TABLE users ADD COLUMN stream_url TEXT;

--- a/cloud/src/auth.ts
+++ b/cloud/src/auth.ts
@@ -736,10 +736,10 @@ export async function handleMe(
 	}
 
 	const row = await env.SHARE_DB.prepare(
-		`SELECT user_id, discord_id, ${displayNameSql("users")} AS display_name, avatar_hash, default_game_public FROM users WHERE user_id = ?`,
+		`SELECT user_id, discord_id, ${displayNameSql("users")} AS display_name, avatar_hash, default_game_public, stream_url FROM users WHERE user_id = ?`,
 	)
 		.bind(session.data.user_id)
-		.first<UserRow & { default_game_public: number }>();
+		.first<UserRow & { default_game_public: number; stream_url: string | null }>();
 
 	if (!row) {
 		// Session points at a deleted user — clean up and 401.
@@ -788,6 +788,10 @@ export async function handleMe(
 			// D1; surfaced as a boolean so the account page can render the
 			// toggle without re-fetching.
 			default_game_public: row.default_game_public === 1,
+			// Casting stream link (twitch/youtube). Auto-attached when this user
+			// takes the streamer slot on a match part; the cast button reads it
+			// to decide whether to offer the one-time "remember my stream" input.
+			stream_url: row.stream_url,
 		},
 		200,
 		cors,
@@ -820,15 +824,44 @@ export async function handleSettings(
 			"INVALID_BODY",
 		);
 	}
-	const { default_game_public } = validation.output;
+	const { default_game_public, stream_url } = validation.output;
 
-	await env.SHARE_DB.prepare(
-		"UPDATE users SET default_game_public = ? WHERE user_id = ?",
+	// Partial update: only the fields the caller sent are written (every schema
+	// field is optional). stream_url: string sets, explicit null clears,
+	// omitted leaves untouched.
+	const sets: string[] = [];
+	const binds: (string | number | null)[] = [];
+	if (default_game_public !== undefined) {
+		sets.push("default_game_public = ?");
+		binds.push(default_game_public ? 1 : 0);
+	}
+	if (stream_url !== undefined) {
+		sets.push("stream_url = ?");
+		binds.push(stream_url);
+	}
+	if (sets.length > 0) {
+		await env.SHARE_DB.prepare(
+			`UPDATE users SET ${sets.join(", ")} WHERE user_id = ?`,
+		)
+			.bind(...binds, session.data.user_id)
+			.run();
+	}
+
+	// Echo the full current settings so the caller can refresh state without a
+	// second round-trip, whichever subset it wrote.
+	const row = await env.SHARE_DB.prepare(
+		"SELECT default_game_public, stream_url FROM users WHERE user_id = ?",
 	)
-		.bind(default_game_public ? 1 : 0, session.data.user_id)
-		.run();
-
-	return jsonResponse({ default_game_public }, 200, cors);
+		.bind(session.data.user_id)
+		.first<{ default_game_public: number; stream_url: string | null }>();
+	return jsonResponse(
+		{
+			default_game_public: row?.default_game_public === 1,
+			stream_url: row?.stream_url ?? null,
+		},
+		200,
+		cors,
+	);
 }
 
 export async function handleLogout(

--- a/cloud/src/schemas/tournament.ts
+++ b/cloud/src/schemas/tournament.ts
@@ -326,8 +326,9 @@ const STREAM_HOSTS = new Set([
 
 // A stream URL for a part — a live stream or an after-the-fact recording, held to
 // the same youtube/twitch host allowlist as the single stream link used before
-// parts (migration 0025 → 0029).
-const StreamUrlSchema = v.pipe(
+// parts (migration 0025 → 0029). Also validates users.stream_url (the per-user
+// casting link, schemas/user.ts) so both fields accept exactly the same URLs.
+export const StreamUrlSchema = v.pipe(
 	v.string(),
 	v.trim(),
 	v.maxLength(500),
@@ -357,6 +358,10 @@ const MatchPartStreamSchema = v.object({
 // caster self-service endpoints both read it.
 export const MAX_CASTERS_PER_PART = 10;
 
+// Single source for the per-part stream cap: the schema's maxLength and the
+// cast auto-attach guard both read it.
+export const MAX_STREAMS_PER_PART = 20;
+
 const MatchPartCasterSchema = v.object({
 	user_id: v.nullable(v.pipe(v.string(), v.regex(nanoid21Regex))),
 	name: v.nullable(v.pipe(v.string(), v.trim(), v.maxLength(80))),
@@ -376,7 +381,10 @@ const MatchPartSchema = v.object({
 		v.array(MatchPartCasterSchema),
 		v.maxLength(MAX_CASTERS_PER_PART),
 	),
-	streams: v.pipe(v.array(MatchPartStreamSchema), v.maxLength(20)),
+	streams: v.pipe(
+		v.array(MatchPartStreamSchema),
+		v.maxLength(MAX_STREAMS_PER_PART),
+	),
 });
 
 // PATCH /v1/tournaments/:id/matches/:match_id/schedule body. Replace-all: the
@@ -396,8 +404,12 @@ export const PatchMatchPartsSchema = v.object({
 // A caster adds/moves THEMSELVES on a part. role picks their slot: "streamer"
 // takes index 0 (bumping the current streamer to co-caster); "cocaster"
 // appends. Omitted → streamer when the part has no caster yet, else co-caster.
+// stream_url is the one-time "remember my stream" path: provided, it's saved
+// to the caller's users.stream_url and used for this cast's auto-attach —
+// later casts need only the click.
 export const CastMatchPartSchema = v.object({
 	role: v.optional(v.picklist(["streamer", "cocaster"])),
+	stream_url: v.optional(StreamUrlSchema),
 });
 
 export const ReportMatchSchema = v.object({

--- a/cloud/src/schemas/user.ts
+++ b/cloud/src/schemas/user.ts
@@ -2,11 +2,18 @@
 
 import * as v from "valibot";
 
-// User-editable account preferences. Currently just the default visibility
-// applied to newly uploaded saves (see handleSettings in cloud/src/auth.ts
-// and the fresh-upload branch in cloud/src/games.ts).
+import { StreamUrlSchema } from "./tournament";
+
+// User-editable account preferences. Every field is optional so a caller
+// updates only what it sends (see handleSettings in cloud/src/auth.ts):
+//   - default_game_public: visibility applied to newly uploaded saves (the
+//     fresh-upload branch in cloud/src/games.ts).
+//   - stream_url: the user's casting stream link (twitch/youtube, same
+//     allowlist as match-part streams). Auto-attached when they take the
+//     streamer slot on a match part; null clears it (no auto-attach).
 export const UserSettingsSchema = v.object({
-	default_game_public: v.boolean(),
+	default_game_public: v.optional(v.boolean()),
+	stream_url: v.optional(v.nullable(StreamUrlSchema)),
 });
 
 export type UserSettings = v.InferOutput<typeof UserSettingsSchema>;

--- a/cloud/src/tournament/player.ts
+++ b/cloud/src/tournament/player.ts
@@ -14,6 +14,7 @@ import { logError } from "../log";
 import {
 	CastMatchPartSchema,
 	MAX_CASTERS_PER_PART,
+	MAX_STREAMS_PER_PART,
 	TournamentSignupSchema,
 } from "../schemas/tournament";
 import { sessionFromRequest, type SessionEnv } from "../session";
@@ -435,11 +436,16 @@ export async function handleTournamentWithdraw(
 // Every attempt CASes on parts_rev and retries against fresh state.
 const CASTER_CAS_ATTEMPTS = 3;
 
-// Resolves the caller's own caster entry once, after the auth + rate-limit gate
-// (so a 429'd call does no extra work) and before the CAS loop (so a retry
-// doesn't re-query it). The cast path uses it to snapshot the caller's username;
-// the uncast path has nothing to prepare.
-type PrepareCasterEntry = (userId: string) => Promise<MatchPartCaster>;
+// Context resolved once per request, after the auth + rate-limit gate (so a
+// 429'd call does no extra work) and before the CAS loop (so a retry doesn't
+// re-query it): the caller's caster entry (cast path only) and their stored
+// stream link — attached when they take the streamer slot, detached again when
+// they drop.
+type CasterContext = {
+	me?: MatchPartCaster;
+	streamUrl: string | null;
+};
+type PrepareCasterContext = (userId: string) => Promise<CasterContext>;
 
 // Applies the caller's intended change to the part's caster list in place,
 // against freshly-loaded state on each CAS attempt. Returns an error Response to
@@ -447,7 +453,7 @@ type PrepareCasterEntry = (userId: string) => Promise<MatchPartCaster>;
 type ApplyCasterMutation = (
 	part: MatchPart,
 	userId: string,
-	me: MatchPartCaster | undefined,
+	ctx: CasterContext,
 ) => Response | null;
 
 async function mutateMyCasterEntry(
@@ -460,7 +466,7 @@ async function mutateMyCasterEntry(
 		// Casting requires a pending match; self-removal is also allowed on
 		// decided ones (byes rejected either way).
 		allowDecided: boolean;
-		prepare?: PrepareCasterEntry;
+		prepare: PrepareCasterContext;
 		mutate: ApplyCasterMutation;
 	},
 ): Promise<Response> {
@@ -483,7 +489,7 @@ async function mutateMyCasterEntry(
 			"RATE_LIMIT_TOURNAMENT_SCHEDULE",
 		);
 	}
-	const me = opts.prepare ? await opts.prepare(userId) : undefined;
+	const ctx = await opts.prepare(userId);
 
 	for (let attempt = 0; attempt < CASTER_CAS_ATTEMPTS; attempt++) {
 		const match = await loadMatch(env, matchId);
@@ -516,7 +522,7 @@ async function mutateMyCasterEntry(
 			return errorResponse("Part not found", 404, cors, "PART_NOT_FOUND");
 		}
 
-		const rejection = opts.mutate(part, userId, me);
+		const rejection = opts.mutate(part, userId, ctx);
 		if (rejection) return rejection;
 
 		const result = await env.SHARE_DB.prepare(
@@ -563,16 +569,36 @@ export async function handleCastMatchPart(
 	return mutateMyCasterEntry(tournamentId, matchId, partId, request, env, {
 		allowDecided: false,
 		// Snapshot the caller's canonical handle as the caster name, mirroring
-		// the admin schedule path (linked caster → canonical username).
+		// the admin schedule path (linked caster → canonical username), plus
+		// their stream link for the streamer auto-attach. A stream_url in the
+		// body is the one-time "remember my stream" path: persist it first so
+		// this and every later cast auto-attach it.
 		prepare: async (userId) => {
 			const u = await env.SHARE_DB.prepare(
-				"SELECT discord_username FROM users WHERE user_id = ?",
+				"SELECT discord_username, stream_url FROM users WHERE user_id = ?",
 			)
 				.bind(userId)
-				.first<{ discord_username: string | null }>();
-			return { user_id: userId, name: u?.discord_username ?? null };
+				.first<{
+					discord_username: string | null;
+					stream_url: string | null;
+				}>();
+			let streamUrl = u?.stream_url ?? null;
+			if (body.body.stream_url !== undefined) {
+				if (body.body.stream_url !== streamUrl) {
+					await env.SHARE_DB.prepare(
+						"UPDATE users SET stream_url = ? WHERE user_id = ?",
+					)
+						.bind(body.body.stream_url, userId)
+						.run();
+				}
+				streamUrl = body.body.stream_url;
+			}
+			return {
+				me: { user_id: userId, name: u?.discord_username ?? null },
+				streamUrl,
+			};
 		},
-		mutate: (part, userId, me) => {
+		mutate: (part, userId, ctx) => {
 			// Drop any existing self entry, then re-insert at the chosen slot.
 			const others = part.casters.filter((c) => c.user_id !== userId);
 			if (others.length + 1 > MAX_CASTERS_PER_PART) {
@@ -585,7 +611,20 @@ export async function handleCastMatchPart(
 			}
 			const asStreamer =
 				role === "streamer" || (role === undefined && others.length === 0);
-			part.casters = asStreamer ? [me!, ...others] : [...others, me!];
+			part.casters = asStreamer ? [ctx.me!, ...others] : [...others, ctx.me!];
+			// Auto-attach the streamer's stream link, so "I'll cast" never leaves
+			// the sitting streamless (the fix this feature exists for). Skipped
+			// for co-casters (the cast airs on the streamer's channel), when the
+			// URL is already listed, and at the stream cap (a later admin
+			// replace-all would fail validation past it).
+			if (
+				asStreamer &&
+				ctx.streamUrl &&
+				!part.streams.some((s) => s.url === ctx.streamUrl) &&
+				part.streams.length < MAX_STREAMS_PER_PART
+			) {
+				part.streams.push({ url: ctx.streamUrl, label: null });
+			}
 			return null;
 		},
 	});
@@ -602,8 +641,22 @@ export async function handleUncastMatchPart(
 		// A caster who signed up but never actually cast shouldn't stay credited
 		// on a decided match; removal of your OWN entry is always additive-safe.
 		allowDecided: true,
-		mutate: (part, userId) => {
+		prepare: async (userId) => {
+			const u = await env.SHARE_DB.prepare(
+				"SELECT stream_url FROM users WHERE user_id = ?",
+			)
+				.bind(userId)
+				.first<{ stream_url: string | null }>();
+			return { streamUrl: u?.stream_url ?? null };
+		},
+		mutate: (part, userId, ctx) => {
 			part.casters = part.casters.filter((c) => c.user_id !== userId);
+			// Symmetric cleanup: dropping also removes the caller's stream link
+			// (matched by URL), so an un-cast sitting isn't left pointing at a
+			// channel nobody is casting on. Other streams are untouched.
+			if (ctx.streamUrl) {
+				part.streams = part.streams.filter((s) => s.url !== ctx.streamUrl);
+			}
 			return null;
 		},
 	});

--- a/cloud/test/integration/tournament/cast.test.ts
+++ b/cloud/test/integration/tournament/cast.test.ts
@@ -365,6 +365,41 @@ describe("caster stream auto-attach", () => {
 		);
 	});
 
+	it("the 0033 backfill infers a link from streamer history", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: { stream_url: TWITCH },
+		});
+		// Simulate a pre-0033 user: casting history exists, no stored link.
+		await env.SHARE_DB.prepare(
+			"UPDATE users SET stream_url = NULL WHERE user_id = ?",
+		)
+			.bind(alice.userId)
+			.run();
+
+		// The backfill statement from migrations/0033_user_stream_url.sql —
+		// keep in sync with the migration (it runs against empty tables in this
+		// harness's beforeAll, so its behavior is asserted here instead).
+		await env.SHARE_DB.prepare(
+			`UPDATE users SET stream_url = (
+				SELECT json_extract(p.value, '$.streams[0].url')
+				FROM tournament_matches m, json_each(m.parts) AS p
+				WHERE m.parts IS NOT NULL AND json_valid(m.parts)
+					AND json_extract(p.value, '$.casters[0].user_id') = users.user_id
+					AND json_extract(p.value, '$.streams[0].url') IS NOT NULL
+				ORDER BY m.rowid DESC LIMIT 1
+			) WHERE stream_url IS NULL`,
+		).run();
+
+		const me = await expectOk<{ stream_url: string | null }>(
+			await request.get({ path: "/v1/auth/me", as: alice }),
+		);
+		expect(me.stream_url).toBe(TWITCH);
+	});
+
 	it("settings can set and clear the stream link", async () => {
 		const alice = await makeUser({ discordUsername: "alice_caster" });
 		const set = await expectOk<{ stream_url: string | null }>(

--- a/cloud/test/integration/tournament/cast.test.ts
+++ b/cloud/test/integration/tournament/cast.test.ts
@@ -35,6 +35,19 @@ async function castersOf(
 	return parts.find((p) => p.id === partId)?.casters ?? [];
 }
 
+async function streamsOf(
+	t: T,
+	matchId: string,
+	partId: string,
+): Promise<{ url: string; label: string | null }[]> {
+	const m = (await t.matches()).find((row) => row.match_id === matchId);
+	const parts = JSON.parse((m?.parts as string) ?? "[]") as {
+		id: string;
+		streams: { url: string; label: string | null }[];
+	}[];
+	return parts.find((p) => p.id === partId)?.streams ?? [];
+}
+
 // Create a scheduled part on the first pending match (admin), returning ids.
 async function setup() {
 	const t = await makeTournament({ advanceTo: "swiss-round-1-generated" });
@@ -192,5 +205,189 @@ describe("caster self-service", () => {
 		});
 		expect(res.status).toBe(204);
 		expect(await castersOf(t, match.match_id, partId)).toEqual([]);
+	});
+});
+
+// The streamer's stream link (users.stream_url) is auto-attached to the part
+// when they take index 0 — remembered from account settings or from a
+// stream_url sent with the cast itself — and removed again when they drop.
+describe("caster stream auto-attach", () => {
+	const TWITCH = "https://twitch.tv/alice_caster";
+
+	it("remembers a stream_url sent with the cast and auto-attaches it on later casts", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+
+		// First cast provides the link once: attached AND persisted.
+		const r1 = await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: { stream_url: TWITCH },
+		});
+		expect(r1.status).toBe(204);
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([
+			{ url: TWITCH, label: null },
+		]);
+		const me = await expectOk<{ stream_url: string | null }>(
+			await request.get({ path: "/v1/auth/me", as: alice }),
+		);
+		expect(me.stream_url).toBe(TWITCH);
+
+		// A later cast on a fresh part needs only the click.
+		const { t: t2, match: m2, partId: p2 } = await setup();
+		const r2 = await request.post({
+			path: castPath(t2.tournamentId, m2.match_id, p2),
+			as: alice,
+			body: {},
+		});
+		expect(r2.status).toBe(204);
+		expect(await streamsOf(t2, m2.match_id, p2)).toEqual([
+			{ url: TWITCH, label: null },
+		]);
+	});
+
+	it("a link saved via account settings attaches for the streamer but not a co-caster", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		const bob = await makeUser({ discordUsername: "bob_caster" });
+		const bobUrl = "https://twitch.tv/bob_caster";
+		await expectOk(
+			await request.post({
+				path: "/v1/auth/settings",
+				as: bob,
+				body: { stream_url: bobUrl },
+			}),
+		);
+
+		// Alice (no stored link) takes the streamer slot: no stream appears.
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: {},
+		});
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([]);
+
+		// Bob joins as co-caster: his link stays off the part (the cast airs on
+		// the streamer's channel)…
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: bob,
+			body: {},
+		});
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([]);
+
+		// …until he promotes himself to streamer.
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: bob,
+			body: { role: "streamer" },
+		});
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([
+			{ url: bobUrl, label: null },
+		]);
+	});
+
+	it("never duplicates an already-listed URL", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: { stream_url: TWITCH },
+		});
+		// Re-cast as streamer with the same stored link.
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: { role: "streamer" },
+		});
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([
+			{ url: TWITCH, label: null },
+		]);
+	});
+
+	it("dropping removes the caller's stream link but leaves others' streams", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		await request.post({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+			body: { stream_url: TWITCH },
+		});
+		// An admin-added unrelated stream must survive alice's drop. (Replace-all
+		// echoes the current parts list plus the extra stream.)
+		const other = { url: "https://youtube.com/watch?v=other", label: "VOD" };
+		await expectOk(
+			await request.patch({
+				path: `/v1/tournaments/${t.tournamentId}/matches/${match.match_id}/schedule`,
+				as: t.admin,
+				body: {
+					parts: [
+						{
+							id: partId,
+							scheduled_at: WHEN,
+							casters: await castersOf(t, match.match_id, partId),
+							streams: [{ url: TWITCH, label: null }, other],
+						},
+					],
+				},
+			}),
+		);
+
+		const res = await request.delete({
+			path: castPath(t.tournamentId, match.match_id, partId),
+			as: alice,
+		});
+		expect(res.status).toBe(204);
+		expect(await castersOf(t, match.match_id, partId)).toEqual([]);
+		expect(await streamsOf(t, match.match_id, partId)).toEqual([other]);
+	});
+
+	it("rejects a stream_url outside the twitch/youtube allowlist", async () => {
+		const { t, match, partId } = await setup();
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		await expectErrorCode(
+			await request.post({
+				path: castPath(t.tournamentId, match.match_id, partId),
+				as: alice,
+				body: { stream_url: "https://example.com/live" },
+			}),
+			{ status: 400, code: "INVALID_BODY" },
+		);
+		// Same allowlist on the settings path.
+		await expectErrorCode(
+			await request.post({
+				path: "/v1/auth/settings",
+				as: alice,
+				body: { stream_url: "https://example.com/live" },
+			}),
+			{ status: 400, code: "INVALID_BODY" },
+		);
+	});
+
+	it("settings can set and clear the stream link", async () => {
+		const alice = await makeUser({ discordUsername: "alice_caster" });
+		const set = await expectOk<{ stream_url: string | null }>(
+			await request.post({
+				path: "/v1/auth/settings",
+				as: alice,
+				body: { stream_url: TWITCH },
+			}),
+		);
+		expect(set.stream_url).toBe(TWITCH);
+
+		const cleared = await expectOk<{
+			stream_url: string | null;
+			default_game_public: boolean;
+		}>(
+			await request.post({
+				path: "/v1/auth/settings",
+				as: alice,
+				body: { stream_url: null },
+			}),
+		);
+		expect(cleared.stream_url).toBeNull();
+		// The partial write didn't clobber the untouched preference.
+		expect(cleared.default_game_public).toBe(true);
 	});
 });

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -124,7 +124,7 @@ Exchange the OAuth code for a session.
 Current session's user profile.
 
 - **Auth:** Session.
-- **Response 200:** `{ user_id, discord_id, display_name, discord_username, avatar_url, is_beta: boolean, is_admin: boolean, default_game_public: boolean }`.
+- **Response 200:** `{ user_id, discord_id, display_name, discord_username, avatar_url, is_beta: boolean, is_admin: boolean, default_game_public: boolean, stream_url: string|null }`.
 - **Errors:** `401 UNAUTHORIZED` (also if the session points at a deleted user, which clears the cookie).
 - **Notes:** Re-claims pre-linked tournament slots on every call. `is_beta`/`is_admin` are advisory (frontend gating); the server re-checks per endpoint.
 
@@ -138,11 +138,11 @@ Local-only login bypass (no Discord).
 - **Notes:** Also grants tournament beta (note `dev-login`) and seeds the `Personal` collection. See `docs/dev-login.md`.
 
 ### `POST /v1/auth/settings`
-Update account settings.
+Update account settings (partial — only the fields sent are written).
 
 - **Auth:** Session.
-- **Body:** `UserSettingsSchema` — `{ default_game_public: boolean }` (required). Default visibility applied to newly uploaded saves.
-- **Response 200:** `{ default_game_public: boolean }`.
+- **Body:** `UserSettingsSchema` — `{ default_game_public?: boolean, stream_url?: string|null }`. `default_game_public` is the default visibility applied to newly uploaded saves. `stream_url` is the casting stream link (YouTube/Twitch allowlist, same as match-part streams), auto-attached when the user takes the streamer slot on a match part; `null` clears it.
+- **Response 200:** `{ default_game_public: boolean, stream_url: string|null }` (the full current settings, whichever subset was written).
 - **Errors:** `401 UNAUTHORIZED`, `400 INVALID_JSON`, `400 INVALID_BODY`.
 
 ### `GET /v1/auth/channels`
@@ -567,10 +567,10 @@ Add yourself as a caster on a match part.
 
 - **Auth:** Session (any logged-in user).
 - **Path:** `id`, `match_id` (21-char), `part_id` (1–40 chars).
-- **Body:** `CastMatchPartSchema` — `{ role?: "streamer" | "cocaster" }` (defaults: streamer if the part has no caster, else co-caster).
+- **Body:** `CastMatchPartSchema` — `{ role?: "streamer" | "cocaster", stream_url?: string }` (role defaults: streamer if the part has no caster, else co-caster). `stream_url` (YouTube/Twitch allowlist) is saved to the account (`users.stream_url`) before the cast applies — the one-time "remember my stream" path.
 - **Response:** `204 No Content` (refetch to see the result).
 - **Errors:** `400 INVALID_BODY`, `401 UNAUTHORIZED`, `404 MATCH_NOT_FOUND` / `PART_NOT_FOUND`, `409 MATCH_NOT_PENDING` / `TOO_MANY_CASTERS` / `CONFLICT`, `429 RATE_LIMIT_TOURNAMENT_SCHEDULE`.
-- **Notes:** Self-only (keyed by your `user_id`); the caster name is snapshotted from your Discord username. CAS on `parts_rev`; max 10 casters/part. Shares the `tournament_schedule` budget.
+- **Notes:** Self-only (keyed by your `user_id`); the caster name is snapshotted from your Discord username. Taking the streamer slot auto-attaches your stored stream link to the part's streams (skipped for co-casters, already-listed URLs, and at the 20-stream cap). CAS on `parts_rev`; max 10 casters/part. Shares the `tournament_schedule` budget.
 
 ### `DELETE /v1/tournaments/:id/matches/:match_id/parts/:part_id/casters/me`
 Remove yourself as a caster.
@@ -579,7 +579,7 @@ Remove yourself as a caster.
 - **Path:** `id`, `match_id` (21-char), `part_id` (1–40 chars).
 - **Response:** `204 No Content`.
 - **Errors:** `401 UNAUTHORIZED`, `404 MATCH_NOT_FOUND` / `PART_NOT_FOUND`, `409 MATCH_NOT_PENDING` (bye) / `CONFLICT`, `429 RATE_LIMIT_TOURNAMENT_SCHEDULE`.
-- **Notes:** Self-only. Allowed even on decided matches (byes still rejected).
+- **Notes:** Self-only. Allowed even on decided matches (byes still rejected). Also removes your stored stream link (matched by URL) from the part's streams, undoing the cast auto-attach.
 
 ---
 

--- a/src/lib/api-cloud.ts
+++ b/src/lib/api-cloud.ts
@@ -114,6 +114,10 @@ export interface UserMe {
 	// private-by-default. Re-imports preserve the existing game's visibility
 	// and tournament uploads are forced public regardless.
 	default_game_public: boolean;
+	// Casting stream link (twitch/youtube), auto-attached to a match part when
+	// this user takes the streamer slot. null = not set; the cast button then
+	// offers a one-time input that remembers the link for later casts.
+	stream_url: string | null;
 }
 
 export interface GameListItem {
@@ -420,19 +424,23 @@ export const cloudApi = {
 		await request("/auth/logout", { ...opts, method: "POST" });
 	},
 
-	// Update account preferences. Currently just the default visibility for
-	// new uploads; returns the persisted value so callers can reconcile.
+	// Update account preferences — send only the fields to change (partial
+	// update). stream_url: string sets the casting link, null clears it.
+	// Returns the full persisted settings so callers can reconcile.
 	updateSettings: async (
-		settings: { default_game_public: boolean },
+		settings: { default_game_public?: boolean; stream_url?: string | null },
 		opts?: CallOpts,
-	): Promise<{ default_game_public: boolean }> => {
+	): Promise<{ default_game_public: boolean; stream_url: string | null }> => {
 		const res = await request("/auth/settings", {
 			...opts,
 			method: "POST",
 			headers: { "Content-Type": "application/json" },
 			body: JSON.stringify(settings),
 		});
-		return res.json() as Promise<{ default_game_public: boolean }>;
+		return res.json() as Promise<{
+			default_game_public: boolean;
+			stream_url: string | null;
+		}>;
 	},
 
 	// --- Video channels (self-service) ---
@@ -1342,13 +1350,16 @@ export const cloudApi = {
 	// Caster self-service: add/move the CURRENT USER on a part's caster list.
 	// role picks the slot ("streamer" takes index 0, bumping the current
 	// streamer to co-caster; "cocaster" appends); omitted → streamer when the
-	// part has no caster, else co-caster. Open to any logged-in user; pending
-	// matches only. Responds 204 — callers refresh via invalidateAll.
+	// part has no caster, else co-caster. streamUrl is the one-time "remember
+	// my stream" path — it's saved to the account and auto-attached on this
+	// and later streamer casts. Open to any logged-in user; pending matches
+	// only. Responds 204 — callers refresh via invalidateAll.
 	castMatchPart: async (
 		tournamentId: string,
 		matchId: string,
 		partId: string,
 		role?: "streamer" | "cocaster",
+		streamUrl?: string,
 		opts?: CallOpts,
 	): Promise<void> => {
 		await request(
@@ -1357,7 +1368,10 @@ export const cloudApi = {
 				...opts,
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify(role ? { role } : {}),
+				body: JSON.stringify({
+					...(role ? { role } : {}),
+					...(streamUrl ? { stream_url: streamUrl } : {}),
+				}),
 			},
 		);
 	},

--- a/src/lib/settings/ChannelSettings.svelte
+++ b/src/lib/settings/ChannelSettings.svelte
@@ -65,10 +65,9 @@
 		class="rounded-lg p-3"
 		style="background-color: rgb(var(--color-surface-raised));"
 	>
-		<div class="text-sm font-bold text-tan">Streaming channels</div>
+		<div class="text-sm font-bold text-tan">Video channels</div>
 		<p class="mt-1 text-xs text-gray-400">
-			Link a channel to show your recent videos on your profile. Paste a channel
-			URL or @handle. YouTube is supported.
+			YouTube channel to show recent videos on your profile.
 		</p>
 
 		<form onsubmit={add} class="mt-3 flex items-center gap-2">

--- a/src/lib/tournament/CastControls.svelte
+++ b/src/lib/tournament/CastControls.svelte
@@ -7,6 +7,11 @@
 	// for pending scheduled sittings — the caller gates on rowIsPendingSitting.
 	// The "needs a caster" flag is not here; it lives with the caster/stream data
 	// in the Casters & Streams cell.
+	//
+	// Streamer casts auto-attach the caster's stream link (users.stream_url,
+	// editable in account preferences). A first-time streamer with no stored
+	// link gets a one-time inline input — whatever they enter is remembered
+	// server-side, so every later cast is again a single click.
 	import { cloudApi, type TournamentDetail, type UserMe } from "$lib/api-cloud";
 	import { rowPart, type MatchRow } from "$lib/tournament/matches-table";
 	import { runAction } from "$lib/tournament/async-action";
@@ -29,22 +34,55 @@
 	const mine = $derived(
 		user != null && casters.some((c) => c.user_id === user.user_id),
 	);
+	// An empty sitting makes the caller the streamer — the only case where a
+	// stream link matters (co-casts air on the streamer's channel).
+	const wouldStream = $derived(casters.length === 0);
 
 	let busy = $state(false);
+	// One-time stream-link input, shown when a would-be streamer has no stored
+	// link yet.
+	let promptOpen = $state(false);
+	let streamUrl = $state("");
 
 	async function cast() {
 		if (!part) return;
 		const partId = part.id;
-		await runAction(
+		// The URL field is a bare-domain magnet ("twitch.tv/sion"); the API
+		// requires a scheme, so add one rather than bounce the cast on a 400.
+		const trimmed = streamUrl.trim();
+		const withUrl =
+			trimmed === ""
+				? undefined
+				: /^https?:\/\//i.test(trimmed)
+					? trimmed
+					: `https://${trimmed}`;
+		const ok = await runAction(
 			() =>
 				cloudApi.castMatchPart(
 					tournament.tournament_id,
 					row.match.match_id,
 					partId,
+					undefined,
+					withUrl,
 				),
 			{ setBusy: (b) => (busy = b), success: "You're casting" },
 		);
+		if (ok !== null) {
+			promptOpen = false;
+			streamUrl = "";
+		}
 	}
+
+	function onCastClick() {
+		// First streamer cast with no remembered link: unfold the one-time
+		// stream input instead of casting streamless right away.
+		if (wouldStream && user?.stream_url == null && !promptOpen) {
+			promptOpen = true;
+			return;
+		}
+		cast();
+	}
+
 	async function drop() {
 		if (!part) return;
 		const partId = part.id;
@@ -67,21 +105,55 @@
 		<!-- Buttons stopPropagation so acting on a row doesn't also open the match
 		     card behind it. -->
 		{#if !mine}
-			<!-- Empty sitting → you become the streamer ("I'll cast"); a sitting that
-			     already has a caster → you join as a co-caster ("Co-cast"). Same
-			     endpoint (omitted role picks the slot); the label just tells you which
-			     you'll get. -->
-			<button
-				type="button"
-				class="rounded border border-input px-2 py-1 text-xs text-tan transition-colors hover:border-orange hover:text-orange disabled:opacity-50"
-				disabled={busy}
-				onclick={(e) => {
-					e.stopPropagation();
-					cast();
-				}}
-			>
-				{casters.length === 0 ? "I'll cast" : "Co-cast"}
-			</button>
+			{#if promptOpen}
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<div
+					class="flex items-center gap-1.5"
+					onclick={(e) => e.stopPropagation()}
+					onkeydown={(e) => e.stopPropagation()}
+				>
+					<!-- Autofocus is fine here: the field only appears in response to the
+					     user's own click, so focus follows their intent. -->
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						type="text"
+						class="w-40 rounded border border-input bg-surface-sunken px-2 py-1 text-xs text-tan placeholder:text-gray-500 focus:border-orange focus:outline-none"
+						placeholder="twitch.tv/you (optional)"
+						title="Your stream link — remembered for future casts. Leave empty to cast without one."
+						bind:value={streamUrl}
+						disabled={busy}
+						autofocus
+						onkeydown={(e) => {
+							if (e.key === "Enter") cast();
+							if (e.key === "Escape") promptOpen = false;
+						}}
+					/>
+					<button
+						type="button"
+						class="rounded border border-input px-2 py-1 text-xs text-tan transition-colors hover:border-orange hover:text-orange disabled:opacity-50"
+						disabled={busy}
+						onclick={cast}
+					>
+						Cast
+					</button>
+				</div>
+			{:else}
+				<!-- Empty sitting → you become the streamer ("I'll cast"); a sitting that
+				     already has a caster → you join as a co-caster ("Co-cast"). Same
+				     endpoint (omitted role picks the slot); the label just tells you which
+				     you'll get. -->
+				<button
+					type="button"
+					class="rounded border border-input px-2 py-1 text-xs text-tan transition-colors hover:border-orange hover:text-orange disabled:opacity-50"
+					disabled={busy}
+					onclick={(e) => {
+						e.stopPropagation();
+						onCastClick();
+					}}
+				>
+					{wouldStream ? "I'll cast" : "Co-cast"}
+				</button>
+			{/if}
 		{:else}
 			<button
 				type="button"

--- a/src/lib/tournament/CastControls.svelte
+++ b/src/lib/tournament/CastControls.svelte
@@ -47,8 +47,8 @@
 	async function cast() {
 		if (!part) return;
 		const partId = part.id;
-		// The URL field is a bare-domain magnet ("twitch.tv/sion"); the API
-		// requires a scheme, so add one rather than bounce the cast on a 400.
+		// The URL field is a bare-domain magnet ("youtube.com/@sion/live"); the
+		// API requires a scheme, so add one rather than bounce the cast on a 400.
 		const trimmed = streamUrl.trim();
 		const withUrl =
 			trimmed === ""
@@ -118,7 +118,7 @@
 					<input
 						type="text"
 						class="w-40 rounded border border-input bg-surface-sunken px-2 py-1 text-xs text-tan placeholder:text-gray-500 focus:border-orange focus:outline-none"
-						placeholder="twitch.tv/you (optional)"
+						placeholder="youtube.com/@you/live (optional)"
 						title="Your stream link — remembered for future casts. Leave empty to cast without one."
 						bind:value={streamUrl}
 						disabled={busy}

--- a/src/lib/tournament/CastControls.svelte
+++ b/src/lib/tournament/CastControls.svelte
@@ -15,6 +15,7 @@
 	import { cloudApi, type TournamentDetail, type UserMe } from "$lib/api-cloud";
 	import { rowPart, type MatchRow } from "$lib/tournament/matches-table";
 	import { runAction } from "$lib/tournament/async-action";
+	import { ensureUrlScheme } from "$lib/utils/url";
 
 	let {
 		row,
@@ -49,13 +50,8 @@
 		const partId = part.id;
 		// The URL field is a bare-domain magnet ("youtube.com/@sion/live"); the
 		// API requires a scheme, so add one rather than bounce the cast on a 400.
-		const trimmed = streamUrl.trim();
-		const withUrl =
-			trimmed === ""
-				? undefined
-				: /^https?:\/\//i.test(trimmed)
-					? trimmed
-					: `https://${trimmed}`;
+		// Empty stays undefined so the cast body omits stream_url entirely.
+		const withUrl = ensureUrlScheme(streamUrl) ?? undefined;
 		const ok = await runAction(
 			() =>
 				cloudApi.castMatchPart(

--- a/src/lib/tournament/TournamentLinksEditor.svelte
+++ b/src/lib/tournament/TournamentLinksEditor.svelte
@@ -8,6 +8,7 @@
 		type TournamentLink,
 	} from "$lib/api-cloud";
 	import { toast } from "$lib/ui/toast";
+	import { ensureUrlScheme } from "$lib/utils/url";
 
 	interface Props {
 		tournament: TournamentDetail;
@@ -40,19 +41,13 @@
 		})),
 	);
 
-	// Prepend https:// when the user omits a scheme (so "old-world-map-pics.com"
-	// works). Anything already carrying a scheme is left for the server to vet.
-	function normalizeUrl(raw: string): string {
-		const trimmed = raw.trim();
-		if (!trimmed) return "";
-		return /:\/\//.test(trimmed) ? trimmed : `https://${trimmed}`;
-	}
-
 	// The payload: complete rows only (both fields filled), normalized. Incomplete
 	// rows stay in local state, uncommitted, so a half-typed link isn't dropped.
+	// ensureUrlScheme prepends https:// to a bare domain ("old-world-map-pics.com")
+	// and returns null for empty, which the url !== "" filter then drops.
 	function buildLinks(): TournamentLink[] {
 		return rows
-			.map((r) => ({ label: r.label.trim(), url: normalizeUrl(r.url) }))
+			.map((r) => ({ label: r.label.trim(), url: ensureUrlScheme(r.url) ?? "" }))
 			.filter((l) => l.label !== "" && l.url !== "");
 	}
 
@@ -88,7 +83,7 @@
 	function commitUrl(row: Row) {
 		// Reflect the normalized form back into the input so what's shown matches
 		// what was saved.
-		row.url = normalizeUrl(row.url);
+		row.url = ensureUrlScheme(row.url) ?? "";
 		commit();
 	}
 

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,0 +1,12 @@
+// URL helpers shared across the app.
+
+// Prepend "https://" when a user-entered URL omits a scheme, so a bare domain
+// like "youtube.com/@you/live" is accepted — the Worker's stream-link
+// validation requires a scheme and would otherwise 400 the paste. A value that
+// already starts with http(s):// is left untouched for the server to vet;
+// empty/whitespace-only input returns null (nothing to submit).
+export function ensureUrlScheme(raw: string): string | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return null;
+	return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+}

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -105,7 +105,9 @@
 		try {
 			const saved = await cloudApi.updateSettings({ stream_url: next });
 			streamUrl = saved.stream_url ?? "";
-			toast.info(saved.stream_url ? "Stream link saved" : "Stream link cleared");
+			toast.info(
+				saved.stream_url ? "Stream link saved" : "Stream link cleared",
+			);
 		} catch (err) {
 			toast.error(
 				`Settings update failed: ${err instanceof Error ? err.message : err}`,
@@ -132,9 +134,7 @@
 				<Tabs.Trigger value="preferences" class={triggerClass}>
 					Preferences
 				</Tabs.Trigger>
-				<Tabs.Trigger value="channels" class={triggerClass}>
-					Channels
-				</Tabs.Trigger>
+				<Tabs.Trigger value="video" class={triggerClass}>Video</Tabs.Trigger>
 				<Tabs.Trigger value="maintenance" class={triggerClass}>
 					Maintenance
 				</Tabs.Trigger>
@@ -228,13 +228,24 @@
 								></span>
 							</button>
 						</div>
+					</div>
+				</div>
+			</Tabs.Content>
 
-						<div class="mt-3 border-t border-border-subtle pt-3">
+			<Tabs.Content value="video">
+				<div class="space-y-3">
+					<div
+						class="rounded-lg p-4"
+						style="background-color: rgb(var(--color-surface));"
+					>
+						<div
+							class="rounded-lg p-3"
+							style="background-color: rgb(var(--color-surface-raised));"
+						>
 							<div class="text-sm font-bold text-tan">Casting stream link</div>
 							<p class="mt-1 text-xs text-gray-400">
-								Your YouTube or Twitch link, attached to a match automatically
-								when you sign up to cast it. Clear the field to turn
-								auto-attach off.
+								YouTube or Twitch stream link added to matches when you are a
+								caster.
 							</p>
 							<form
 								class="mt-2 flex items-center gap-2"
@@ -245,8 +256,8 @@
 							>
 								<input
 									type="text"
-									class="min-w-0 flex-1 rounded border border-input bg-surface-sunken px-2 py-1.5 text-sm text-tan placeholder:text-gray-500 focus:border-orange focus:outline-none"
-									placeholder="youtube.com/@you/live"
+									class="min-w-0 flex-1 rounded border border-input bg-surface-sunken px-2 py-1.5 text-sm text-tan focus:border-orange focus:outline-none"
+									aria-label="Casting stream link"
 									bind:value={streamUrl}
 									disabled={savingStream}
 								/>
@@ -260,11 +271,8 @@
 							</form>
 						</div>
 					</div>
+					<ChannelSettings initialChannels={data.channels} />
 				</div>
-			</Tabs.Content>
-
-			<Tabs.Content value="channels">
-				<ChannelSettings initialChannels={data.channels} />
 			</Tabs.Content>
 
 			<Tabs.Content value="maintenance">

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -9,6 +9,7 @@
 	import { PARSER_VERSION } from "$lib/parser/types";
 	import { formatGameTitle } from "$lib/utils/formatting";
 	import { isNewer } from "$lib/utils/semver";
+	import { ensureUrlScheme } from "$lib/utils/url";
 	import { toast } from "$lib/ui/toast";
 	import type { PageData } from "./$types";
 
@@ -96,15 +97,10 @@
 
 	async function saveStreamUrl() {
 		if (savingStream) return;
-		const trimmed = streamUrl.trim();
 		// A bare domain ("youtube.com/@you/live") is the natural thing to paste;
 		// the worker requires a scheme, so add one instead of bouncing on a 400.
-		const next =
-			trimmed === ""
-				? null
-				: /^https?:\/\//i.test(trimmed)
-					? trimmed
-					: `https://${trimmed}`;
+		// Empty → null, which clears the stored link.
+		const next = ensureUrlScheme(streamUrl);
 		savingStream = true;
 		try {
 			const saved = await cloudApi.updateSettings({ stream_url: next });

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -30,6 +30,13 @@
 	let defaultPublic = $state(data.user.default_game_public);
 	let savingPref = $state(false);
 
+	// Casting stream link — plain save-on-submit (not optimistic: the worker
+	// validates the host allowlist, so the persisted value is what it echoes
+	// back, not what was typed).
+	// svelte-ignore state_referenced_locally
+	let streamUrl = $state(data.user.stream_url ?? "");
+	let savingStream = $state(false);
+
 	// Already filtered to out-of-date games server-side (see +page.ts), so the
 	// count and modal list cover the user's entire library, not just a page.
 	const outOfDateGames = $derived(data.outOfDateGames);
@@ -84,6 +91,31 @@
 			);
 		} finally {
 			savingPref = false;
+		}
+	}
+
+	async function saveStreamUrl() {
+		if (savingStream) return;
+		const trimmed = streamUrl.trim();
+		// A bare domain ("twitch.tv/sion") is the natural thing to paste; the
+		// worker requires a scheme, so add one instead of bouncing on a 400.
+		const next =
+			trimmed === ""
+				? null
+				: /^https?:\/\//i.test(trimmed)
+					? trimmed
+					: `https://${trimmed}`;
+		savingStream = true;
+		try {
+			const saved = await cloudApi.updateSettings({ stream_url: next });
+			streamUrl = saved.stream_url ?? "";
+			toast.info(saved.stream_url ? "Stream link saved" : "Stream link cleared");
+		} catch (err) {
+			toast.error(
+				`Settings update failed: ${err instanceof Error ? err.message : err}`,
+			);
+		} finally {
+			savingStream = false;
 		}
 	}
 
@@ -199,6 +231,37 @@
 										: 'translate-x-1'}"
 								></span>
 							</button>
+						</div>
+
+						<div class="mt-3 border-t border-border-subtle pt-3">
+							<div class="text-sm font-bold text-tan">Casting stream link</div>
+							<p class="mt-1 text-xs text-gray-400">
+								Your Twitch or YouTube link, attached to a match automatically
+								when you sign up to cast it. Clear the field to turn
+								auto-attach off.
+							</p>
+							<form
+								class="mt-2 flex items-center gap-2"
+								onsubmit={(e) => {
+									e.preventDefault();
+									saveStreamUrl();
+								}}
+							>
+								<input
+									type="text"
+									class="min-w-0 flex-1 rounded border border-input bg-surface-sunken px-2 py-1.5 text-sm text-tan placeholder:text-gray-500 focus:border-orange focus:outline-none"
+									placeholder="twitch.tv/you"
+									bind:value={streamUrl}
+									disabled={savingStream}
+								/>
+								<button
+									type="submit"
+									class="rounded border border-input px-3 py-1.5 text-sm text-tan transition-colors hover:border-orange hover:text-orange disabled:opacity-50"
+									disabled={savingStream}
+								>
+									Save
+								</button>
+							</form>
 						</div>
 					</div>
 				</div>

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -97,8 +97,8 @@
 	async function saveStreamUrl() {
 		if (savingStream) return;
 		const trimmed = streamUrl.trim();
-		// A bare domain ("twitch.tv/sion") is the natural thing to paste; the
-		// worker requires a scheme, so add one instead of bouncing on a 400.
+		// A bare domain ("youtube.com/@you/live") is the natural thing to paste;
+		// the worker requires a scheme, so add one instead of bouncing on a 400.
 		const next =
 			trimmed === ""
 				? null
@@ -236,7 +236,7 @@
 						<div class="mt-3 border-t border-border-subtle pt-3">
 							<div class="text-sm font-bold text-tan">Casting stream link</div>
 							<p class="mt-1 text-xs text-gray-400">
-								Your Twitch or YouTube link, attached to a match automatically
+								Your YouTube or Twitch link, attached to a match automatically
 								when you sign up to cast it. Clear the field to turn
 								auto-attach off.
 							</p>
@@ -250,7 +250,7 @@
 								<input
 									type="text"
 									class="min-w-0 flex-1 rounded border border-input bg-surface-sunken px-2 py-1.5 text-sm text-tan placeholder:text-gray-500 focus:border-orange focus:outline-none"
-									placeholder="twitch.tv/you"
+									placeholder="youtube.com/@you/live"
 									bind:value={streamUrl}
 									disabled={savingStream}
 								/>


### PR DESCRIPTION
Fixes the "sion clicks *I'll cast* but his stream link never makes it onto the match" gap. The root cause is structural: `casters/me` is open to any logged-in user, but stream links live on the parts list behind the participant/admin-gated schedule editor — a non-participant caster **can't** attach their own stream at all.

## What this does

**Casters get a remembered stream link that rides along with the cast.**

- New `users.stream_url` (migration 0033), validated against the same YouTube/Twitch host allowlist as part streams (`StreamUrlSchema` is now shared with `schemas/user.ts`).
- **Taking the streamer slot auto-attaches the stored link** to the part's `streams`. Co-casters don't attach (the cast airs on the streamer's channel); promoting yourself to streamer does. Dedupe by URL; respects the 20-stream cap (now the exported `MAX_STREAMS_PER_PART`, single-sourced with the schema). All inside the existing `parts_rev` CAS loop.
- **Dropping detaches it again** (matched by URL), so an un-cast sitting isn't left pointing at a channel nobody is casting on.
- **First-time casters are prompted once, inline**: if you'd become the streamer and have no stored link, "I'll cast" unfolds a small input (`youtube.com/@you/live (optional)`) right in the row. Whatever you enter is persisted (`stream_url` on the cast body) — every later cast is a single click. Bare domains get `https://` prefixed client-side (the API requires a scheme). Empty = cast streamless, exactly today's behavior.
- **Profile control**: Account → Preferences gains a "Casting stream link" field — edit, or clear to turn auto-attach off. `POST /v1/auth/settings` became a partial update (all fields optional, `null` clears) and echoes the full settings; `GET /v1/auth/me` now returns `stream_url`.
- **Backfill**: the migration seeds `stream_url` from casting history — the first stream URL on each user's most recent streamer sitting. Heuristic (streams aren't attributed to users in the parts data), but it only sets a visible, editable default; on a copy of current data it correctly infers the links for 8 casters (sion, alcaras, aran, boldus, …), so existing casters get one-click casting from day one.

![prompt](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/caster-stream-prompt.png)
![done](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/caster-stream-done.png)
![prefs](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/caster-stream-prefs.png)

## Testing

- 7 new integration tests in `cast.test.ts` (13 total, all green): remember-once via the cast body, settings round-trip incl. partial update, streamer-vs-co-caster attach, promote-to-streamer attach, URL dedupe, drop cleanup leaving others' streams, host allowlist on both endpoints, and the 0033 backfill statement itself (duplicated in-test with a keep-in-sync pointer, since the harness applies migrations to empty tables).
- `npm run lint`, `svelte-check`, and the worker suite pass. Exercised end-to-end on the local stack (cast → auto-attach → drop → detach, plus the browser flow in the screenshots).

## Heads-up, unrelated to this PR

`main` currently fails 4 unit tests in `canonical-map-options.test.ts`: b39f690 re-baked `map-option-defs.ts` (new `MAP_OPTIONS_MULTI_DOTA_INNER_TERRAIN`) but `cloud/src/tournament/canonical-map-options.ts` didn't get the matching entry. Left untouched here to keep this PR scoped — happy to send the four-line mirror fix separately if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
