### PR TITLE
feat(techs): science chart with Cumulative | Per Turn | Number of Techs toggle

### DIFF
--- a/src/lib/Chart.svelte
+++ b/src/lib/Chart.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <script lang="ts">
-	import { onMount, tick } from "svelte";
+	import { onMount, tick, untrack } from "svelte";
 	import type { ECElementEvent, EChartsOption } from "echarts";
 
 	let {
@@ -106,7 +106,13 @@
 			chart.setOption(currentOption, true);
 			// Force resize to handle tab visibility changes
 			chart.resize();
-			onLayout?.();
+			// untrack: the notify must not add the callback prop (or anything the
+			// handler touches) to this effect's dependencies. A parent's inline
+			// `onLayout` handler is recreated whenever its fragment re-renders —
+			// e.g. from the layout-tick state the handler itself bumps — so a
+			// tracked call re-runs this effect and loops (setOption → onLayout →
+			// tick++ → new handler → setOption …: effect_update_depth_exceeded).
+			untrack(() => onLayout?.());
 		}
 	});
 </script>

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -116,112 +116,76 @@
 		TECH_NAMES[tech] ?? formatEnum(tech, "TECH_");
 
 	// ─── Chart option ─────────────────────────────────────────────────
-	const techDiscoveryChartOption = $derived(
-		techDiscoveryHistory.length > 0
-			? (() => {
-					const histories = techDiscoveryHistory;
-					const maxTechCount = Math.max(
-						...histories.flatMap((player) =>
-							player.data.map((d) => d.tech_count),
-						),
-					);
-					const finalTurn = Math.max(
-						...histories.flatMap((player) => player.data.map((d) => d.turn)),
-					);
-					const seriesLabels = histories.map(
-						(p) =>
-							playerById.get(p.player_id)?.label ??
-							formatEnum(p.nation, "NATION_"),
-					);
-
-					return {
-						...CHART_THEME,
-						title: {
-							...CHART_THEME.title,
-							text: "Tech Discovery Over Time",
-						},
-						legend: {
-							show: false,
-							data: seriesLabels,
-							selected: chartFilter,
-						},
-						tooltip: {
-							trigger: "axis",
-							// Points are sparse (one per discovery), so snap the axis
-							// pointer to the nearest event and drive the tooltip off the
-							// axis — hovering anywhere works, matching the other charts.
-							axisPointer: { snap: true },
-							formatter: (params: unknown) => {
-								const arr = params as Array<{
-									marker: string;
-									seriesName: string;
-									data: [number, number, string | null];
-								}>;
-								if (arr.length === 0) return "";
-								const turn = arr[0].data[0];
-								const rows = arr
-									.map((p) => {
-										const [, count, tech] = p.data;
-										const suffix = tech ? ` — ${techName(tech)}` : "";
-										return `${p.marker}${p.seriesName}: <b>${count}</b>${suffix}`;
-									})
-									.join("<br/>");
-								return `Turn ${turn}<br/>${rows}`;
-							},
-						},
-						// No axis-name titles — the title + tooltip carry the meaning,
-						// matching the Military Power plot. containLabel reserves room
-						// for the tick numbers now that the fixed left/bottom gutters
-						// (which the axis names needed) are gone.
-						grid: {
-							top: 44,
-							left: 8,
-							right: 20,
-							bottom: 24,
-							containLabel: true,
-						},
-						xAxis: {
-							type: "value",
-							splitLine: { show: false },
-							max: finalTurn,
-						},
-						yAxis: {
-							type: "value",
-							max: maxTechCount + 2,
-						},
-						series: histories.map((player, i) => {
-							const rp = playerById.get(player.player_id);
-							const color = rp?.color ?? getNationChartColor(player.nation, i);
-							return {
-								name: rp?.label ?? formatEnum(player.nation, "NATION_"),
-								type: "line" as const,
-								data: player.data.map((d) => [
-									d.turn,
-									d.tech_count,
-									d.tech_name,
-								]),
-								itemStyle: { color },
-								// Milestone markers stay hidden until hover (per the shared
-								// look) but still name the discovered tech in the tooltip.
-								symbol: (value: [number, number, string | null]) =>
-									value[2] ? "circle" : "none",
-								symbolSize: 8,
-								emphasis: {
-									symbolSize: 12,
-								},
-								...filledLineStyle(color),
-							};
-						}),
-					} as EChartsOption;
-				})()
-			: null,
-	);
+	// Cumulative science over time — the plot the science rail annotates (its
+	// spikes and key-tech markers are science events, so they read against the
+	// science curve, not a tech count). Same compact styling as the Military
+	// Power plot; per-tech detail lives in the Techs-by-Turn table below.
+	const scienceChartOption = $derived.by<EChartsOption | null>(() => {
+		const science = allYields.filter((y) => y.yield_type === "YIELD_SCIENCE");
+		if (science.length === 0) return null;
+		const turns = science[0].data.map((d) => d.turn);
+		const minTurn = turns[0] ?? 0;
+		const maxTurn = turns[turns.length - 1] ?? 0;
+		const pad = Math.max(1, (maxTurn - minTurn) * 0.02);
+		return {
+			...CHART_THEME,
+			title: {
+				...CHART_THEME.title,
+				text: "Cumulative Science",
+			},
+			legend: {
+				show: false,
+				data: science.map(
+					(p) =>
+						playerById.get(p.player_id)?.label ??
+						formatEnum(p.nation, "NATION_"),
+				),
+				selected: chartFilter,
+			},
+			tooltip: { trigger: "axis" },
+			// No axis-name titles — the title + tooltip carry the meaning,
+			// matching the Military Power plot. containLabel reserves room
+			// for the tick numbers now that the fixed left/bottom gutters
+			// (which the axis names needed) are gone.
+			grid: {
+				top: 44,
+				left: 8,
+				right: 20,
+				bottom: 24,
+				containLabel: true,
+			},
+			xAxis: {
+				type: "value",
+				min: minTurn - pad,
+				max: maxTurn + pad,
+				minInterval: 1,
+				splitLine: { show: false },
+			},
+			yAxis: {
+				type: "value",
+				// Draw the y-axis at the left edge, not at x=0 (the turn axis min
+				// is negative, so onZero would float the axis inside the plot).
+				axisLine: { onZero: false },
+			},
+			series: science.map((player, i) => {
+				const rp = playerById.get(player.player_id);
+				const color = rp?.color ?? getNationChartColor(player.nation, i);
+				return {
+					name: rp?.label ?? formatEnum(player.nation, "NATION_"),
+					type: "line" as const,
+					data: player.data.map((d) => [d.turn, d.cumulative]),
+					itemStyle: { color },
+					...filledLineStyle(color),
+				};
+			}),
+		} as EChartsOption;
+	});
 
 	// ─── Science annotation rail ──────────────────────────────────────
-	// An <EventRail> under the Tech Discovery chart of science-relevant
+	// An <EventRail> under the Cumulative Science chart of science-relevant
 	// events per player: key science techs the player researched AND
 	// demonstrably used (see science-techs.ts), free-tech turns, and one-off
-	// science gains. (Cumulative science itself lives on the Yields tab.)
+	// science gains. (The per-turn science rate lives on the Yields tab.)
 	// Like the Military rail, the annotated variant renders for two-player
 	// matchups; other games get the plain chart.
 
@@ -617,7 +581,7 @@
 	// ─── Planner links + unique techs ─────────────────────────────────
 
 	// Per player: a deep-link of their FULL research order into the owtt
-	// tech-tree planner. Rendered under the Tech Discovery chart (the full
+	// tech-tree planner. Rendered under the science chart (the full
 	// path), not next to the unique-techs chips, so the link's scope is clear.
 	const owttLinks = $derived(
 		orderedPlayers
@@ -753,7 +717,7 @@
 	});
 </script>
 
-{#if techDiscoveryChartOption}
+{#if scienceChartOption}
 	<div
 		class="mb-4 rounded-lg p-4"
 		style="background-color: rgb(var(--color-surface));"
@@ -764,7 +728,7 @@
 			     at its true turn-x on the live chart (mil-tab pattern). -->
 			<div class="relative">
 				<Chart
-					option={techDiscoveryChartOption}
+					option={scienceChartOption}
 					height="360px"
 					onReady={(c) => (railChart = c)}
 					onLayout={() => (railLayoutTick += 1)}
@@ -800,9 +764,9 @@
 			{/if}
 		{:else}
 			<ChartContainer
-				option={techDiscoveryChartOption}
+				option={scienceChartOption}
 				height="400px"
-				title="Tech Discovery Over Time"
+				title="Cumulative Science"
 			/>
 		{/if}
 		{#if owttLinks.length > 0}

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -13,6 +13,7 @@
 		MemoryInfo,
 	} from "$lib/parser/types";
 	import type { EChartsOption, ECharts } from "echarts";
+	import { ToggleGroup } from "bits-ui";
 	import Chart from "$lib/Chart.svelte";
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import { formatEnum } from "$lib/utils/formatting";
@@ -116,33 +117,102 @@
 		TECH_NAMES[tech] ?? formatEnum(tech, "TECH_");
 
 	// ─── Chart option ─────────────────────────────────────────────────
-	// Cumulative science over time — the plot the science rail annotates (its
-	// spikes and key-tech markers are science events, so they read against the
-	// science curve, not a tech count). Same compact styling as the Military
-	// Power plot; per-tech detail lives in the Techs-by-Turn table below.
-	const scienceChartOption = $derived.by<EChartsOption | null>(() => {
+	// The plot the science rail annotates, in three switchable views:
+	// cumulative science (default — the rail's markers are science events, so
+	// they read against the science curve), per-turn science rate (small
+	// numbers, so a tech adoption's effect stays visible late-game), and the
+	// tech count over time (with the discovered tech named per point). Same
+	// compact styling as the Military Power plot in every mode.
+	type TechsChartMode = "cumulative" | "rate" | "techs";
+	let chartMode = $state<TechsChartMode>("cumulative");
+
+	const CHART_MODE_TITLES: Record<TechsChartMode, string> = {
+		cumulative: "Cumulative Science",
+		rate: "Science per Turn",
+		techs: "Techs Discovered",
+	};
+
+	// Shared toggle-item tokens (matches the Yields tab / YieldsStatsPanel).
+	const toggleItemClass =
+		"px-2.5 py-1 text-xs text-tan transition-colors data-[state=off]:bg-surface data-[state=on]:bg-surface-raised";
+
+	const chartOption = $derived.by<EChartsOption | null>(() => {
+		// Per-mode series: [turn, value] pairs (techs mode carries the discovered
+		// tech's name as a third element for its tooltip/markers).
 		const science = allYields.filter((y) => y.yield_type === "YIELD_SCIENCE");
-		if (science.length === 0) return null;
-		const turns = science[0].data.map((d) => d.turn);
-		const minTurn = turns[0] ?? 0;
-		const maxTurn = turns[turns.length - 1] ?? 0;
+		const perPlayer =
+			chartMode === "techs"
+				? techDiscoveryHistory.map((p) => ({
+						player_id: p.player_id,
+						nation: p.nation,
+						points: p.data.map(
+							(d): [number, number | null, string | null] => [
+								d.turn,
+								d.tech_count,
+								d.tech_name,
+							],
+						),
+					}))
+				: science.map((p) => ({
+						player_id: p.player_id,
+						nation: p.nation,
+						points: p.data.map(
+							(d): [number, number | null, string | null] => [
+								d.turn,
+								chartMode === "rate" ? d.rate : d.cumulative,
+								null,
+							],
+						),
+					}));
+		if (perPlayer.length === 0) return null;
+
+		const turns = perPlayer.flatMap((p) => p.points.map((d) => d[0]));
+		const minTurn = Math.min(...turns);
+		const maxTurn = Math.max(...turns);
 		const pad = Math.max(1, (maxTurn - minTurn) * 0.02);
+
 		return {
 			...CHART_THEME,
 			title: {
 				...CHART_THEME.title,
-				text: "Cumulative Science",
+				text: CHART_MODE_TITLES[chartMode],
 			},
 			legend: {
 				show: false,
-				data: science.map(
+				data: perPlayer.map(
 					(p) =>
 						playerById.get(p.player_id)?.label ??
 						formatEnum(p.nation, "NATION_"),
 				),
 				selected: chartFilter,
 			},
-			tooltip: { trigger: "axis" },
+			tooltip:
+				chartMode === "techs"
+					? {
+							trigger: "axis",
+							// Points are sparse (one per discovery), so snap the axis
+							// pointer to the nearest event and drive the tooltip off the
+							// axis — hovering anywhere works, matching the other charts.
+							axisPointer: { snap: true },
+							formatter: (params: unknown) => {
+								const arr = params as Array<{
+									marker: string;
+									seriesName: string;
+									data: [number, number | null, string | null];
+								}>;
+								if (arr.length === 0) return "";
+								const turn = arr[0].data[0];
+								const rows = arr
+									.map((p) => {
+										const [, count, tech] = p.data;
+										const suffix = tech ? ` — ${techName(tech)}` : "";
+										return `${p.marker}${p.seriesName}: <b>${count}</b>${suffix}`;
+									})
+									.join("<br/>");
+								return `Turn ${turn}<br/>${rows}`;
+							},
+						}
+					: { trigger: "axis" },
 			// No axis-name titles — the title + tooltip carry the meaning,
 			// matching the Military Power plot. containLabel reserves room
 			// for the tick numbers now that the fixed left/bottom gutters
@@ -167,14 +237,24 @@
 				// is negative, so onZero would float the axis inside the plot).
 				axisLine: { onZero: false },
 			},
-			series: science.map((player, i) => {
+			series: perPlayer.map((player, i) => {
 				const rp = playerById.get(player.player_id);
 				const color = rp?.color ?? getNationChartColor(player.nation, i);
 				return {
 					name: rp?.label ?? formatEnum(player.nation, "NATION_"),
 					type: "line" as const,
-					data: player.data.map((d) => [d.turn, d.cumulative]),
+					data: player.points,
 					itemStyle: { color },
+					// Techs mode: milestone markers stay hidden until hover (per the
+					// shared look) but still name the discovered tech in the tooltip.
+					...(chartMode === "techs"
+						? {
+								symbol: (value: [number, number | null, string | null]) =>
+									value[2] ? "circle" : "none",
+								symbolSize: 8,
+								emphasis: { symbolSize: 12 },
+							}
+						: {}),
 					...filledLineStyle(color),
 				};
 			}),
@@ -182,7 +262,7 @@
 	});
 
 	// ─── Science annotation rail ──────────────────────────────────────
-	// An <EventRail> under the Cumulative Science chart of science-relevant
+	// An <EventRail> under the science chart (any view mode) of science-relevant
 	// events per player: key science techs the player researched AND
 	// demonstrably used (see science-techs.ts), free-tech turns, and one-off
 	// science gains. (The per-turn science rate lives on the Yields tab.)
@@ -717,18 +797,38 @@
 	});
 </script>
 
-{#if scienceChartOption}
+{#if chartOption}
 	<div
 		class="mb-4 rounded-lg p-4"
 		style="background-color: rgb(var(--color-surface));"
 	>
+		<!-- View switch for the plot: science totals, per-turn rate (small
+		     numbers, so late-game tech effects stay visible), or tech count. -->
+		<ToggleGroup.Root
+			type="single"
+			value={chartMode}
+			onValueChange={(v) => {
+				if (v) chartMode = v as TechsChartMode;
+			}}
+			class="mb-2 flex w-fit overflow-hidden rounded border border-surface"
+		>
+			<ToggleGroup.Item value="cumulative" class="rounded-l {toggleItemClass}">
+				Cumulative
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="rate" class={toggleItemClass}>
+				Per Turn
+			</ToggleGroup.Item>
+			<ToggleGroup.Item value="techs" class="rounded-r {toggleItemClass}">
+				Number of Techs
+			</ToggleGroup.Item>
+		</ToggleGroup.Root>
 		{#if scienceRailGroups.length > 0}
 			<!-- Matchup variant: the plot plus the science event rail below it —
 			     key-tech payoffs, free techs, one-off science gains — each marker
 			     at its true turn-x on the live chart (mil-tab pattern). -->
 			<div class="relative">
 				<Chart
-					option={scienceChartOption}
+					option={chartOption}
 					height="360px"
 					onReady={(c) => (railChart = c)}
 					onLayout={() => (railLayoutTick += 1)}
@@ -764,9 +864,9 @@
 			{/if}
 		{:else}
 			<ChartContainer
-				option={scienceChartOption}
+				option={chartOption}
 				height="400px"
-				title="Cumulative Science"
+				title={CHART_MODE_TITLES[chartMode]}
 			/>
 		{/if}
 		{#if owttLinks.length > 0}


### PR DESCRIPTION
The Techs tab's chart gains a view toggle — **Cumulative | Per Turn | Number of Techs** — defaulting to cumulative science.

Motivation for the toggle (community feedback on the first cut of this PR): cumulative totals get big after ~turn 60, so the effect of a single tech adoption disappears into the curve. Per Turn keeps the numbers small enough to see it; Number of Techs is the old chart, kept as a third view — including its per-point tooltip naming the tech discovered at each step.

| Mode | |
|---|---|
| Cumulative Science (default) | ![cumulative](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/techs-mode-cumulative.png) |
| Science per Turn | ![rate](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/techs-mode-rate.png) |
| Techs Discovered | ![techs](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/techs-mode-techs.png) |

- Default is cumulative because the science rail's markers are science events — key-tech payoffs, free techs, one-off gains — so they read against the science curve they actually affect (the rail's original pairing). The rail, "Bonus science" caption, and planner links render under all three views.
- Same compact Military-Power styling in every mode; the toggle reuses the Yields tab's `ToggleGroup` tokens. The per-turn science rate also lives on the Yields tab, but here it sits under the rail's annotations, which is the point.
- **Bug fix in `Chart.svelte` that the toggle exposed**: the option-change `$effect` called `onLayout?.()` *tracked*, so a parent whose inline handler bumps layout-tick state (the rail pattern) re-created the handler prop and re-ran the effect endlessly — `effect_update_depth_exceeded` on the first option change under a rail. The notify is now `untrack()`ed. The same latent loop was reachable on the Military tab (chart-filter change on a matchup with the rail).
- Two files (`TechsTab.svelte`, `Chart.svelte`); independent of #133 — whichever merges second gets a trivial rebase, which I'll handle.

`npm run lint` + `svelte-check` clean; all three modes + toggle cycling exercised on a local 1v1 (loop verified fixed — zero page errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
