### PR TITLE
feat(stats): starting-leader archetype and trait win rates

### DIFF
--- a/cloud/src/derive-player-summary.test.ts
+++ b/cloud/src/derive-player-summary.test.ts
@@ -130,5 +130,8 @@ describe("derivePlayerSummary — starting leader", () => {
 		const summary = derive(blob);
 		expect(summary.starting_ruler_archetype).toBe("TRAIT_SCHOLAR_ARCHETYPE");
 		expect(summary.succession_count).toBe(2);
+		// The successor's own trait, acquired on the turn they took the throne,
+		// must not land in the starting leader's list.
+		expect(summary.starting_ruler_traits).toBeNull();
 	});
 });

--- a/cloud/src/derive-player-summary.test.ts
+++ b/cloud/src/derive-player-summary.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+import type { FullGameData, PlayerRosterEntry } from "./schemas/game";
+import {
+	buildSummaryGameContext,
+	derivePlayerSummary,
+} from "./derive-player-summary";
+
+// A minimal blob carrying only what the starting-leader derivation reads.
+// The real FullGameData is far wider (the Valibot schema treats most entries as
+// unknown), so the fixture is cast the same way the module narrows its input.
+function blobWith(over: {
+	characters?: Array<Record<string, unknown>>;
+	character_traits?: Array<Record<string, unknown>>;
+}): FullGameData {
+	return {
+		match_metadata: { total_turns: 60 },
+		player_history: [],
+		city_statistics: { cities: [] },
+		families: [],
+		characters: [],
+		character_traits: [],
+		completed_techs: [],
+		law_adoption_history: [],
+		...over,
+	} as unknown as FullGameData;
+}
+
+// One leader for player 0, crowned on turn 1 (a starting leader is born
+// pre-game — birth_turn is negative — and takes the throne on the first turn).
+const LEADER = {
+	xml_id: 7,
+	player_xml_id: 0,
+	is_royal: true,
+	became_leader_turn: 1,
+	death_turn: null,
+	archetype: "TRAIT_SCHOLAR_ARCHETYPE",
+};
+
+const PLAYER = { player_index: 0 } as unknown as PlayerRosterEntry;
+
+function derive(blob: FullGameData) {
+	return derivePlayerSummary(blob, PLAYER, buildSummaryGameContext(blob));
+}
+
+describe("derivePlayerSummary — starting leader", () => {
+	it("captures the traits the leader starts with, stamped on turn 1", () => {
+		const blob = blobWith({
+			characters: [LEADER],
+			character_traits: [
+				{
+					character_xml_id: 7,
+					trait_name: "TRAIT_SCHOLAR_ARCHETYPE",
+					acquired_turn: 1,
+				},
+				{
+					character_xml_id: 7,
+					trait_name: "TRAIT_INTELLIGENT",
+					acquired_turn: 1,
+				},
+			],
+		});
+
+		const summary = derive(blob);
+
+		expect(summary.starting_ruler_archetype).toBe("TRAIT_SCHOLAR_ARCHETYPE");
+		// Both the archetype trait and the personality trait land here; splitting
+		// the two is the stats aggregator's job, not the derivation's.
+		expect(JSON.parse(summary.starting_ruler_traits ?? "[]")).toEqual([
+			"TRAIT_SCHOLAR_ARCHETYPE",
+			"TRAIT_INTELLIGENT",
+		]);
+	});
+
+	it("excludes traits acquired after the game began", () => {
+		const blob = blobWith({
+			characters: [LEADER],
+			character_traits: [
+				{
+					character_xml_id: 7,
+					trait_name: "TRAIT_INTELLIGENT",
+					acquired_turn: 1,
+				},
+				// Won through an event mid-game — not part of the starting roll.
+				{ character_xml_id: 7, trait_name: "TRAIT_WARLIKE", acquired_turn: 26 },
+			],
+		});
+
+		expect(JSON.parse(derive(blob).starting_ruler_traits ?? "[]")).toEqual([
+			"TRAIT_INTELLIGENT",
+		]);
+	});
+
+	it("ignores other players' leaders", () => {
+		const blob = blobWith({
+			characters: [
+				LEADER,
+				{
+					...LEADER,
+					xml_id: 9,
+					player_xml_id: 1,
+					archetype: "TRAIT_ZEALOT_ARCHETYPE",
+				},
+			],
+			character_traits: [
+				{ character_xml_id: 9, trait_name: "TRAIT_ROMANTIC", acquired_turn: 1 },
+			],
+		});
+
+		const summary = derive(blob);
+		expect(summary.starting_ruler_archetype).toBe("TRAIT_SCHOLAR_ARCHETYPE");
+		expect(summary.starting_ruler_traits).toBeNull();
+	});
+
+	it("takes the earliest crowned leader when a succession happened", () => {
+		const blob = blobWith({
+			characters: [
+				{
+					...LEADER,
+					xml_id: 11,
+					became_leader_turn: 34,
+					archetype: "TRAIT_HERO_ARCHETYPE",
+				},
+				LEADER,
+			],
+			character_traits: [
+				{ character_xml_id: 11, trait_name: "TRAIT_BOLD", acquired_turn: 34 },
+			],
+		});
+
+		const summary = derive(blob);
+		expect(summary.starting_ruler_archetype).toBe("TRAIT_SCHOLAR_ARCHETYPE");
+		expect(summary.succession_count).toBe(2);
+	});
+});

--- a/cloud/src/derive-player-summary.ts
+++ b/cloud/src/derive-player-summary.ts
@@ -168,7 +168,13 @@ export function derivePlayerSummary(
 		const traits = blob.character_traits as CharacterTraitRow[];
 		const startTraits: string[] = [];
 		for (const t of traits) {
-			if (t.character_xml_id === startingRuler.xml_id && t.acquired_turn <= 0) {
+			// The game stamps a starting leader's traits — their archetype plus
+			// the personality trait(s) they begin with — on turn 1, not turn 0:
+			// characters are born pre-game (birth_turn is negative) but no trait
+			// row exists before the first played turn. The original `<= 0` bound
+			// therefore matched nothing, leaving this column empty for every row.
+			// Traits acquired later (events, aging) have higher turns and stay out.
+			if (t.character_xml_id === startingRuler.xml_id && t.acquired_turn <= 1) {
 				startTraits.push(t.trait_name);
 			}
 		}

--- a/cloud/src/stats/aggregate.ts
+++ b/cloud/src/stats/aggregate.ts
@@ -46,6 +46,11 @@ export const CHUNK_SIZE = 50;
 // charts/helpers.ts — kept in sync by eye (no shared module across packages).
 const ALL_NATIONS = "__all__";
 
+// A character's archetype is itself a trait, flagged bArchetype in the game
+// data and suffixed _ARCHETYPE (TRAIT_SCHEMER_ARCHETYPE). It rides along in
+// starting_ruler_traits; the leader charts split the two apart.
+const ARCHETYPE_TRAIT = /_ARCHETYPE$/;
+
 // Succession laws (the inheritance rule, one class flagged bSuccession in the
 // game data) are a different kind of law from civic laws — they start at turn 1
 // and change mainly via forced events — so they're excluded from the law-adoption
@@ -64,6 +69,7 @@ interface BaseRow {
 	is_human: number;
 	is_uploader: number;
 	starting_ruler_archetype: string | null;
+	starting_ruler_traits: string | null; // JSON array of strings
 	final_points: number | null;
 	cities_total: number | null;
 	fifth_city_turn: number | null;
@@ -206,7 +212,7 @@ async function loadBaseRows(
 		const res = await env.SHARE_DB.prepare(
 			`SELECT ps.game_id, ps.player_index,
 			        ps.nation, ps.family_classes, ps.is_human, ps.is_uploader,
-			        ps.starting_ruler_archetype,
+			        ps.starting_ruler_archetype, ps.starting_ruler_traits,
 			        ps.final_points, ps.cities_total,
 			        ps.fifth_city_turn, ps.tenth_city_turn,
 			        ps.is_winner,
@@ -627,6 +633,54 @@ export async function buildChartBundle(
 			avg_points: s.totalPoints / s.pointsCount,
 		}));
 
+	// --- Starting leader: archetype + starting traits -----------------
+	// One row per focal player, keyed off the leader who first held the throne
+	// (player_summaries.starting_ruler_*). Old World rolls that leader's
+	// archetype and personality traits at game start rather than letting the
+	// player pick them, so these read as "how did this draw fare", not "what
+	// did players choose" — the same wins/games shape as nationWinRate, so the
+	// bar doubles as the distribution.
+	// The archetype trait itself is excluded from the trait tally: every leader
+	// has exactly one and it's already the other chart's whole dimension.
+	const archetypeStats = new Map<string, { games: number; wins: number }>();
+	const traitStats = new Map<string, { games: number; wins: number }>();
+	const bumpOutcome = (
+		stats: Map<string, { games: number; wins: number }>,
+		key: string,
+		won: boolean,
+	) => {
+		const s = stats.get(key) ?? { games: 0, wins: 0 };
+		s.games += 1;
+		if (won) s.wins += 1;
+		stats.set(key, s);
+	};
+	for (const r of selfRows) {
+		const won = r.is_winner === 1;
+		if (r.starting_ruler_archetype) {
+			bumpOutcome(archetypeStats, r.starting_ruler_archetype, won);
+		}
+		for (const t of parseJsonArray(r.starting_ruler_traits)) {
+			if (ARCHETYPE_TRAIT.test(t)) continue;
+			bumpOutcome(traitStats, t, won);
+		}
+	}
+	const startingArchetypeWinRate = [...archetypeStats.entries()].map(
+		([archetype, { games, wins }]) => ({
+			archetype,
+			games,
+			wins,
+			rate: games > 0 ? wins / games : 0,
+		}),
+	);
+	const startingTraitWinRate = [...traitStats.entries()].map(
+		([trait, { games, wins }]) => ({
+			trait,
+			games,
+			wins,
+			rate: games > 0 ? wins / games : 0,
+		}),
+	);
+
 	// --- Family classes ----------------------------------------------
 	// Each player picks 3 family classes from their nation's pool. We track,
 	// per (nation, class): how often it was picked and how many of those
@@ -843,6 +897,8 @@ export async function buildChartBundle(
 		nations,
 		nationWinRate,
 		nationAvgPoints,
+		startingArchetypeWinRate,
+		startingTraitWinRate,
 		familyByNation,
 		yieldCurves,
 		lawTiming,
@@ -916,6 +972,8 @@ function emptyCore(parserVersion: string): ChartBundleCore {
 		nations: [],
 		nationWinRate: [],
 		nationAvgPoints: [],
+		startingArchetypeWinRate: [],
+		startingTraitWinRate: [],
 		familyByNation: [],
 		yieldCurves: { turns: [], counts: [], series: {}, outcome: null },
 		lawTiming: [],

--- a/cloud/src/stats/cache.ts
+++ b/cloud/src/stats/cache.ts
@@ -21,8 +21,16 @@ import type { UserScope, UserStatsScope } from "./types";
 // Bumping this is equivalent to a global cache flush — every read
 // becomes a miss and recomputes. Use when the ChartBundle shape itself
 // changes in a backwards-incompatible way (e.g. dropping a field). For
-// data-only changes (a new chart, a new aggregation), no bump needed.
-export const BUNDLE_SCHEMA_VERSION = 5;
+// data-only changes (a chart drawn from fields the bundle already
+// carries), no bump needed.
+//
+// Adding a field counts: entries live for 24h, so without a bump a
+// frontend deployed behind the Worker would read a cached bundle that
+// predates the field and blow up on it (the bundle types declare every
+// field required, so consumers dereference them directly).
+//
+// 6: starting-leader archetype + trait win rates.
+export const BUNDLE_SCHEMA_VERSION = 6;
 
 export interface StatsCacheEnv extends SessionEnv {
 	// SESSIONS_KV is the existing KV binding; this module reuses it

--- a/cloud/src/stats/types.ts
+++ b/cloud/src/stats/types.ts
@@ -106,6 +106,30 @@ export interface ChartBundleCore {
 		avg_points: number;
 	}>;
 
+	// --- Leaders -----------------------------------------------------
+	// The focal players' starting leaders — the character who first held the
+	// throne — split into the two things the game rolls for them: their
+	// archetype (exactly one each) and the personality traits they begin with
+	// (zero or more, archetype excluded). `games` is the distribution, `wins`
+	// the outcome, so one wins/games bar answers both.
+	//
+	// Read per row, not in aggregate: over an all-humans corpus the overall
+	// rate is ~50% by construction (a 1v1 contributes one winner and one
+	// loser), so the signal is how far a given archetype/trait sits from that.
+	startingArchetypeWinRate: Array<{
+		archetype: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
+	startingTraitWinRate: Array<{
+		trait: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
 	// --- Families ----------------------------------------------------
 	// Per (nation, class): games where the player picked that class for
 	// that nation, and how many they won. The frontend derives pick rate

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -305,7 +305,7 @@ User-corpus aggregate stats bundle.
 - **Auth:** Public (owner extras) — owner (`self`) corpus includes private games; visitor/anon forced to public.
 - **Path:** `user_id` (21-char).
 - **Query:** `scope` (default `all`; `public`|`vs_ai`|`mp`|`tournament`|`<collection_id>`; collection and `public` narrowing are owner-only).
-- **Response 200:** `ChartBundle` — `ChartBundleCore` (meta, summary, nations, win rates, yield curves, law/tech timing…) plus user-only `win_rate` and `games_with_outcome`.
+- **Response 200:** `ChartBundle` — `ChartBundleCore` (meta, summary, nations, win rates, starting-leader archetype/trait win rates, yield curves, law/tech timing…) plus user-only `win_rate` and `games_with_outcome`.
 - **Errors:** `400 INVALID_USER_ID`, `404 NOT_FOUND`.
 - **Notes:** KV-cached, keyed on `{ user_id, viewerScope, scope, parser_version }`.
 

--- a/src/lib/game-detail/LeaderCard.svelte
+++ b/src/lib/game-detail/LeaderCard.svelte
@@ -7,7 +7,13 @@
 	import type { DetailPlayer, Reign } from "./helpers";
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import Popover from "$lib/ui/Popover.svelte";
-	import { formatEnum, toRomanNumeral } from "$lib/utils/formatting";
+	import {
+		archetypeSpriteKey,
+		formatArchetype,
+		formatEnum,
+		isArchetypeTrait,
+		toRomanNumeral,
+	} from "$lib/utils/formatting";
 	import { getCivilizationColor } from "$lib/config";
 	import { GOAL_NAMES } from "$lib/generated/goal-names";
 
@@ -45,14 +51,11 @@
 		c.cognomen ? formatEnum(c.cognomen, "COGNOMEN_") : null;
 
 	const archetypeLabel = (c: CharacterInfo): string | null =>
-		c.archetype
-			? formatEnum(c.archetype.replace(/_ARCHETYPE$/, ""), "TRAIT_")
-			: null;
+		c.archetype ? formatArchetype(c.archetype) : null;
 
-	// Archetype icon key for the `traits` sprite category: the save's
-	// TRAIT_<X>_ARCHETYPE trait maps to the icon file TRAIT_<X> (suffix dropped).
+	// Archetype icon key for the `traits` sprite category.
 	const archetypeIcon = (c: CharacterInfo): string | null =>
-		c.archetype ? c.archetype.replace(/_ARCHETYPE$/, "") : null;
+		c.archetype ? archetypeSpriteKey(c.archetype) : null;
 
 	const deathLabel = (reason: string | null): string | null =>
 		reason
@@ -90,7 +93,7 @@
 
 	// Traits excluding the archetype marker (shown separately as the archetype).
 	const detailTraits = $derived(
-		reign.traits.filter((t) => !t.trait_name.endsWith("_ARCHETYPE")),
+		reign.traits.filter((t) => !isArchetypeTrait(t.trait_name)),
 	);
 </script>
 

--- a/src/lib/game-detail/MilitaryTab.svelte
+++ b/src/lib/game-detail/MilitaryTab.svelte
@@ -7,7 +7,11 @@
 	import type { ChartOption, ECharts } from "$lib/echarts";
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import Chart from "$lib/Chart.svelte";
-	import { formatEnum } from "$lib/utils/formatting";
+	import {
+		archetypeSpriteKey,
+		formatArchetype,
+		formatEnum,
+	} from "$lib/utils/formatting";
 	import { CHART_THEME, getNationChartColor } from "$lib/config";
 	import { LAW_TO_CLASS } from "$lib/generated/law-classes";
 	import { TECH_BONUS_UNITS, UNIT_STATS } from "$lib/generated/unit-stats";
@@ -244,9 +248,7 @@
 	): string {
 		const name = c.first_name ? formatEnum(c.first_name, "NAME_") : "New ruler";
 		const cog = c.cognomen ? ` ‘${formatEnum(c.cognomen, "COGNOMEN_")}’` : "";
-		const arch = c.archetype
-			? formatEnum(c.archetype.replace(/_ARCHETYPE$/, ""), "TRAIT_")
-			: null;
+		const arch = c.archetype ? formatArchetype(c.archetype) : null;
 		const ratings = [
 			ratingChip("Wis", "RATING_WISDOM", c.wisdom),
 			ratingChip("Cha", "RATING_CHARISMA", c.charisma),
@@ -392,9 +394,7 @@
 					(a, b) => (a.became_leader_turn ?? 0) - (b.became_leader_turn ?? 0),
 				)) {
 				const turn = c.became_leader_turn as number;
-				const archKey = c.archetype
-					? c.archetype.replace(/_ARCHETYPE$/, "")
-					: null;
+				const archKey = c.archetype ? archetypeSpriteKey(c.archetype) : null;
 				events.push({
 					kind: "leader",
 					turn,

--- a/src/lib/stats/StatsView.svelte
+++ b/src/lib/stats/StatsView.svelte
@@ -20,6 +20,10 @@
 		nationAvgPointsOption,
 		nationWinLossStackedOption,
 	} from "./charts/nations";
+	import {
+		startingArchetypeWinLossOption,
+		startingTraitWinLossOption,
+	} from "./charts/leaders";
 	import { expansionWinRateOption } from "./charts/cities";
 	import type { ChartBundle, StatsCategory } from "./types";
 
@@ -65,6 +69,10 @@
 				return nationWinLossStackedOption(bundle);
 			case "nation-avg-points":
 				return nationAvgPointsOption(bundle);
+			case "starting-archetype-winloss":
+				return startingArchetypeWinLossOption(bundle);
+			case "starting-trait-winloss":
+				return startingTraitWinLossOption(bundle);
 			case "city-expansion-winrate":
 				return expansionWinRateOption(bundle);
 			default:

--- a/src/lib/stats/charts/helpers.ts
+++ b/src/lib/stats/charts/helpers.ts
@@ -1,17 +1,21 @@
 // Shared helpers for the stats chart option builders. Reuses the
 // existing chart-theme constants from $lib/config.
 
+import type { ChartOption } from "$lib/echarts";
 import { CHART_THEME } from "$lib/config";
 import { formatEnum } from "$lib/utils/formatting";
 
 // Strip leaderless enum prefix for axis labels. The stats SQL returns
-// raw values (NATION_PERSIA, ARCHETYPE_BUILDER, etc.); the chart axes
+// raw values (NATION_PERSIA, TRAIT_SCHEMER_ARCHETYPE, etc.); the chart axes
 // need humanized text.
 export function fmtNation(value: string): string {
 	return formatEnum(value, "NATION_");
 }
+// A character's archetype is stored as the archetype *trait* it maps to
+// (TRAIT_SCHEMER_ARCHETYPE) — the game flags those traits bArchetype. Drop the
+// suffix for display, matching the game-detail leader cards.
 export function fmtArchetype(value: string): string {
-	return formatEnum(value, "ARCHETYPE_");
+	return formatEnum(value.replace(/_ARCHETYPE$/, ""), "TRAIT_");
 }
 export function fmtTrait(value: string): string {
 	return formatEnum(value, "TRAIT_");
@@ -98,6 +102,80 @@ export function crestAxisLabel(
 		formatter: (value: string) =>
 			crestUrl(value) ? `{${key(value)}|} ${name(value)}` : name(value),
 		rich,
+	};
+}
+
+// One category's outcome tally for a win/loss bar.
+export interface WinLossRow {
+	key: string;
+	games: number;
+	wins: number;
+}
+
+// Horizontal stacked wins/losses bar: bar length = games played, the split
+// shows the rate. Sorted by games ascending so the busiest category sits at
+// the top (ECharts stacks a category axis bottom-up). One builder behind every
+// outcome bar in the catalog — nations, leader archetypes, starting traits —
+// so they stay identical by construction rather than by copy.
+export function winLossStackedOption(opts: {
+	rows: WinLossRow[];
+	// Display name for a row key (fmtNation, fmtArchetype, …).
+	label: (value: string) => string;
+	// Sprite for a row key, when the category has icon art (nation crests,
+	// archetype glyphs). Omit for text-only labels.
+	iconUrl?: (value: string) => string | undefined;
+	// Room reserved for the axis labels; widen for long names.
+	labelWidth?: number;
+}): ChartOption {
+	const { rows, label, iconUrl, labelWidth = 140 } = opts;
+	const sorted = [...rows].sort((a, b) => a.games - b.games);
+	const keys = sorted.map((r) => r.key);
+	return {
+		...CHART_THEME,
+		tooltip: {
+			...CHART_THEME.tooltip,
+			axisPointer: { type: "shadow" },
+			formatter: (params: unknown) => {
+				const p = (params as { dataIndex: number }[])[0];
+				const row = sorted[p.dataIndex];
+				if (!row) return "";
+				return `${label(row.key)}<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round((row.wins / row.games) * 100)}%`;
+			},
+		},
+		grid: { ...COMMON_GRID, left: labelWidth },
+		xAxis: { type: "value" },
+		yAxis: {
+			type: "category",
+			data: keys,
+			// Larger icon + name (white from the theme) for the headline charts;
+			// an icon-less category renders the name alone at the same inset, so
+			// both variants align to the grid edge identically.
+			axisLabel: iconUrl
+				? crestAxisLabel(keys, iconUrl, label, labelWidth - 8, 20, 14)
+				: {
+						interval: 0,
+						align: "left" as const,
+						margin: labelWidth - 8,
+						fontSize: 14,
+						formatter: label,
+					},
+		},
+		series: [
+			{
+				name: "Wins",
+				type: "bar",
+				stack: "outcome",
+				data: sorted.map((r) => r.wins),
+				itemStyle: { color: WIN_COLOR },
+			},
+			{
+				name: "Losses",
+				type: "bar",
+				stack: "outcome",
+				data: sorted.map((r) => r.games - r.wins),
+				itemStyle: { color: LOSS_COLOR },
+			},
+		],
 	};
 }
 

--- a/src/lib/stats/charts/helpers.ts
+++ b/src/lib/stats/charts/helpers.ts
@@ -6,7 +6,7 @@ import { CHART_THEME } from "$lib/config";
 import { formatEnum } from "$lib/utils/formatting";
 
 // Strip leaderless enum prefix for axis labels. The stats SQL returns
-// raw values (NATION_PERSIA, TRAIT_SCHEMER_ARCHETYPE, etc.); the chart axes
+// raw values (NATION_PERSIA, TRAIT_INTELLIGENT, etc.); the chart axes
 // need humanized text.
 export function fmtNation(value: string): string {
 	return formatEnum(value, "NATION_");
@@ -51,17 +51,8 @@ export const COMMON_GRID = { left: 60, right: 30, top: 40, bottom: 60 };
 // icon-bearing axis labels (crests, avatars) have breathing room, plus
 // padding for the grid margins. Shared by the registry specs and the
 // tournament stats charts so the same chart sizes identically everywhere.
-//
-// A spec that sets a subtitle needs the extra room StatsView's `titled()`
-// reserves for it (grid.top 64 → 92), or its bars render tighter than the
-// same chart without one.
-const SUBTITLE_HEIGHT = 28;
-export function barChartHeight(
-	rowCount: number,
-	opts?: { subtitle?: boolean },
-): string {
-	const extra = opts?.subtitle ? SUBTITLE_HEIGHT : 0;
-	return `${Math.max(rowCount, 1) * 34 + 90 + extra}px`;
+export function barChartHeight(rowCount: number): string {
+	return `${Math.max(rowCount, 1) * 34 + 90}px`;
 }
 
 // Axis-title placement, mirroring the game-detail charts: the title sits
@@ -126,7 +117,7 @@ export interface WinLossRow {
 // so they stay identical by construction rather than by copy.
 export function winLossStackedOption(opts: {
 	rows: WinLossRow[];
-	// Display name for a row key (fmtNation, fmtArchetype, …).
+	// Display name for a row key (fmtNation, fmtTrait, …).
 	label: (value: string) => string;
 	// Sprite for a row key, when the category has icon art (nation crests,
 	// archetype glyphs). Omit for text-only labels.

--- a/src/lib/stats/charts/helpers.ts
+++ b/src/lib/stats/charts/helpers.ts
@@ -11,12 +11,6 @@ import { formatEnum } from "$lib/utils/formatting";
 export function fmtNation(value: string): string {
 	return formatEnum(value, "NATION_");
 }
-// A character's archetype is stored as the archetype *trait* it maps to
-// (TRAIT_SCHEMER_ARCHETYPE) — the game flags those traits bArchetype. Drop the
-// suffix for display, matching the game-detail leader cards.
-export function fmtArchetype(value: string): string {
-	return formatEnum(value.replace(/_ARCHETYPE$/, ""), "TRAIT_");
-}
 export function fmtTrait(value: string): string {
 	return formatEnum(value, "TRAIT_");
 }
@@ -57,8 +51,17 @@ export const COMMON_GRID = { left: 60, right: 30, top: 40, bottom: 60 };
 // icon-bearing axis labels (crests, avatars) have breathing room, plus
 // padding for the grid margins. Shared by the registry specs and the
 // tournament stats charts so the same chart sizes identically everywhere.
-export function barChartHeight(rowCount: number): string {
-	return `${Math.max(rowCount, 1) * 34 + 90}px`;
+//
+// A spec that sets a subtitle needs the extra room StatsView's `titled()`
+// reserves for it (grid.top 64 → 92), or its bars render tighter than the
+// same chart without one.
+const SUBTITLE_HEIGHT = 28;
+export function barChartHeight(
+	rowCount: number,
+	opts?: { subtitle?: boolean },
+): string {
+	const extra = opts?.subtitle ? SUBTITLE_HEIGHT : 0;
+	return `${Math.max(rowCount, 1) * 34 + 90 + extra}px`;
 }
 
 // Axis-title placement, mirroring the game-detail charts: the title sits
@@ -105,11 +108,15 @@ export function crestAxisLabel(
 	};
 }
 
-// One category's outcome tally for a win/loss bar.
+// One category's outcome tally for a win/loss bar. `rate` is the server's
+// own wins/games — passed through rather than recomputed here, so the value
+// the tooltip shows is the one the aggregator guarded against a zero
+// denominator.
 export interface WinLossRow {
 	key: string;
 	games: number;
 	wins: number;
+	rate: number;
 }
 
 // Horizontal stacked wins/losses bar: bar length = games played, the split
@@ -139,7 +146,7 @@ export function winLossStackedOption(opts: {
 				const p = (params as { dataIndex: number }[])[0];
 				const row = sorted[p.dataIndex];
 				if (!row) return "";
-				return `${label(row.key)}<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round((row.wins / row.games) * 100)}%`;
+				return `${label(row.key)}<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round(row.rate * 100)}%`;
 			},
 		},
 		grid: { ...COMMON_GRID, left: labelWidth },

--- a/src/lib/stats/charts/leaders.ts
+++ b/src/lib/stats/charts/leaders.ts
@@ -1,0 +1,63 @@
+// Leaders tab option builders — how a starting leader's roll fared.
+//
+// Old World rolls each player's starting leader: one archetype and the
+// personality traits they begin with. Both bars are the shared wins/losses
+// stack, so bar length reads as the distribution ("how often did this come
+// up") and the split as the outcome ("how often did it win").
+
+import type { ChartOption } from "$lib/echarts";
+import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
+import type { ChartBundleCore } from "../types";
+import { fmtArchetype, fmtTrait, winLossStackedOption } from "./helpers";
+
+// Archetype glyphs ship under the archetype trait's name with the _ARCHETYPE
+// suffix dropped (TRAIT_SCHEMER_ARCHETYPE → traits/TRAIT_SCHEMER), the same
+// mapping the game-detail leader cards use.
+function archetypeIconUrl(archetype: string): string | undefined {
+	return SPRITE_MANIFEST[`traits/${archetype.replace(/_ARCHETYPE$/, "")}`];
+}
+
+// The ten archetypes are a fixed, small set, so every one that appears fits on
+// one chart. Typed against ChartBundleCore — it renders identically for a user
+// library and a tournament corpus.
+export function startingArchetypeWinLossOption(
+	bundle: ChartBundleCore,
+): ChartOption {
+	return winLossStackedOption({
+		rows: bundle.startingArchetypeWinRate.map((r) => ({
+			key: r.archetype,
+			games: r.games,
+			wins: r.wins,
+		})),
+		label: fmtArchetype,
+		iconUrl: archetypeIconUrl,
+	});
+}
+
+// Starting traits have a long tail (~40 across a large corpus, most of them
+// one-offs), so the chart keeps the traits with the most games behind them —
+// the same cap the tech and law charts use to stay readable. No sprite ships
+// for personality traits, so these are name-only rows.
+const MAX_TRAIT_ROWS = 15;
+
+export function startingTraitWinLossOption(
+	bundle: ChartBundleCore,
+): ChartOption {
+	const rows = [...bundle.startingTraitWinRate]
+		.sort((a, b) => b.games - a.games)
+		.slice(0, MAX_TRAIT_ROWS)
+		.map((r) => ({ key: r.trait, games: r.games, wins: r.wins }));
+	return winLossStackedOption({
+		rows,
+		label: fmtTrait,
+		// Trait names run longer than nation names ("Compassionate"), so the
+		// labels get more room than the shared default.
+		labelWidth: 160,
+	});
+}
+
+// Rows the trait chart actually draws — the registry sizes the container off
+// the same cap, so the chart never scrolls past its box.
+export function visibleTraitRowCount(bundle: ChartBundleCore): number {
+	return Math.min(bundle.startingTraitWinRate.length, MAX_TRAIT_ROWS);
+}

--- a/src/lib/stats/charts/leaders.ts
+++ b/src/lib/stats/charts/leaders.ts
@@ -7,14 +7,25 @@
 
 import type { ChartOption } from "$lib/echarts";
 import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
+import { archetypeSpriteKey, formatArchetype } from "$lib/utils/formatting";
 import type { ChartBundleCore } from "../types";
-import { fmtArchetype, fmtTrait, winLossStackedOption } from "./helpers";
+import { fmtTrait, winLossStackedOption } from "./helpers";
 
-// Archetype glyphs ship under the archetype trait's name with the _ARCHETYPE
-// suffix dropped (TRAIT_SCHEMER_ARCHETYPE → traits/TRAIT_SCHEMER), the same
-// mapping the game-detail leader cards use.
+// Both leader charts share an empty state: they're empty for the same reason,
+// and the copy is referenced from the registry specs and the tournament page
+// rather than retyped at each.
+export const LEADER_EMPTY_MESSAGE =
+	"No leader data in these saves yet — they were parsed before characters were captured.";
+
 function archetypeIconUrl(archetype: string): string | undefined {
-	return SPRITE_MANIFEST[`traits/${archetype.replace(/_ARCHETYPE$/, "")}`];
+	return SPRITE_MANIFEST[`traits/${archetypeSpriteKey(archetype)}`];
+}
+
+// Art ships for the archetypes and a couple of the plain traits (Strength,
+// Weakness); crestAxisLabel falls back to a name-only label per value, so a
+// resolver that misses most traits still lights up the ones that have one.
+function traitIconUrl(trait: string): string | undefined {
+	return SPRITE_MANIFEST[`traits/${trait}`];
 }
 
 // The ten archetypes are a fixed, small set, so every one that appears fits on
@@ -28,16 +39,16 @@ export function startingArchetypeWinLossOption(
 			key: r.archetype,
 			games: r.games,
 			wins: r.wins,
+			rate: r.rate,
 		})),
-		label: fmtArchetype,
+		label: formatArchetype,
 		iconUrl: archetypeIconUrl,
 	});
 }
 
 // Starting traits have a long tail (~40 across a large corpus, most of them
 // one-offs), so the chart keeps the traits with the most games behind them —
-// the same cap the tech and law charts use to stay readable. No sprite ships
-// for personality traits, so these are name-only rows.
+// the same cap the tech and law charts use to stay readable.
 const MAX_TRAIT_ROWS = 15;
 
 export function startingTraitWinLossOption(
@@ -46,10 +57,16 @@ export function startingTraitWinLossOption(
 	const rows = [...bundle.startingTraitWinRate]
 		.sort((a, b) => b.games - a.games)
 		.slice(0, MAX_TRAIT_ROWS)
-		.map((r) => ({ key: r.trait, games: r.games, wins: r.wins }));
+		.map((r) => ({
+			key: r.trait,
+			games: r.games,
+			wins: r.wins,
+			rate: r.rate,
+		}));
 	return winLossStackedOption({
 		rows,
 		label: fmtTrait,
+		iconUrl: traitIconUrl,
 		// Trait names run longer than nation names ("Compassionate"), so the
 		// labels get more room than the shared default.
 		labelWidth: 160,

--- a/src/lib/stats/charts/leaders.ts
+++ b/src/lib/stats/charts/leaders.ts
@@ -21,13 +21,6 @@ function archetypeIconUrl(archetype: string): string | undefined {
 	return SPRITE_MANIFEST[`traits/${archetypeSpriteKey(archetype)}`];
 }
 
-// Art ships for the archetypes and a couple of the plain traits (Strength,
-// Weakness); crestAxisLabel falls back to a name-only label per value, so a
-// resolver that misses most traits still lights up the ones that have one.
-function traitIconUrl(trait: string): string | undefined {
-	return SPRITE_MANIFEST[`traits/${trait}`];
-}
-
 // The ten archetypes are a fixed, small set, so every one that appears fits on
 // one chart. Typed against ChartBundleCore — it renders identically for a user
 // library and a tournament corpus.
@@ -66,7 +59,18 @@ export function startingTraitWinLossOption(
 	return winLossStackedOption({
 		rows,
 		label: fmtTrait,
-		iconUrl: traitIconUrl,
+		// No icon resolver — these are name-only rows. `trait.xml` is the
+		// authority through zIconName, and only 28 of its 306 records declare
+		// art: the ten bArchetype archetypes (each pointing at the bare id,
+		// which is what archetypeSpriteKey reproduces), seventeen
+		// TRAIT_CLERGY_* pointing into the `religions` sprite category, and
+		// TRAIT_PRESET_ARCHETYPE. The sprite manifest is not the authority
+		// here — its `traits` category is baked from the art folder, so it also
+		// carries HUD icons that aren't trait records at all (TRAIT_STRENGTH,
+		// TRAIT_WEAKNESS: a trait's classification is bStrength/bWeakness on
+		// the record) plus one DLC connection trait. None of those is a trait a
+		// leader can start with, so a `traits/<trait>` lookup can only miss.
+		//
 		// Trait names run longer than nation names ("Compassionate"), so the
 		// labels get more room than the shared default.
 		labelWidth: 160,

--- a/src/lib/stats/charts/nations.ts
+++ b/src/lib/stats/charts/nations.ts
@@ -6,69 +6,32 @@ import type { ChartBundle, ChartBundleCore } from "../types";
 import {
 	CHART_THEME,
 	COMMON_GRID,
-	LOSS_COLOR,
 	WIN_COLOR,
 	crestAxisLabel,
 	fmtNation,
+	winLossStackedOption,
 } from "./helpers";
 
 function nationCrestUrl(nation: string): string | undefined {
 	return SPRITE_MANIFEST[`crests/CREST_${nation}`];
 }
 
-// Win rate by nation — stacked wins/losses bar (horizontal): bar length =
-// games played, the wins/losses split shows the rate. Sorted by games
-// played, most at top. Typed against ChartBundleCore (only reads nationWinRate)
-// so it renders unchanged at tournament scope, where the bundle has no Overview.
+// Win rate by nation — the shared stacked wins/losses bar: bar length = games
+// played, the split shows the rate. Typed against ChartBundleCore (only reads
+// nationWinRate) so it renders unchanged at tournament scope, where the bundle
+// has no Overview.
 export function nationWinLossStackedOption(
 	bundle: ChartBundleCore,
 ): ChartOption {
-	const rows = [...bundle.nationWinRate].sort((a, b) => a.games - b.games);
-	const nations = rows.map((r) => r.nation);
-	return {
-		...CHART_THEME,
-		tooltip: {
-			...CHART_THEME.tooltip,
-			axisPointer: { type: "shadow" },
-			formatter: (params: unknown) => {
-				const p = (params as { dataIndex: number }[])[0];
-				const row = rows[p.dataIndex];
-				if (!row) return "";
-				return `${fmtNation(row.nation)}<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round(row.rate * 100)}%`;
-			},
-		},
-		grid: { ...COMMON_GRID, left: 140 },
-		xAxis: { type: "value" },
-		yAxis: {
-			type: "category",
-			data: nations,
-			// Larger crest + name (white from the theme) for the headline charts.
-			axisLabel: crestAxisLabel(
-				nations,
-				nationCrestUrl,
-				fmtNation,
-				132,
-				20,
-				14,
-			),
-		},
-		series: [
-			{
-				name: "Wins",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.wins),
-				itemStyle: { color: WIN_COLOR },
-			},
-			{
-				name: "Losses",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.games - r.wins),
-				itemStyle: { color: LOSS_COLOR },
-			},
-		],
-	};
+	return winLossStackedOption({
+		rows: bundle.nationWinRate.map((r) => ({
+			key: r.nation,
+			games: r.games,
+			wins: r.wins,
+		})),
+		label: fmtNation,
+		iconUrl: nationCrestUrl,
+	});
 }
 
 // Average final points by nation — horizontal bar sorted by points, best

--- a/src/lib/stats/charts/nations.ts
+++ b/src/lib/stats/charts/nations.ts
@@ -28,6 +28,7 @@ export function nationWinLossStackedOption(
 			key: r.nation,
 			games: r.games,
 			wins: r.wins,
+			rate: r.rate,
 		})),
 		label: fmtNation,
 		iconUrl: nationCrestUrl,

--- a/src/lib/stats/charts/registry.ts
+++ b/src/lib/stats/charts/registry.ts
@@ -41,20 +41,17 @@ export const CHART_SPECS: ChartSpec[] = [
 		id: "starting-archetype-winloss",
 		category: "leaders",
 		title: "Starting archetype",
-		subtitle: "Games played, split by outcome",
 		hasData: (b) => b.startingArchetypeWinRate.length > 0,
 		emptyMessage: () => LEADER_EMPTY_MESSAGE,
-		height: (b) =>
-			barChartHeight(b.startingArchetypeWinRate.length, { subtitle: true }),
+		height: (b) => barChartHeight(b.startingArchetypeWinRate.length),
 	},
 	{
 		id: "starting-trait-winloss",
 		category: "leaders",
 		title: "Starting leader traits",
-		subtitle: "Top 15 by games played, split by outcome",
 		hasData: (b) => b.startingTraitWinRate.length > 0,
 		emptyMessage: () => LEADER_EMPTY_MESSAGE,
-		height: (b) => barChartHeight(visibleTraitRowCount(b), { subtitle: true }),
+		height: (b) => barChartHeight(visibleTraitRowCount(b)),
 	},
 	// Families — category anchor only; rendered by FamilyStatsPanel
 	// (per-nation pick/win bars), not the generic spec loop.

--- a/src/lib/stats/charts/registry.ts
+++ b/src/lib/stats/charts/registry.ts
@@ -51,7 +51,7 @@ export const CHART_SPECS: ChartSpec[] = [
 		id: "starting-trait-winloss",
 		category: "leaders",
 		title: "Starting leader traits",
-		subtitle: "Games played, split by outcome",
+		subtitle: "Top 15 by games played, split by outcome",
 		hasData: (b) => b.startingTraitWinRate.length > 0,
 		emptyMessage: () => LEADER_EMPTY_MESSAGE,
 		height: (b) => barChartHeight(visibleTraitRowCount(b), { subtitle: true }),

--- a/src/lib/stats/charts/registry.ts
+++ b/src/lib/stats/charts/registry.ts
@@ -6,10 +6,12 @@
 
 import type { ChartSpec, StatsCategory } from "../types";
 import { barChartHeight } from "./helpers";
+import { visibleTraitRowCount } from "./leaders";
 
 export const CATEGORIES: Array<{ id: StatsCategory; label: string }> = [
 	{ id: "yields", label: "Yields" },
 	{ id: "nations", label: "Nations" },
+	{ id: "leaders", label: "Leaders" },
 	{ id: "families", label: "Families" },
 	{ id: "laws", label: "Laws" },
 	{ id: "cities", label: "Cities" },
@@ -31,6 +33,29 @@ export const CHART_SPECS: ChartSpec[] = [
 		title: "Average final points",
 		hasData: (b) => b.nationAvgPoints.length > 0,
 		height: (b) => barChartHeight(b.nationAvgPoints.length),
+	},
+	// Leaders — the starting leader's roll: their archetype, and the traits
+	// they began the game with. Both bars carry games (length) and wins
+	// (split), so each answers distribution and outcome at once.
+	{
+		id: "starting-archetype-winloss",
+		category: "leaders",
+		title: "Starting archetype",
+		subtitle: "Games played, split by outcome",
+		hasData: (b) => b.startingArchetypeWinRate.length > 0,
+		emptyMessage: () =>
+			"No leader data yet — saves parsed before characters were captured don't carry one.",
+		height: (b) => barChartHeight(b.startingArchetypeWinRate.length),
+	},
+	{
+		id: "starting-trait-winloss",
+		category: "leaders",
+		title: "Starting leader traits",
+		subtitle: "Games played, split by outcome",
+		hasData: (b) => b.startingTraitWinRate.length > 0,
+		emptyMessage: () =>
+			"No leader data yet — saves parsed before characters were captured don't carry one.",
+		height: (b) => barChartHeight(visibleTraitRowCount(b)),
 	},
 	// Families — category anchor only; rendered by FamilyStatsPanel
 	// (per-nation pick/win bars), not the generic spec loop.

--- a/src/lib/stats/charts/registry.ts
+++ b/src/lib/stats/charts/registry.ts
@@ -6,7 +6,7 @@
 
 import type { ChartSpec, StatsCategory } from "../types";
 import { barChartHeight } from "./helpers";
-import { visibleTraitRowCount } from "./leaders";
+import { LEADER_EMPTY_MESSAGE, visibleTraitRowCount } from "./leaders";
 
 export const CATEGORIES: Array<{ id: StatsCategory; label: string }> = [
 	{ id: "yields", label: "Yields" },
@@ -43,9 +43,9 @@ export const CHART_SPECS: ChartSpec[] = [
 		title: "Starting archetype",
 		subtitle: "Games played, split by outcome",
 		hasData: (b) => b.startingArchetypeWinRate.length > 0,
-		emptyMessage: () =>
-			"No leader data yet — saves parsed before characters were captured don't carry one.",
-		height: (b) => barChartHeight(b.startingArchetypeWinRate.length),
+		emptyMessage: () => LEADER_EMPTY_MESSAGE,
+		height: (b) =>
+			barChartHeight(b.startingArchetypeWinRate.length, { subtitle: true }),
 	},
 	{
 		id: "starting-trait-winloss",
@@ -53,9 +53,8 @@ export const CHART_SPECS: ChartSpec[] = [
 		title: "Starting leader traits",
 		subtitle: "Games played, split by outcome",
 		hasData: (b) => b.startingTraitWinRate.length > 0,
-		emptyMessage: () =>
-			"No leader data yet — saves parsed before characters were captured don't carry one.",
-		height: (b) => barChartHeight(visibleTraitRowCount(b)),
+		emptyMessage: () => LEADER_EMPTY_MESSAGE,
+		height: (b) => barChartHeight(visibleTraitRowCount(b), { subtitle: true }),
 	},
 	// Families — category anchor only; rendered by FamilyStatsPanel
 	// (per-nation pick/win bars), not the generic spec loop.

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -71,6 +71,25 @@ export interface ChartBundleCore {
 		avg_points: number;
 	}>;
 
+	// The focal players' starting leaders, split into what the game rolls for
+	// them: the archetype (one each) and the personality traits they begin with
+	// (archetype excluded). `games` is the distribution, `wins` the outcome.
+	// Over an all-humans corpus the overall rate is ~50% by construction, so
+	// the signal is the deviation per archetype/trait.
+	startingArchetypeWinRate: Array<{
+		archetype: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
+	startingTraitWinRate: Array<{
+		trait: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
 	familyByNation: Array<{
 		nation: string;
 		class: string;
@@ -138,6 +157,7 @@ export type UserScope =
 
 export type StatsCategory =
 	| "nations"
+	| "leaders"
 	| "families"
 	| "yields"
 	| "laws"

--- a/src/lib/utils/formatting.ts
+++ b/src/lib/utils/formatting.ts
@@ -454,3 +454,39 @@ export function formatRelativeToNow(iso: string | null | undefined): string {
 		return rtf.format(Math.round(diffMs / (30 * DAY)), "month");
 	return rtf.format(Math.round(diffMs / (365 * DAY)), "year");
 }
+
+// ─── Character archetypes ────────────────────────────────────────────
+//
+// Old World models a character's archetype as a trait flagged bArchetype,
+// stored under the trait's own id with an _ARCHETYPE suffix
+// (TRAIT_SCHEMER_ARCHETYPE). Three things follow from that shape, and all
+// three had grown their own copy of the suffix rule: the display name drops
+// the suffix, the sprite ships under the bare trait id, and a character's
+// trait list has to exclude the archetype so it isn't shown twice.
+//
+// Lives here rather than beside its callers because both the game-detail view
+// (which the frozen web/ viewer symlinks) and the stats charts need it, and
+// this module is already on both sides of that boundary.
+//
+// The Worker keeps its own copy of the suffix rule (cloud/src/stats/
+// aggregate.ts) — cloud/ is a separate package with no shared module.
+
+const ARCHETYPE_SUFFIX = /_ARCHETYPE$/;
+
+/** True for the archetype trait itself, e.g. TRAIT_SCHEMER_ARCHETYPE. */
+export function isArchetypeTrait(traitName: string): boolean {
+	return ARCHETYPE_SUFFIX.test(traitName);
+}
+
+/** Display name for an archetype: TRAIT_SCHEMER_ARCHETYPE → "Schemer". */
+export function formatArchetype(archetype: string): string {
+	return formatEnum(archetype.replace(ARCHETYPE_SUFFIX, ""), "TRAIT_");
+}
+
+/**
+ * Sprite name for an archetype's glyph: TRAIT_SCHEMER_ARCHETYPE →
+ * TRAIT_SCHEMER, which is how the art ships in the `traits` category.
+ */
+export function archetypeSpriteKey(archetype: string): string {
+	return archetype.replace(ARCHETYPE_SUFFIX, "");
+}

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-	// Tournament stats page. Three tabs — Players (standings), Nations (nation
-	// win rate), Casters (caster leaderboard) — spanning both stats subsystems:
-	// Plane A tournament-native (standings + casters) and Plane B1 (the
-	// ChartBundle pointed at the tournament's games). Renders the charts directly
-	// (no chart registry) through the shared ChartContainer, reusing the chart
-	// theme/grid; the tab bar mirrors the user-stats chip tabs.
+	// Tournament stats page. Five tabs — Players (standings + nation picks),
+	// Nations (nation win rate), Leaders (starting archetype and traits), Yields
+	// (per-turn curves) and Casters (caster leaderboard) — spanning both stats
+	// subsystems: Plane A tournament-native (standings + casters) and Plane B1
+	// (the ChartBundle pointed at the tournament's games). Renders the charts
+	// directly (no chart registry) through the shared ChartContainer, reusing the
+	// chart theme/grid; the tab bar mirrors the user-stats chip tabs.
 	import { Tabs } from "bits-ui";
 	import { goto } from "$app/navigation";
 	import { page } from "$app/state";

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -11,6 +11,11 @@
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import YieldsStatsPanel from "$lib/stats/YieldsStatsPanel.svelte";
 	import { barChartHeight } from "$lib/stats/charts/helpers";
+	import {
+		startingArchetypeWinLossOption,
+		startingTraitWinLossOption,
+		visibleTraitRowCount,
+	} from "$lib/stats/charts/leaders";
 	import { nationWinLossStackedOption } from "$lib/stats/charts/nations";
 	import {
 		AVATAR_LABEL_SIZE,
@@ -37,6 +42,8 @@
 	const casters = $derived(data.competition.caster_leaderboard);
 	const playerPicks = $derived(data.competition.player_picks);
 	const nationWinRate = $derived(data.games.nationWinRate);
+	const startingArchetypes = $derived(data.games.startingArchetypeWinRate);
+	const startingTraits = $derived(data.games.startingTraitWinRate);
 
 	// Circular avatar images for the players/casters axis labels, rasterized
 	// client-side from the Discord CDN (ECharts rich-text labels can't round
@@ -75,7 +82,7 @@
 	// The active tab lives in ?category (controlled: value derived from the
 	// URL, change → goto), mirroring the user-stats subtabs (StatsView) so a
 	// tab is deep-linkable and survives refresh.
-	const TABS = ["players", "nations", "yields", "casters"] as const;
+	const TABS = ["players", "nations", "leaders", "yields", "casters"] as const;
 	type StatsTab = (typeof TABS)[number];
 	const tab = $derived.by<StatsTab>(() => {
 		const fromUrl = page.url.searchParams.get("category");
@@ -106,6 +113,7 @@
 		>
 			<Tabs.Trigger value="players" class={triggerClass}>Players</Tabs.Trigger>
 			<Tabs.Trigger value="nations" class={triggerClass}>Nations</Tabs.Trigger>
+			<Tabs.Trigger value="leaders" class={triggerClass}>Leaders</Tabs.Trigger>
 			<Tabs.Trigger value="yields" class={triggerClass}>Yields</Tabs.Trigger>
 			<Tabs.Trigger value="casters" class={triggerClass}>Casters</Tabs.Trigger>
 		</Tabs.List>
@@ -156,6 +164,45 @@
 				{:else}
 					<p class="p-8 text-center italic text-tan opacity-60">
 						No completed games yet.
+					</p>
+				{/if}
+			</section>
+		</Tabs.Content>
+
+		<!-- Leaders — the starting leader each player was dealt (Plane B1):
+		     archetype and the traits they began with, each as games played
+		     split by outcome. -->
+		<Tabs.Content value="leaders">
+			<section class="mb-8">
+				<h2 class="mb-3 text-base font-bold text-tan">Starting archetype</h2>
+				{#if startingArchetypes.length > 0}
+					<ChartContainer
+						option={startingArchetypeWinLossOption(data.games)}
+						height={barChartHeight(startingArchetypes.length)}
+						title="Starting archetype"
+					/>
+				{:else}
+					<p class="p-8 text-center italic text-tan opacity-60">
+						No leader data yet — saves parsed before characters were captured
+						don't carry one.
+					</p>
+				{/if}
+			</section>
+
+			<section class="mb-8">
+				<h2 class="mb-3 text-base font-bold text-tan">
+					Starting leader traits
+				</h2>
+				{#if startingTraits.length > 0}
+					<ChartContainer
+						option={startingTraitWinLossOption(data.games)}
+						height={barChartHeight(visibleTraitRowCount(data.games))}
+						title="Starting leader traits"
+					/>
+				{:else}
+					<p class="p-8 text-center italic text-tan opacity-60">
+						No leader data yet — saves parsed before characters were captured
+						don't carry one.
 					</p>
 				{/if}
 			</section>

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -12,6 +12,7 @@
 	import YieldsStatsPanel from "$lib/stats/YieldsStatsPanel.svelte";
 	import { barChartHeight } from "$lib/stats/charts/helpers";
 	import {
+		LEADER_EMPTY_MESSAGE,
 		startingArchetypeWinLossOption,
 		startingTraitWinLossOption,
 		visibleTraitRowCount,
@@ -183,8 +184,7 @@
 					/>
 				{:else}
 					<p class="p-8 text-center italic text-tan opacity-60">
-						No leader data yet — saves parsed before characters were captured
-						don't carry one.
+						{LEADER_EMPTY_MESSAGE}
 					</p>
 				{/if}
 			</section>
@@ -201,8 +201,7 @@
 					/>
 				{:else}
 					<p class="p-8 text-center italic text-tan opacity-60">
-						No leader data yet — saves parsed before characters were captured
-						don't carry one.
+						{LEADER_EMPTY_MESSAGE}
 					</p>
 				{/if}
 			</section>


### PR DESCRIPTION
Adds a **Leaders** category to the stats catalog — a Leaders tab on the tournament stats page, and a Leaders subtab in the user-corpus catalog — answering "which starting leader did you get, and how did it go".

![tournament](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/stats-leaders-tournament.png)

Two charts, both the wins/losses stack the nation chart already uses, so **bar length is the distribution and the split is the win rate** — one bar answers both questions:

- **Starting archetype** — all ten, on the game's own archetype glyphs.
- **Starting leader traits** — the personality traits the leader began with, capped at 15 rows like the tech/law charts (there's a long tail of one-offs). No sprite ships for these, so they're name-only rows.

Over an all-humans corpus the overall rate is ~50% by construction (a 1v1 contributes one winner and one loser), so the signal is a row's deviation from that — noted in the bundle types so a future reader doesn't misread the aggregate.

## Why archetype and not the leader's name

Old World rolls the starting leader per game: across 405 cached public games the names are generated (`NAME_BELTUM_RIMENNI`, `NAME_HITTITE_MALE10`), 90 distinct name+archetype combos appear in 150 games with most showing up once, and the same name turns up under different archetypes. Charting the identity would be a list of one-offs; the archetype (10 values, `bArchetype` in `trait.xml`) is the axis with signal.

## Fixes a latent derivation bug (the reason the trait chart has data at all)

`derivePlayerSummary` collected starting traits with `acquired_turn <= 0`. The game stamps a starting leader's traits on **turn 1** — characters are born pre-game (negative `birth_turn`), but no trait row exists before the first played turn — so the filter matched nothing and `player_summaries.starting_ruler_traits` has been NULL for **every row ever written** (verified: 0 of 1041 rows in a local corpus, and empty in a production dump). Bounded at turn 1 it captures the archetype trait plus the personality trait(s) the leader starts with, and still excludes traits won later through events. Four unit tests pin the boundary, the other-player scoping, and the succession case.

**Backfill:** existing rows repopulate through the admin reindex sweep (`POST /v1/admin/games/:id/reindex` → `buildSummaryStatements`), which rebuilds `player_summaries` from the stored blob — no migration, nothing new to run. Caveat: saves parsed before the parser captured `characters` carry no leader data in the blob at all, so those need an owner-side reparse; the charts show `n` in the tooltip and an empty state that says so.

## Shape

- **No schema change.** Archetype is already a `player_summaries` column; the traits ride the existing JSON array and are split apart by the `_ARCHETYPE` suffix (the game's own `bArchetype` flag), so the archetype isn't double-counted in the trait tally.
- Two bundle fields (`startingArchetypeWinRate`, `startingTraitWinRate`) shaped exactly like `nationWinRate`, mirrored into the frontend types.
- One registry entry per chart → StatsView renders them through the existing spec loop; the tournament stats page (which renders charts directly, no registry) gets the matching tab.
- **Extracted** the wins/losses stacked bar out of `nations.ts` into `winLossStackedOption` in `charts/helpers.ts`, so all three outcome bars are one builder rather than three copies. `nationWinLossStackedOption` keeps its name and signature; the option it produces is unchanged.
- The `_ARCHETYPE` suffix rule now lives in one place — `formatArchetype`, `archetypeSpriteKey` and `isArchetypeTrait` in `$lib/utils/formatting`, called from the leader charts, `LeaderCard` and `MilitaryTab`. That replaces the stats-local `fmtArchetype` (dead and wrong: it stripped an `ARCHETYPE_` prefix; the values are `TRAIT_X_ARCHETYPE`) along with the copies of the same rule at the game-detail call sites. The Worker keeps its own regex — `cloud/` is a separate package with no shared module.
- Bumped `BUNDLE_SCHEMA_VERSION` 5→6: entries live 24h, and the frontend dereferences the new fields directly, so a bundle cached before the deploy would break it. Amended the constant's comment with that reasoning.

## Testing

- 4 new unit tests (`cloud/src/derive-player-summary.test.ts`); `npm run lint`, `svelte-check`, and the worker suite pass.
- Exercised end-to-end locally: 68 public games imported into local dev (fresh uploads derive traits on 136 of 140 rows), 24 linked to a fixture tournament — both surfaces in the screenshots are that corpus.

Unrelated heads-up, still open from #137: `cloud/src/tournament/canonical-map-options.test.ts` fails 4 tests on `main` (b39f690 re-baked `map-option-defs.ts` without the matching cloud-mirror entry for `MAP_OPTIONS_MULTI_DOTA_INNER_TERRAIN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

