### PR TITLE
feat(stats): capital family, family city footprint, and families on the tournament page

### DIFF
--- a/cloud/migrations/0037_capital_family_class.sql
+++ b/cloud/migrations/0037_capital_family_class.sql
@@ -1,0 +1,18 @@
+-- The family class that holds the player's capital.
+--
+-- A player's three families are already recorded (player_summaries
+-- .family_classes), but which of them runs the capital is a distinct and
+-- earlier decision: the capital is the city every early bonus compounds
+-- through, so its family's class shapes the opening in a way "we had Traders
+-- somewhere" does not.
+--
+-- Derived from the blob's city_statistics: the player's is_capital city, read
+-- through owner_player_xml_id so a mirror match can't credit one side with the
+-- other's capital. NULL when the player ended with no capital (eliminated, or
+-- a pre-2.6.0 blob whose cities carry no family class). Backfilled for
+-- existing rows by the admin reindex sweep, which rebuilds player_summaries
+-- from the stored blob.
+ALTER TABLE player_summaries ADD COLUMN capital_family_class TEXT;
+
+CREATE INDEX idx_summaries_capital_family
+    ON player_summaries(capital_family_class);

--- a/cloud/migrations/0037_capital_family_class.sql
+++ b/cloud/migrations/0037_capital_family_class.sql
@@ -12,7 +12,8 @@
 -- a pre-2.6.0 blob whose cities carry no family class). Backfilled for
 -- existing rows by the admin reindex sweep, which rebuilds player_summaries
 -- from the stored blob.
+--
+-- Deliberately unindexed: the stats layer selects player_summaries by game_id
+-- and buckets by this column in JS (loadBaseRows / buildChartBundle), so an
+-- index on it would be write cost on every upload and reindex for no read.
 ALTER TABLE player_summaries ADD COLUMN capital_family_class TEXT;
-
-CREATE INDEX idx_summaries_capital_family
-    ON player_summaries(capital_family_class);

--- a/cloud/migrations/0038_player_family_cities.sql
+++ b/cloud/migrations/0038_player_family_cities.sql
@@ -1,0 +1,29 @@
+-- Per-player, per-family-class city footprint.
+--
+-- player_summaries.family_classes already records *which* three classes a
+-- player ran, but not how much of the empire each ended up holding, or how
+-- early it arrived. Those are the two questions that separate a family you
+-- leaned on from one you merely had: a class holding half your cities from
+-- turn 20 played a different game than one that showed up with a single late
+-- conquest.
+--
+-- One row per (game, player, family class) — at most three per player, so this
+-- stays small. Derived from the blob's city_statistics at index time, keyed on
+-- owner_player_xml_id so a mirror match can't credit one side with the other's
+-- cities. `cities` counts the player's end-of-game holdings of that class (the
+-- save is an end-state snapshot, so a razed or lost city isn't in it), and
+-- `first_founded_turn` is the earliest founding among them, which the stats
+-- layer turns into "how much of the game it was present for".
+--
+-- Backfilled for existing games by the admin reindex sweep, which rebuilds the
+-- derived tables from the stored blob.
+CREATE TABLE player_family_cities (
+    game_id TEXT NOT NULL REFERENCES games(game_id) ON DELETE CASCADE,
+    player_index INTEGER NOT NULL,
+    family_class TEXT NOT NULL,
+    cities INTEGER NOT NULL,
+    first_founded_turn INTEGER,
+    PRIMARY KEY (game_id, player_index, family_class)
+);
+
+CREATE INDEX idx_family_cities_class ON player_family_cities(family_class);

--- a/cloud/migrations/0038_player_family_cities.sql
+++ b/cloud/migrations/0038_player_family_cities.sql
@@ -17,6 +17,11 @@
 --
 -- Backfilled for existing games by the admin reindex sweep, which rebuilds the
 -- derived tables from the stored blob.
+--
+-- No secondary index: the only reader (loadFamilyCities in
+-- stats/aggregate.ts) selects by game_id, which the primary key's leading
+-- column already serves. One on family_class would cost every upload and
+-- reindex a write for a lookup nothing performs.
 CREATE TABLE player_family_cities (
     game_id TEXT NOT NULL REFERENCES games(game_id) ON DELETE CASCADE,
     player_index INTEGER NOT NULL,
@@ -25,5 +30,3 @@ CREATE TABLE player_family_cities (
     first_founded_turn INTEGER,
     PRIMARY KEY (game_id, player_index, family_class)
 );
-
-CREATE INDEX idx_family_cities_class ON player_family_cities(family_class);

--- a/cloud/src/CLAUDE.md
+++ b/cloud/src/CLAUDE.md
@@ -32,6 +32,10 @@ Run from `cloud/`: `npm test` (both projects), or filter with `--project unit` /
 
 When you bump `PARSER_VERSION` in `src/lib/parser/types.ts`, also add the new string to `KNOWN_PARSER_VERSIONS` in `cloud/src/schemas/game.ts` with a one-line changelog entry above the set. The Worker rejects unknown versions with `INVALID_BLOB: Unknown parser_version`, so a frontend that ships ahead of the Worker breaks all uploads. **Deploy ordering: Worker first, frontend second.**
 
+## Bumping `BUNDLE_SCHEMA_VERSION`
+
+The stats bundle's cache-flush lever (`cloud/src/stats/cache.ts`). **Don't edit the constant** — it's derived as the highest key of the `BUNDLE_SCHEMA_CHANGELOG` table right above it, so you bump it by adding an entry saying what changed. Bump whenever the `ChartBundle` gains or loses a field: entries live 24h and consumers dereference every field directly, so a frontend deployed behind the Worker would read a pre-field bundle and blow up on it. A chart drawn from fields the bundle already carries needs no bump. The value is deliberately **not** restated in `docs/aggregate-statistics.md` — it sat four versions stale there across four stats PRs, so don't reintroduce it.
+
 ## Events retention
 
 A nightly cron (03:47 UTC, `[triggers]` in `cloud/wrangler.toml`) prunes the `events` table per the policy in `cloud/src/retention.ts`: 24h for rate-limit counters, 90d for general audit, never for tournament audit. Two rules when touching events:

--- a/cloud/src/derive-player-summary.test.ts
+++ b/cloud/src/derive-player-summary.test.ts
@@ -26,7 +26,10 @@ function blobWith(over: {
 	} as unknown as FullGameData;
 }
 
-const PLAYER = { player_index: 0 } as unknown as PlayerRosterEntry;
+const PLAYER = {
+	player_index: 0,
+	nation: "NATION_ROME",
+} as unknown as PlayerRosterEntry;
 
 function derive(blob: FullGameData) {
 	return derivePlayerSummary(blob, PLAYER, buildSummaryGameContext(blob));
@@ -139,7 +142,13 @@ describe("derivePlayerSummary — starting leader", () => {
 
 // A city at the given culture level, owned by player 0 unless stated. `held`
 // defaults to the sole owner — pass it to describe a city that changed hands.
-function city(culture: string | null, owner = 0, held = [owner]) {
+// `family` is the class running it; `capital()` wraps the capital case.
+function city(
+	culture: string | null,
+	owner = 0,
+	held = [owner],
+	family: string | null = "FAMILYCLASS_TRADERS",
+) {
 	return {
 		city_id: 1,
 		owner_nation: "NATION_ROME",
@@ -148,7 +157,15 @@ function city(culture: string | null, owner = 0, held = [owner]) {
 		player_families: held.map((player_xml_id) => ({ player_xml_id })),
 		founded_turn: 3,
 		culture_level: culture,
+		is_capital: false,
+		family_class: family,
 	};
+}
+
+// The capital — the one city the capital-family derivation keys on. Culture is
+// irrelevant to those assertions, so it rides at null.
+function capital(owner = 0, family: string | null = "FAMILYCLASS_TRADERS") {
+	return { ...city(null, owner, [owner], family), is_capital: true };
 }
 
 // best_culture_level is what makes a wonder's eligibility answerable: a wonder
@@ -221,5 +238,38 @@ describe("derivePlayerSummary — best culture level", () => {
 			derive(blobWith({ city_statistics: { cities: [legacy] } }))
 				.best_culture_level,
 		).toBe("CULTURE_STRONG");
+	});
+});
+
+describe("derivePlayerSummary — capital family class", () => {
+	it("reads the family class off the player's capital", () => {
+		const summary = derive(
+			blobWith({
+				city_statistics: {
+					cities: [
+						city(null, 0, [0], "FAMILYCLASS_SAGES"),
+						capital(0, "FAMILYCLASS_LANDOWNERS"),
+					],
+				},
+			}),
+		);
+		expect(summary.capital_family_class).toBe("FAMILYCLASS_LANDOWNERS");
+	});
+
+	it("ignores another player's capital", () => {
+		const summary = derive(
+			blobWith({
+				city_statistics: { cities: [capital(1, "FAMILYCLASS_CLERICS")] },
+			}),
+		);
+		expect(summary.capital_family_class).toBeNull();
+	});
+
+	it("is null when the player has no capital, or it carries no family", () => {
+		expect(derive(blobWith({})).capital_family_class).toBeNull();
+		expect(
+			derive(blobWith({ city_statistics: { cities: [capital(0, null)] } }))
+				.capital_family_class,
+		).toBeNull();
 	});
 });

--- a/cloud/src/derive-player-summary.ts
+++ b/cloud/src/derive-player-summary.ts
@@ -44,6 +44,8 @@ interface CityRow {
 	player_families?: Array<{ player_xml_id: number }>;
 	founded_turn: number;
 	culture_level: string | null;
+	is_capital: boolean;
+	family_class: string | null;
 }
 
 interface FamilyRow {
@@ -112,6 +114,7 @@ export function buildSummaryGameContext(
 
 export interface DerivedSummary {
 	family_classes: string | null; // JSON array
+	capital_family_class: string | null;
 	starting_ruler_archetype: string | null;
 	starting_ruler_traits: string | null; // JSON array
 	starting_ruler_reign_turns: number | null;
@@ -235,6 +238,11 @@ export function derivePlayerSummary(
 	// passed over. Resolving it exactly needs per-turn city culture, which the
 	// blob doesn't carry (derive/city-statistics.ts reads one level per city).
 	let best_culture_level: string | null = null;
+	// The family running the capital — the city every early bonus compounds
+	// through, so a distinct decision from which three families the player has.
+	// Keyed on owner_player_xml_id rather than nation so a mirror match doesn't
+	// credit one side with the other's capital.
+	let capital_family_class: string | null = null;
 	for (const c of cities) {
 		if (player.nation !== null && c.owner_nation === player.nation) {
 			cities_total += 1;
@@ -252,6 +260,9 @@ export function derivePlayerSummary(
 			cultureRank(c.culture_level) > cultureRank(best_culture_level)
 		) {
 			best_culture_level = c.culture_level;
+		}
+		if (c.is_capital && c.owner_player_xml_id === idx && c.family_class) {
+			capital_family_class = c.family_class;
 		}
 	}
 	founderTurns.sort((a, b) => a - b);
@@ -302,6 +313,7 @@ export function derivePlayerSummary(
 
 	return {
 		family_classes,
+		capital_family_class,
 		starting_ruler_archetype,
 		starting_ruler_traits,
 		starting_ruler_reign_turns,

--- a/cloud/src/derive-player-summary.ts
+++ b/cloud/src/derive-player-summary.ts
@@ -261,7 +261,15 @@ export function derivePlayerSummary(
 		) {
 			best_culture_level = c.culture_level;
 		}
-		if (c.is_capital && c.owner_player_xml_id === idx && c.family_class) {
+		// First match wins. A player holds one capital, so the guard should never
+		// fire — but the blob is an unordered list, and without it a second
+		// is_capital row would silently make attribution depend on array order.
+		if (
+			capital_family_class === null &&
+			c.is_capital &&
+			c.owner_player_xml_id === idx &&
+			c.family_class
+		) {
 			capital_family_class = c.family_class;
 		}
 	}

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -101,14 +101,18 @@ export function isScraperUA(ua: string | null): boolean {
 // D1 caps bound parameters at 100 per query (much tighter than standalone
 // SQLite's 999). Multi-row INSERTs chunked so N_rows × N_cols ≤ 99 to
 // leave headroom, all bundled into one db.batch() call so an upload/reindex
-// remains a single transaction. GPT_COLS MUST equal the length of the
-// `columns` array in buildGamePlayerTurnStatements — if they drift, chunks
-// overshoot the param cap and every insert fails with "too many SQL
-// variables".
+// remains a single transaction. Each *_COLS below MUST equal the length of the
+// `columns` array its builder binds — if they drift, chunks overshoot the param
+// cap and every insert fails with "too many SQL variables", which fails the
+// whole batch and so the whole upload.
 const D1_MAX_PARAMS = 99;
 const GPT_COLS = 34; // 3 keys + 14 yields × 2 + military_power + legitimacy + points
 const GPT_ROWS_PER_INSERT = Math.floor(D1_MAX_PARAMS / GPT_COLS); // 2
 const TECH_LAW_ROWS_PER_INSERT = Math.floor(D1_MAX_PARAMS / 4); // 24
+const FAMILY_CITY_COLS = 5; // game_id, player_index, family_class, cities, first_founded_turn
+const FAMILY_CITY_ROWS_PER_INSERT = Math.floor(
+	D1_MAX_PARAMS / FAMILY_CITY_COLS,
+); // 19
 
 // ---------- Rate limit checks (D1 events table) ----------
 
@@ -640,6 +644,12 @@ function buildGamePlayerTurnStatements(
 // one side with the other's; a city with no family (unassigned or pre-2.6.0
 // blob) simply doesn't contribute.
 //
+// Human seats only. The stats layer reads these rows through a
+// `ps.is_human = 1` join (loadFamilyCities in stats/aggregate.ts), so an AI's
+// families are rows nothing can ever read — and with up to three per seat, the
+// AI seats of an ordinary vs-AI save are also what would carry the insert past
+// D1's parameter cap.
+//
 // `first_founded_turn` deliberately counts only cities this player founded
 // (first_owner_player_xml_id). A captured city keeps the turn its *original*
 // owner founded it, so counting captures would date a family to a turn the
@@ -663,6 +673,12 @@ function buildFamilyCityStatements(
 	const cities = cityStats?.cities;
 	if (!Array.isArray(cities) || cities.length === 0) return [];
 
+	const humanIndexes = new Set(
+		(blob.player_roster as PlayerRosterEntry[])
+			.filter((p) => p.is_human)
+			.map((p) => p.player_index),
+	);
+
 	// key = `${player_index}|${family_class}`
 	const tally = new Map<
 		string,
@@ -675,6 +691,7 @@ function buildFamilyCityStatements(
 	>();
 	for (const c of cities) {
 		if (c.owner_player_xml_id == null || !c.family_class) continue;
+		if (!humanIndexes.has(c.owner_player_xml_id)) continue;
 		const key = `${c.owner_player_xml_id}|${c.family_class}`;
 		const e = tally.get(key) ?? {
 			player: c.owner_player_xml_id,
@@ -702,7 +719,10 @@ function buildFamilyCityStatements(
 		"first_founded_turn",
 	];
 	const statements: D1PreparedStatement[] = [];
-	for (const chunk of chunked([...tally.values()], TECH_LAW_ROWS_PER_INSERT)) {
+	for (const chunk of chunked(
+		[...tally.values()],
+		FAMILY_CITY_ROWS_PER_INSERT,
+	)) {
 		const sql = buildMultiRowInsert(
 			"player_family_cities",
 			columns,

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -634,6 +634,74 @@ function buildGamePlayerTurnStatements(
 	return statements;
 }
 
+// Per-(player, family class) city footprint: how many of the player's
+// end-of-game cities that class holds, and when its first one was founded.
+// Cities are keyed on owner_player_xml_id so a mirror match doesn't credit one
+// side with the other's; a city with no family (unassigned or pre-2.6.0 blob)
+// simply doesn't contribute.
+function buildFamilyCityStatements(
+	db: D1Database,
+	gameId: string,
+	blob: FullGameData,
+): D1PreparedStatement[] {
+	const cityStats = blob.city_statistics as {
+		cities?: Array<{
+			owner_player_xml_id: number | null;
+			family_class: string | null;
+			founded_turn: number | null;
+		}>;
+	};
+	const cities = cityStats?.cities;
+	if (!Array.isArray(cities) || cities.length === 0) return [];
+
+	// key = `${player_index}|${family_class}`
+	const tally = new Map<
+		string,
+		{ player: number; familyClass: string; cities: number; firstTurn: number | null }
+	>();
+	for (const c of cities) {
+		if (c.owner_player_xml_id == null || !c.family_class) continue;
+		const key = `${c.owner_player_xml_id}|${c.family_class}`;
+		const e = tally.get(key) ?? {
+			player: c.owner_player_xml_id,
+			familyClass: c.family_class,
+			cities: 0,
+			firstTurn: null,
+		};
+		e.cities += 1;
+		if (
+			c.founded_turn != null &&
+			(e.firstTurn === null || c.founded_turn < e.firstTurn)
+		) {
+			e.firstTurn = c.founded_turn;
+		}
+		tally.set(key, e);
+	}
+	if (tally.size === 0) return [];
+
+	const columns = [
+		"game_id",
+		"player_index",
+		"family_class",
+		"cities",
+		"first_founded_turn",
+	];
+	const statements: D1PreparedStatement[] = [];
+	for (const chunk of chunked([...tally.values()], TECH_LAW_ROWS_PER_INSERT)) {
+		const sql = buildMultiRowInsert(
+			"player_family_cities",
+			columns,
+			chunk.length,
+		);
+		const bindings: unknown[] = [];
+		for (const e of chunk) {
+			bindings.push(gameId, e.player, e.familyClass, e.cities, e.firstTurn);
+		}
+		statements.push(db.prepare(sql).bind(...bindings));
+	}
+	return statements;
+}
+
 function buildTechEventStatements(
 	db: D1Database,
 	gameId: string,
@@ -1657,6 +1725,7 @@ export async function handleGameUpload(
 		winnerIndex,
 	});
 	const gptStmts = buildGamePlayerTurnStatements(env.SHARE_DB, gameId, blob);
+	const familyCityStmts = buildFamilyCityStatements(env.SHARE_DB, gameId, blob);
 	const techStmts = buildTechEventStatements(env.SHARE_DB, gameId, blob);
 	const lawStmts = buildLawEventStatements(env.SHARE_DB, gameId, blob);
 	const wonderStmts = [
@@ -1668,6 +1737,7 @@ export async function handleGameUpload(
 		env.SHARE_DB.prepare(gameRow.sql).bind(...gameRow.bindings),
 		...summaryStmts,
 		...gptStmts,
+		...familyCityStmts,
 		...techStmts,
 		...lawStmts,
 		...wonderStmts,
@@ -3067,6 +3137,9 @@ export async function handleAdminReindex(
 		env.SHARE_DB.prepare("DELETE FROM game_wonder_pool WHERE game_id = ?").bind(
 			gameId,
 		),
+		env.SHARE_DB.prepare(
+			"DELETE FROM player_family_cities WHERE game_id = ?",
+		).bind(gameId),
 		...buildSummaryStatements(env.SHARE_DB, {
 			gameId,
 			blob,
@@ -3074,6 +3147,7 @@ export async function handleAdminReindex(
 			winnerIndex,
 		}),
 		...buildGamePlayerTurnStatements(env.SHARE_DB, gameId, blob),
+		...buildFamilyCityStatements(env.SHARE_DB, gameId, blob),
 		...buildTechEventStatements(env.SHARE_DB, gameId, blob),
 		...buildLawEventStatements(env.SHARE_DB, gameId, blob),
 		...buildWonderEventStatements(env.SHARE_DB, gameId, blob),

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -635,10 +635,18 @@ function buildGamePlayerTurnStatements(
 }
 
 // Per-(player, family class) city footprint: how many of the player's
-// end-of-game cities that class holds, and when its first one was founded.
-// Cities are keyed on owner_player_xml_id so a mirror match doesn't credit one
-// side with the other's; a city with no family (unassigned or pre-2.6.0 blob)
-// simply doesn't contribute.
+// end-of-game cities that class holds, and when the player founded their first
+// one. Cities are keyed on owner_player_xml_id so a mirror match doesn't credit
+// one side with the other's; a city with no family (unassigned or pre-2.6.0
+// blob) simply doesn't contribute.
+//
+// `first_founded_turn` deliberately counts only cities this player founded
+// (first_owner_player_xml_id). A captured city keeps the turn its *original*
+// owner founded it, so counting captures would date a family to a turn the
+// player had nothing to do with — measured at 0.8% of rows, and enough to flip
+// the founding order for 1.4% of players. A family that only ever arrived by
+// conquest therefore has no founding turn, which is the honest answer for a
+// stat about founding order.
 function buildFamilyCityStatements(
 	db: D1Database,
 	gameId: string,
@@ -647,6 +655,7 @@ function buildFamilyCityStatements(
 	const cityStats = blob.city_statistics as {
 		cities?: Array<{
 			owner_player_xml_id: number | null;
+			first_owner_player_xml_id: number | null;
 			family_class: string | null;
 			founded_turn: number | null;
 		}>;
@@ -657,7 +666,12 @@ function buildFamilyCityStatements(
 	// key = `${player_index}|${family_class}`
 	const tally = new Map<
 		string,
-		{ player: number; familyClass: string; cities: number; firstTurn: number | null }
+		{
+			player: number;
+			familyClass: string;
+			cities: number;
+			firstTurn: number | null;
+		}
 	>();
 	for (const c of cities) {
 		if (c.owner_player_xml_id == null || !c.family_class) continue;
@@ -670,6 +684,7 @@ function buildFamilyCityStatements(
 		};
 		e.cities += 1;
 		if (
+			c.first_owner_player_xml_id === c.owner_player_xml_id &&
 			c.founded_turn != null &&
 			(e.firstTurn === null || c.founded_turn < e.firstTurn)
 		) {

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -456,6 +456,7 @@ function buildSummaryStatements(
 	const stmt = db.prepare(
 		`INSERT INTO player_summaries (
 			game_id, player_index, player_name, nation, family_classes,
+			capital_family_class,
 			is_human, is_uploader,
 			starting_ruler_archetype, starting_ruler_traits,
 			starting_ruler_reign_turns, succession_count,
@@ -464,7 +465,7 @@ function buildSummaryStatements(
 			techs_completed, laws_count,
 			fifth_city_turn, tenth_city_turn, fourth_law_turn, seventh_law_turn,
 			is_winner, vp_margin
-		) VALUES (?,?,?,?,?, ?,?, ?,?,?,?, ?,?,?,?,?,?, ?,?, ?,?,?,?, ?,?)`,
+		) VALUES (?,?,?,?,?, ?, ?,?, ?,?,?,?, ?,?,?,?,?,?, ?,?, ?,?,?,?, ?,?)`,
 	);
 
 	return roster.map((p) => {
@@ -475,6 +476,7 @@ function buildSummaryStatements(
 			p.player_name,
 			p.nation,
 			s.family_classes,
+			s.capital_family_class,
 			p.is_human ? 1 : 0,
 			uploaderIndex !== null && p.player_index === uploaderIndex ? 1 : 0,
 			s.starting_ruler_archetype,

--- a/cloud/src/stats/aggregate.ts
+++ b/cloud/src/stats/aggregate.ts
@@ -67,6 +67,7 @@ interface BaseRow {
 	player_index: number;
 	nation: string | null;
 	family_classes: string | null; // JSON array of strings
+	capital_family_class: string | null;
 	is_human: number;
 	is_uploader: number;
 	starting_ruler_archetype: string | null;
@@ -224,7 +225,8 @@ async function loadBaseRows(
 	for (const ids of chunk(gameIds, CHUNK_SIZE)) {
 		const res = await env.SHARE_DB.prepare(
 			`SELECT ps.game_id, ps.player_index,
-			        ps.nation, ps.family_classes, ps.is_human, ps.is_uploader,
+			        ps.nation, ps.family_classes, ps.capital_family_class,
+			        ps.is_human, ps.is_uploader,
 			        ps.starting_ruler_archetype, ps.starting_ruler_traits,
 			        ps.best_culture_level,
 			        ps.final_points, ps.cities_total,
@@ -863,6 +865,29 @@ export async function buildChartBundle(
 		};
 	});
 
+	// --- Capital family ----------------------------------------------
+	// Which family class runs the focal player's capital, and how those games
+	// went. Distinct from familyByNation below, which asks whether a class was
+	// among the player's three at all: the capital is where the early bonuses
+	// compound, so its class is the sharper read. Same wins/games shape as
+	// nationWinRate, so one bar carries both the distribution and the rate.
+	const capitalStats = new Map<string, { games: number; wins: number }>();
+	for (const r of selfRows) {
+		if (!r.capital_family_class) continue;
+		const s = capitalStats.get(r.capital_family_class) ?? { games: 0, wins: 0 };
+		s.games += 1;
+		if (r.is_winner === 1) s.wins += 1;
+		capitalStats.set(r.capital_family_class, s);
+	}
+	const capitalFamilyWinRate = [...capitalStats.entries()].map(
+		([family_class, { games, wins }]) => ({
+			family_class,
+			games,
+			wins,
+			rate: games > 0 ? wins / games : 0,
+		}),
+	);
+
 	// --- Family classes ----------------------------------------------
 	// Each player picks 3 family classes from their nation's pool. We track,
 	// per (nation, class): how often it was picked and how many of those
@@ -1082,6 +1107,7 @@ export async function buildChartBundle(
 		startingArchetypeWinRate,
 		startingTraitWinRate,
 		wonderStats,
+		capitalFamilyWinRate,
 		familyByNation,
 		yieldCurves,
 		lawTiming,
@@ -1158,6 +1184,7 @@ function emptyCore(parserVersion: string): ChartBundleCore {
 		startingArchetypeWinRate: [],
 		startingTraitWinRate: [],
 		wonderStats: [],
+		capitalFamilyWinRate: [],
 		familyByNation: [],
 		yieldCurves: { turns: [], counts: [], series: {}, outcome: null },
 		lawTiming: [],

--- a/cloud/src/stats/aggregate.ts
+++ b/cloud/src/stats/aggregate.ts
@@ -477,6 +477,38 @@ async function loadWonderPool(
 	return out;
 }
 
+interface FamilyCityRow {
+	game_id: string;
+	player_index: number;
+	family_class: string;
+	cities: number;
+	first_founded_turn: number | null;
+}
+
+// Per-(game, player, family class) city footprint — at most three rows per
+// player, so this is a small join even over a large corpus.
+async function loadFamilyCities(
+	env: AggregateEnv,
+	gameIds: string[],
+): Promise<FamilyCityRow[]> {
+	const out: FamilyCityRow[] = [];
+	for (const ids of chunk(gameIds, CHUNK_SIZE)) {
+		const res = await env.SHARE_DB.prepare(
+			`SELECT fc.game_id, fc.player_index, fc.family_class, fc.cities,
+			        fc.first_founded_turn
+			 FROM player_family_cities fc
+			 JOIN player_summaries ps ON ps.game_id = fc.game_id
+			                          AND ps.player_index = fc.player_index
+			 WHERE ps.is_human = 1
+			   AND fc.game_id IN (${placeholders(ids.length)})`,
+		)
+			.bind(...ids)
+			.all<FamilyCityRow>();
+		out.push(...((res.results ?? []) as FamilyCityRow[]));
+	}
+	return out;
+}
+
 interface SaveDateRow {
 	date: string;
 	weekday: number | null;
@@ -567,6 +599,7 @@ export async function buildChartBundle(
 		lawEvents,
 		wonderEvents,
 		wonderPool,
+		familyCityRows,
 		saveDateRows,
 	] = await Promise.all([
 		loadBaseRows(env, corpus.gameIds),
@@ -575,6 +608,7 @@ export async function buildChartBundle(
 		loadLawEvents(env, corpus.gameIds),
 		loadWonderEvents(env, corpus.gameIds),
 		loadWonderPool(env, corpus.gameIds),
+		loadFamilyCities(env, corpus.gameIds),
 		loadSaveDates(env, corpus.gameIds),
 	]);
 
@@ -889,16 +923,49 @@ export async function buildChartBundle(
 	);
 
 	// --- Family classes ----------------------------------------------
-	// Each player picks 3 family classes from their nation's pool. We track,
-	// per (nation, class): how often it was picked and how many of those
-	// games were won — enough to show pick rate and win rate per nation.
+	// Each player picks 3 family classes from their nation's pool. Per
+	// (nation, class): how often it was picked, how many of those games were
+	// won, how much of the empire it ended up running, and where it fell in the
+	// player's founding order — the family that seeded your first city is a
+	// different commitment from the one that showed up third.
+	const familyCityByPlayer = new Map<string, FamilyCityRow[]>();
+	for (const fc of familyCityRows) {
+		const k = `${fc.game_id}|${fc.player_index}`;
+		const arr = familyCityByPlayer.get(k) ?? [];
+		arr.push(fc);
+		familyCityByPlayer.set(k, arr);
+	}
+
 	const familyByNationMap = new Map<
 		string,
-		{ nation: string; class: string; count: number; wins: number }
+		{
+			nation: string;
+			class: string;
+			count: number;
+			wins: number;
+			// City-share running mean; a player missing city data contributes to
+			// neither this nor the slot tally, so each carries its own sample.
+			shareSum: number;
+			shareCount: number;
+			// Picks where this class was the player's 1st / 2nd / 3rd family, by
+			// the turn its first city was founded.
+			slotCounts: [number, number, number];
+		}
 	>();
 
 	for (const r of selfRows) {
 		if (!r.nation) continue;
+		const own = familyCityByPlayer.get(`${r.game_id}|${r.player_index}`) ?? [];
+		const ownCities = own.reduce((sum, fc) => sum + fc.cities, 0);
+		// Founding order: the player's families ranked by when their first city
+		// landed. Families with no founding turn (older blobs) rank last and
+		// contribute no slot.
+		const order = own
+			.filter((fc) => fc.first_founded_turn != null)
+			.sort(
+				(a, b) => (a.first_founded_turn ?? 0) - (b.first_founded_turn ?? 0),
+			)
+			.map((fc) => fc.family_class);
 		for (const c of parseJsonArray(r.family_classes)) {
 			const k = `${r.nation}|${c}`;
 			const fbn = familyByNationMap.get(k) ?? {
@@ -906,14 +973,34 @@ export async function buildChartBundle(
 				class: c,
 				count: 0,
 				wins: 0,
+				shareSum: 0,
+				shareCount: 0,
+				slotCounts: [0, 0, 0] as [number, number, number],
 			};
 			fbn.count += 1;
 			if (r.is_winner === 1) fbn.wins += 1;
+			const mine = own.find((fc) => fc.family_class === c);
+			if (mine && ownCities > 0) {
+				fbn.shareSum += mine.cities / ownCities;
+				fbn.shareCount += 1;
+			}
+			// Only the first three slots are meaningful — a player runs three
+			// families — so a later index (possible with captured cities) is left
+			// uncounted rather than folded into "third".
+			const slot = order.indexOf(c);
+			if (slot >= 0 && slot < 3) fbn.slotCounts[slot] += 1;
 			familyByNationMap.set(k, fbn);
 		}
 	}
 
-	const familyByNation = [...familyByNationMap.values()];
+	const familyByNation = [...familyByNationMap.values()].map((f) => ({
+		nation: f.nation,
+		class: f.class,
+		count: f.count,
+		wins: f.wins,
+		avg_share: f.shareCount > 0 ? f.shareSum / f.shareCount : null,
+		slot_counts: f.slotCounts,
+	}));
 
 	// Yield curves are computed in loadYieldCurves (median + P25/P75 band
 	// per turn) and assigned to the bundle directly below.

--- a/cloud/src/stats/aggregate.ts
+++ b/cloud/src/stats/aggregate.ts
@@ -962,9 +962,7 @@ export async function buildChartBundle(
 		// contribute no slot.
 		const order = own
 			.filter((fc) => fc.first_founded_turn != null)
-			.sort(
-				(a, b) => (a.first_founded_turn ?? 0) - (b.first_founded_turn ?? 0),
-			)
+			.sort((a, b) => (a.first_founded_turn ?? 0) - (b.first_founded_turn ?? 0))
 			.map((fc) => fc.family_class);
 		for (const c of parseJsonArray(r.family_classes)) {
 			const k = `${r.nation}|${c}`;
@@ -999,6 +997,10 @@ export async function buildChartBundle(
 		count: f.count,
 		wins: f.wins,
 		avg_share: f.shareCount > 0 ? f.shareSum / f.shareCount : null,
+		// The mean's own sample — picks with city data, which can be fewer than
+		// `count`. The frontend weights by this when recombining nations, so a
+		// nation with sparse city data doesn't pull the cross-nation mean.
+		share_samples: f.shareCount,
 		slot_counts: f.slotCounts,
 	}));
 

--- a/cloud/src/stats/cache.ts
+++ b/cloud/src/stats/cache.ts
@@ -31,7 +31,9 @@ import type { UserScope, UserStatsScope } from "./types";
 //
 // 6: starting-leader archetype + trait win rates.
 // 7: per-wonder build rate, builder win rate, and build-turn distribution.
-// 8: capital family class win rate.
+// 8: capital family class win rate, plus avg_share / share_samples /
+//    slot_counts on familyByNation (per-class city footprint and founding
+//    order).
 export const BUNDLE_SCHEMA_VERSION = 8;
 
 export interface StatsCacheEnv extends SessionEnv {

--- a/cloud/src/stats/cache.ts
+++ b/cloud/src/stats/cache.ts
@@ -31,7 +31,8 @@ import type { UserScope, UserStatsScope } from "./types";
 //
 // 6: starting-leader archetype + trait win rates.
 // 7: per-wonder build rate, builder win rate, and build-turn distribution.
-export const BUNDLE_SCHEMA_VERSION = 7;
+// 8: capital family class win rate.
+export const BUNDLE_SCHEMA_VERSION = 8;
 
 export interface StatsCacheEnv extends SessionEnv {
 	// SESSIONS_KV is the existing KV binding; this module reuses it

--- a/cloud/src/stats/cache.ts
+++ b/cloud/src/stats/cache.ts
@@ -5,11 +5,12 @@
 // to the public-scope cache. PARSER_VERSION (echoed by the Worker via
 // KNOWN_PARSER_VERSIONS) is embedded in the key so a frontend that
 // bumps parser naturally orphans every old entry instead of needing a
-// purge step.
+// purge step; BUNDLE_SCHEMA_VERSION is embedded beside it and does the
+// same for a change to the bundle's own shape.
 //
 // Key shape:
-//   stats:v{parser_version}:user:{user_id}:{viewerScope}:{scope}
-//   stats:v{parser_version}:tournament:{tournament_id}:{updated_at}
+//   stats:v{BUNDLE_SCHEMA_VERSION}-p{parser_version}:user:{user_id}:{viewerScope}:{scope}
+//   stats:v{BUNDLE_SCHEMA_VERSION}-p{parser_version}:tournament:{tournament_id}:{updated_at}
 //
 // We reuse the existing SESSIONS_KV binding (no new infra) — the
 // `stats:` prefix keeps these distinct from `session:` and `oauth:`
@@ -18,23 +19,30 @@
 import type { SessionEnv } from "../session";
 import type { UserScope, UserStatsScope } from "./types";
 
-// Bumping this is equivalent to a global cache flush — every read
-// becomes a miss and recomputes. Use when the ChartBundle shape itself
-// changes in a backwards-incompatible way (e.g. dropping a field). For
-// data-only changes (a chart drawn from fields the bundle already
-// carries), no bump needed.
+// What each version of the bundle shape changed. This table *is* the version:
+// BUNDLE_SCHEMA_VERSION below is its highest key, so a bump can't happen
+// without saying what changed, and the two can't drift apart.
 //
-// Adding a field counts: entries live for 24h, so without a bump a
-// frontend deployed behind the Worker would read a cached bundle that
-// predates the field and blow up on it (the bundle types declare every
-// field required, so consumers dereference them directly).
+// Bumping is equivalent to a global cache flush — every read becomes a miss
+// and recomputes. Bump when the ChartBundle shape itself changes: dropping a
+// field, or adding one. Adding counts because entries live for 24h, so without
+// a bump a frontend deployed behind the Worker would read a cached bundle that
+// predates the field and blow up on it (the bundle types declare every field
+// required, so consumers dereference them directly). A data-only change — a
+// chart drawn from fields the bundle already carries — needs no bump.
 //
-// 6: starting-leader archetype + trait win rates.
-// 7: per-wonder build rate, builder win rate, and build-turn distribution.
-// 8: capital family class win rate, plus avg_share / share_samples /
-//    slot_counts on familyByNation (per-class city footprint and founding
-//    order).
-export const BUNDLE_SCHEMA_VERSION = 8;
+// Versions 1-3 never shipped; the constant was introduced at 4.
+const BUNDLE_SCHEMA_CHANGELOG: Record<number, string> = {
+	4: "initial cached bundle shape",
+	5: "winner/loser split on the yield curves (yieldCurves.outcome)",
+	6: "starting-leader archetype + trait win rates",
+	7: "per-wonder build rate, builder win rate, and build-turn distribution",
+	8: "capital family class win rate, plus avg_share / share_samples / slot_counts on familyByNation (per-class city footprint and founding order)",
+};
+
+export const BUNDLE_SCHEMA_VERSION = Math.max(
+	...Object.keys(BUNDLE_SCHEMA_CHANGELOG).map(Number),
+);
 
 export interface StatsCacheEnv extends SessionEnv {
 	// SESSIONS_KV is the existing KV binding; this module reuses it

--- a/cloud/src/stats/types.ts
+++ b/cloud/src/stats/types.ts
@@ -169,6 +169,18 @@ export interface ChartBundleCore {
 	}>;
 
 	// --- Families ----------------------------------------------------
+	// The family class holding each focal player's capital, with how those
+	// games ended. Distinct from familyByNation: that asks whether a class was
+	// among the player's three, this asks which one ran the city the early
+	// bonuses compound through. Over an all-humans corpus the overall rate is
+	// ~50% by construction, so the signal is a class's deviation from it.
+	capitalFamilyWinRate: Array<{
+		family_class: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
 	// Per (nation, class): games where the player picked that class for
 	// that nation, and how many they won. The frontend derives pick rate
 	// (count ÷ nation games) and win rate (wins ÷ count) per nation.

--- a/cloud/src/stats/types.ts
+++ b/cloud/src/stats/types.ts
@@ -189,9 +189,12 @@ export interface ChartBundleCore {
 		class: string;
 		count: number;
 		wins: number;
-		// Mean share of the player's end-of-game cities this class held. Null
-		// when no in-scope player has city data for it — older blobs carry no
-		// family on their cities.
+		// Mean share of the player's end-of-game cities this class held. The
+		// denominator counts only cities that carry a family — a city with no
+		// family_class is skipped on both sides of the ratio — so it is a
+		// narrower base than player_summaries.cities_total, which counts every
+		// city matching the player's owner_nation. Null when no in-scope player
+		// has city data for it: older blobs carry no family on their cities.
 		avg_share: Nullable<number>;
 		// Picks behind avg_share (those with city data) — the mean's own sample,
 		// which the frontend weights by when recombining across nations.

--- a/cloud/src/stats/types.ts
+++ b/cloud/src/stats/types.ts
@@ -189,6 +189,14 @@ export interface ChartBundleCore {
 		class: string;
 		count: number;
 		wins: number;
+		// Mean share of the player's end-of-game cities this class held. Null
+		// when no in-scope player has city data for it — older blobs carry no
+		// family on their cities.
+		avg_share: Nullable<number>;
+		// Picks where this class was the player's 1st / 2nd / 3rd family, ranked
+		// by when its first city was founded. Sums to at most `count` — a pick
+		// with no founding data contributes to none of them.
+		slot_counts: [number, number, number];
 	}>;
 
 	// --- Yields ------------------------------------------------------

--- a/cloud/src/stats/types.ts
+++ b/cloud/src/stats/types.ts
@@ -193,6 +193,9 @@ export interface ChartBundleCore {
 		// when no in-scope player has city data for it — older blobs carry no
 		// family on their cities.
 		avg_share: Nullable<number>;
+		// Picks behind avg_share (those with city data) — the mean's own sample,
+		// which the frontend weights by when recombining across nations.
+		share_samples: number;
 		// Picks where this class was the player's 1st / 2nd / 3rd family, ranked
 		// by when its first city was founded. Sums to at most `count` — a pick
 		// with no founding data contributes to none of them.

--- a/cloud/test/helpers/save-blob.ts
+++ b/cloud/test/helpers/save-blob.ts
@@ -15,9 +15,32 @@ import { nanoid } from "nanoid";
 
 const PARSER_VERSION = "2.4.0";
 
+// Nation per roster index. Every seat gets a distinct nation so that anything
+// keyed on nation rather than player index — derivePlayerSummary's
+// `cities_total`, the per-nation stats rows — attributes to the seat that owns
+// it. The first three are load-bearing: tests that predate the wider roster
+// assume player 0 is Egypt, player 1 Rome, and the `aiPlayer` seat Greece.
+// A roster larger than this list is a fixture-authoring error.
+const NATIONS = [
+	"NATION_EGYPT",
+	"NATION_ROME",
+	"NATION_GREECE",
+	"NATION_PERSIA",
+	"NATION_ASSYRIA",
+	"NATION_BABYLONIA",
+	"NATION_CARTHAGE",
+	"NATION_KUSH",
+	"NATION_AKSUM",
+	"NATION_HITTITE",
+	"NATION_MAURYA",
+	"NATION_TAMIL",
+	"NATION_YUEZHI",
+] as const;
+
 export interface UploadFixtureOpts {
-	// player_index of the winning human (must be 0 or 1 — fixture
-	// always builds exactly two humans at indexes 0 and 1).
+	// player_index of the winning human. Restricted to the first two seats,
+	// which is every seat in the default two-human shape; a wider or narrower
+	// roster is `humans` below.
 	readonly winnerIndex: 0 | 1;
 	// Salt mixed into the ZIP placeholder so two fixtures produce
 	// distinct file_hash values; defaults to a fresh nanoid.
@@ -30,12 +53,14 @@ export interface UploadFixtureOpts {
 	// — bump those when adding a new value. Used by reimport tests that
 	// need to produce a newer version than an earlier upload.
 	readonly parserVersion?: string;
-	// Number of humans in the roster. Defaults to 2 (the standard
-	// tournament-match shape). Pass 1 to build a single-human save — used
-	// by the bye-upload test, which checks the worker rejects a one-human
-	// save against a bye match with WRONG_HUMAN_COUNT. With humans=1 the
-	// only valid winnerIndex is 0.
-	readonly humans?: 1 | 2;
+	// Number of humans in the roster, seated at indexes 0..humans-1. Defaults
+	// to 2 (the standard tournament-match shape). Pass 1 to build a single-human
+	// save — used by the bye-upload test, which checks the worker rejects a
+	// one-human save against a bye match with WRONG_HUMAN_COUNT; with humans=1
+	// the only valid winnerIndex is 0. Larger values model a multiplayer save,
+	// where the per-seat derived rows multiply (see the family-stats param-cap
+	// test). Capped at NATIONS.length.
+	readonly humans?: number;
 	// Wonder-stats inputs (see cloud/test/integration/games/wonder-stats.test.ts).
 	// `wonders` seeds player_wonders — a null nation marks a build whose builder
 	// the parser couldn't resolve. `disabledImprovements` seeds the game-level
@@ -54,16 +79,17 @@ export interface UploadFixtureOpts {
 	// another player (which keeps its original founding turn).
 	readonly cities?: ReadonlyArray<{
 		owner: number;
-		culture_level?: string;
+		cultureLevel?: string;
 		familyClass?: string | null;
 		foundedTurn?: number;
 		isCapital?: boolean;
 		capturedFrom?: number;
 	}>;
 	readonly disabledImprovements?: readonly string[];
-	// Append a non-human player at index 2. The wonder stats count only human
-	// builders, so an AI build has to be visible to the eligibility gate — a
-	// wonder it finished is off the board for the humans in that game.
+	// Append a non-human player after the humans (index 2 in the default
+	// two-human shape). The wonder stats count only human builders, so an AI
+	// build has to be visible to the eligibility gate — a wonder it finished is
+	// off the board for the humans in that game.
 	readonly aiPlayer?: boolean;
 }
 
@@ -109,72 +135,32 @@ export async function buildUploadFormData(
 function buildMinimalGameBlob(
 	winnerIndex: 0 | 1,
 	parserVersion: string | undefined,
-	humans: 1 | 2,
+	humans: number,
 	opts: UploadFixtureOpts,
 ): Record<string, unknown> {
-	// Player 1 (NATION_ROME) only exists in the two-human shape; a single-human
-	// save (a bye) has just Player 0.
-	const players = [
-		{
-			player_name: "Player 0",
-			nation: "NATION_EGYPT",
-			is_human: true,
-			legitimacy: 50,
-			state_religion: null,
-		},
-		{
-			player_name: "Player 1",
-			nation: "NATION_ROME",
-			is_human: true,
-			legitimacy: 50,
-			state_religion: null,
-		},
-	]
-		.slice(0, humans)
-		.concat(
-			opts.aiPlayer
-				? [
-						{
-							player_name: "Player 2",
-							nation: "NATION_GREECE",
-							is_human: false,
-							legitimacy: 50,
-							state_religion: null,
-						},
-					]
-				: [],
-		);
-	const playerRoster: Array<{
-		player_index: number;
-		player_name: string;
-		nation: string;
-		is_human: boolean;
-		online_id: string | null;
-	}> = [
-		{
-			player_index: 0,
-			player_name: "Player 0",
-			nation: "NATION_EGYPT",
-			is_human: true,
-			online_id: "steam:000000000000001",
-		},
-		{
-			player_index: 1,
-			player_name: "Player 1",
-			nation: "NATION_ROME",
-			is_human: true,
-			online_id: "steam:000000000000002",
-		},
-	].slice(0, humans);
-	if (opts.aiPlayer) {
-		playerRoster.push({
-			player_index: 2,
-			player_name: "Player 2",
-			nation: "NATION_GREECE",
-			is_human: false,
-			online_id: null,
-		});
-	}
+	// One seat per human at indexes 0..humans-1, then the optional AI seat
+	// immediately after them. A single-human save (a bye) has just Player 0.
+	const seats = Array.from({ length: humans }, (_, i) => ({
+		index: i,
+		isHuman: true,
+	})).concat(opts.aiPlayer ? [{ index: humans, isHuman: false }] : []);
+	const players = seats.map((s) => ({
+		player_name: `Player ${s.index}`,
+		nation: NATIONS[s.index],
+		is_human: s.isHuman,
+		legitimacy: 50,
+		state_religion: null,
+	}));
+	const playerRoster = seats.map((s) => ({
+		player_index: s.index,
+		player_name: `Player ${s.index}`,
+		nation: NATIONS[s.index],
+		is_human: s.isHuman,
+		// Only humans carry an OnlineID; the worker links the uploader's.
+		online_id: s.isHuman
+			? `steam:${String(s.index + 1).padStart(15, "0")}`
+			: null,
+	}));
 	return {
 		version: 2,
 		parser_version: parserVersion ?? PARSER_VERSION,
@@ -235,11 +221,13 @@ function buildMinimalGameBlob(
 			cities: (opts.cities ?? []).map((c, i) => ({
 				city_id: i + 1,
 				city_name: `CITYNAME_TEST_${i}`,
-				owner_nation: "NATION_EGYPT",
+				// The current owner's nation, not a fixed one — a real save can't
+				// have a city flying a nation nobody at that index plays.
+				owner_nation: NATIONS[c.owner],
 				owner_player_xml_id: c.owner,
 				first_owner_player_xml_id: c.capturedFrom ?? c.owner,
 				founded_turn: c.foundedTurn ?? 5,
-				culture_level: c.culture_level,
+				culture_level: c.cultureLevel ?? null,
 				is_capital: c.isCapital ?? false,
 				family_class: c.familyClass ?? null,
 			})),

--- a/cloud/test/helpers/save-blob.ts
+++ b/cloud/test/helpers/save-blob.ts
@@ -38,19 +38,27 @@ export interface UploadFixtureOpts {
 	readonly humans?: 1 | 2;
 	// Wonder-stats inputs (see cloud/test/integration/games/wonder-stats.test.ts).
 	// `wonders` seeds player_wonders — a null nation marks a build whose builder
-	// the parser couldn't resolve. `cities` seeds city_statistics with the
-	// culture levels that gate wonder eligibility. `disabledImprovements` seeds
-	// the game-level list parser 2.12.0 captures; omit it to model an older
-	// blob, which carries no wonder pool at all.
+	// the parser couldn't resolve. `disabledImprovements` seeds the game-level
+	// list parser 2.12.0 captures; omit it to model an older blob, which carries
+	// no wonder pool at all.
 	readonly wonders?: ReadonlyArray<{
 		player_id: number;
 		wonder: string;
 		completed_turn: number;
 		nation?: string | null;
 	}>;
+	// Cities seeded into city_statistics — one seed feeding both the culture
+	// levels that gate wonder eligibility (wonder-stats tests) and the family
+	// city footprint (family-stats tests). Defaults mark the city as founded by
+	// its owner on turn 5; pass `capturedFrom` to model a city taken from
+	// another player (which keeps its original founding turn).
 	readonly cities?: ReadonlyArray<{
-		owner_player_xml_id: number;
-		culture_level: string;
+		owner: number;
+		culture_level?: string;
+		familyClass?: string | null;
+		foundedTurn?: number;
+		isCapital?: boolean;
+		capturedFrom?: number;
 	}>;
 	readonly disabledImprovements?: readonly string[];
 	// Append a non-human player at index 2. The wonder stats count only human
@@ -228,10 +236,12 @@ function buildMinimalGameBlob(
 				city_id: i + 1,
 				city_name: `CITYNAME_TEST_${i}`,
 				owner_nation: "NATION_EGYPT",
-				owner_player_xml_id: c.owner_player_xml_id,
-				first_owner_player_xml_id: c.owner_player_xml_id,
-				founded_turn: 5,
+				owner_player_xml_id: c.owner,
+				first_owner_player_xml_id: c.capturedFrom ?? c.owner,
+				founded_turn: c.foundedTurn ?? 5,
 				culture_level: c.culture_level,
+				is_capital: c.isCapital ?? false,
+				family_class: c.familyClass ?? null,
 			})),
 		},
 		improvement_data: {},
@@ -252,7 +262,24 @@ function buildMinimalGameBlob(
 		// summary derivation iterates them unconditionally — empty arrays
 		// keep the derivation happy without seeding meaningful per-player
 		// data (which isn't relevant to tournament-link tests).
-		families: [],
+		// The player's families, mirrored from the seeded cities: a class the
+		// player holds a city of is a class they run. player_summaries
+		// .family_classes (and so familyByNation) is derived from this list, not
+		// from the cities themselves. A captured city doesn't add a family.
+		families: [
+			...new Map(
+				(opts.cities ?? [])
+					.filter((c) => c.familyClass && c.capturedFrom === undefined)
+					.map((c) => [
+						`${c.owner}|${c.familyClass}`,
+						{
+							family_name: `FAMILY_TEST_${c.familyClass}`,
+							family_class: c.familyClass,
+							player_xml_id: c.owner,
+						},
+					]),
+			).values(),
+		],
 		characters: [],
 		character_traits: [],
 		player_roster: playerRoster,

--- a/cloud/test/integration/games/family-stats.test.ts
+++ b/cloud/test/integration/games/family-stats.test.ts
@@ -20,6 +20,7 @@ beforeAll(async () => {
 
 const SAGES = "FAMILYCLASS_SAGES";
 const TRADERS = "FAMILYCLASS_TRADERS";
+const CHAMPIONS = "FAMILYCLASS_CHAMPIONS";
 
 type FamilyRow = {
 	nation: string;
@@ -34,13 +35,29 @@ type FamilyRow = {
 async function upload(
 	user: TestUser,
 	opts: Parameters<typeof buildUploadFormData>[0],
-): Promise<void> {
+): Promise<string> {
 	const res = await postMultipart({
 		path: "/v1/games",
 		form: await buildUploadFormData(opts),
 		as: user,
 	});
+	// A failing insert takes the whole upload batch down, so the status code is
+	// the assertion that matters for the param-cap cases below.
 	expect(res.status).toBe(201);
+	return (await expectOk<{ game_id: string }>(res)).game_id;
+}
+
+// The (player, family class) rows the upload actually wrote.
+async function footprint(
+	gameId: string,
+): Promise<Array<{ player_index: number; family_class: string }>> {
+	const res = await env.SHARE_DB.prepare(
+		`SELECT player_index, family_class FROM player_family_cities
+		 WHERE game_id = ? ORDER BY player_index, family_class`,
+	)
+		.bind(gameId)
+		.all<{ player_index: number; family_class: string }>();
+	return res.results ?? [];
 }
 
 async function families(user: TestUser): Promise<Map<string, FamilyRow>> {
@@ -130,6 +147,73 @@ describe("family stats", () => {
 		}>(await request.get({ path: `/v1/users/${user.userId}/stats`, as: user }));
 		expect(bundle.capitalFamilyWinRate).toEqual([
 			{ family_class: TRADERS, games: 1, wins: 1, rate: 1 },
+		]);
+	});
+
+	// A pre-2.6.0 blob's cities carry no family_class at all. The whole backfill
+	// story rests on those games degrading to "no data" instead of failing, so
+	// the empty bundle field is the assertion.
+	it("yields no capital family rows when no city carries a family", async () => {
+		const user = await makeUser();
+		await upload(user, {
+			winnerIndex: 0,
+			cities: [{ owner: 0, isCapital: true }, { owner: 0 }],
+		});
+
+		const bundle = await expectOk<{
+			capitalFamilyWinRate: unknown[];
+			familyByNation: unknown[];
+		}>(await request.get({ path: `/v1/users/${user.userId}/stats`, as: user }));
+		expect(bundle.capitalFamilyWinRate).toEqual([]);
+		expect(bundle.familyByNation).toEqual([]);
+	});
+
+	// player_family_cities takes 5 bindings per row against D1's 99-parameter
+	// ceiling, so the insert has to chunk at 19 rows. A full multiplayer lobby
+	// clears that in one game — eight seats running three families each is 24
+	// rows — and because every derived write shares one atomic batch(), an
+	// over-wide chunk doesn't lose the footprint, it 500s the upload.
+	it("writes every human seat's families past the insert parameter cap", async () => {
+		const user = await makeUser();
+		const HUMANS = 8;
+		const CLASSES = [SAGES, TRADERS, CHAMPIONS];
+		const gameId = await upload(user, {
+			winnerIndex: 0,
+			humans: HUMANS,
+			cities: Array.from({ length: HUMANS }, (_, owner) =>
+				CLASSES.map((familyClass, i) => ({
+					owner,
+					familyClass,
+					foundedTurn: 4 + i * 8,
+					isCapital: i === 0,
+				})),
+			).flat(),
+		});
+
+		const rows = await footprint(gameId);
+		expect(rows.length).toBe(HUMANS * CLASSES.length);
+		expect(rows.filter((r) => r.player_index === HUMANS - 1).length).toBe(
+			CLASSES.length,
+		);
+	});
+
+	// Nothing reads an AI's footprint — loadFamilyCities joins on
+	// ps.is_human = 1 — so writing one is dead storage, and in a vs-AI save the
+	// AI seats are most of the rows.
+	it("leaves AI seats out of the footprint table", async () => {
+		const user = await makeUser();
+		const gameId = await upload(user, {
+			winnerIndex: 0,
+			aiPlayer: true,
+			cities: [
+				{ owner: 0, familyClass: SAGES, isCapital: true },
+				// The AI at index 2 runs a family of its own.
+				{ owner: 2, familyClass: TRADERS, isCapital: true },
+			],
+		});
+
+		expect(await footprint(gameId)).toEqual([
+			{ player_index: 0, family_class: SAGES },
 		]);
 	});
 });

--- a/cloud/test/integration/games/family-stats.test.ts
+++ b/cloud/test/integration/games/family-stats.test.ts
@@ -1,0 +1,135 @@
+// Integration tests for the family slice of the stats bundle.
+//
+// Two things here are easy to get subtly wrong and invisible once wrong: the
+// share of a player's cities a family class ended up holding, and the founding
+// order those families arrived in — which must be read from the cities the
+// player *founded*, since a captured city keeps the turn its original owner
+// founded it. Both go through the real upload pipeline (blob →
+// player_family_cities) and are read back through GET /v1/users/:id/stats.
+
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { expectOk } from "../../helpers/assertions";
+import { makeUser, type TestUser } from "../../helpers/builders";
+import { postMultipart, request } from "../../helpers/requests";
+import { buildUploadFormData } from "../../helpers/save-blob";
+
+beforeAll(async () => {
+	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
+});
+
+const SAGES = "FAMILYCLASS_SAGES";
+const TRADERS = "FAMILYCLASS_TRADERS";
+
+type FamilyRow = {
+	nation: string;
+	class: string;
+	count: number;
+	wins: number;
+	avg_share: number | null;
+	share_samples: number;
+	slot_counts: [number, number, number];
+};
+
+async function upload(
+	user: TestUser,
+	opts: Parameters<typeof buildUploadFormData>[0],
+): Promise<void> {
+	const res = await postMultipart({
+		path: "/v1/games",
+		form: await buildUploadFormData(opts),
+		as: user,
+	});
+	expect(res.status).toBe(201);
+}
+
+async function families(user: TestUser): Promise<Map<string, FamilyRow>> {
+	const bundle = await expectOk<{
+		familyByNation: FamilyRow[];
+		capitalFamilyWinRate: Array<{ family_class: string; games: number }>;
+	}>(await request.get({ path: `/v1/users/${user.userId}/stats`, as: user }));
+	return new Map(bundle.familyByNation.map((r) => [r.class, r]));
+}
+
+describe("family stats", () => {
+	it("splits the city share across the player's classes", async () => {
+		const user = await makeUser();
+		// Three cities: two Sages, one Traders — a 2:1 empire.
+		await upload(user, {
+			winnerIndex: 0,
+			cities: [
+				{ owner: 0, familyClass: SAGES, foundedTurn: 4, isCapital: true },
+				{ owner: 0, familyClass: SAGES, foundedTurn: 20 },
+				{ owner: 0, familyClass: TRADERS, foundedTurn: 12 },
+			],
+		});
+
+		const rows = await families(user);
+		expect(rows.get(SAGES)?.avg_share).toBeCloseTo(2 / 3, 5);
+		expect(rows.get(TRADERS)?.avg_share).toBeCloseTo(1 / 3, 5);
+		expect(rows.get(SAGES)?.share_samples).toBe(1);
+	});
+
+	it("ranks founding order by the player's own foundings", async () => {
+		const user = await makeUser();
+		await upload(user, {
+			winnerIndex: 0,
+			cities: [
+				{ owner: 0, familyClass: SAGES, foundedTurn: 8, isCapital: true },
+				{ owner: 0, familyClass: TRADERS, foundedTurn: 30 },
+			],
+		});
+
+		const rows = await families(user);
+		// Sages first, Traders second.
+		expect(rows.get(SAGES)?.slot_counts).toEqual([1, 0, 0]);
+		expect(rows.get(TRADERS)?.slot_counts).toEqual([0, 1, 0]);
+	});
+
+	it("doesn't let a captured city backdate a family's founding", async () => {
+		const user = await makeUser();
+		await upload(user, {
+			winnerIndex: 0,
+			cities: [
+				{ owner: 0, familyClass: SAGES, foundedTurn: 8, isCapital: true },
+				{ owner: 0, familyClass: TRADERS, foundedTurn: 30 },
+				// Taken from the opponent, who founded it on turn 2. Counting it
+				// would make Traders look like the player's first family.
+				{
+					owner: 0,
+					familyClass: TRADERS,
+					foundedTurn: 2,
+					capturedFrom: 1,
+				},
+			],
+		});
+
+		const rows = await families(user);
+		expect(rows.get(SAGES)?.slot_counts).toEqual([1, 0, 0]);
+		expect(rows.get(TRADERS)?.slot_counts).toEqual([0, 1, 0]);
+		// The captured city still counts toward the empire's composition.
+		expect(rows.get(TRADERS)?.avg_share).toBeCloseTo(2 / 3, 5);
+	});
+
+	it("reads the capital's class off the capital city", async () => {
+		const user = await makeUser();
+		await upload(user, {
+			winnerIndex: 0,
+			cities: [
+				{ owner: 0, familyClass: TRADERS, foundedTurn: 3, isCapital: true },
+				{ owner: 0, familyClass: SAGES, foundedTurn: 9 },
+			],
+		});
+
+		const bundle = await expectOk<{
+			capitalFamilyWinRate: Array<{
+				family_class: string;
+				games: number;
+				wins: number;
+			}>;
+		}>(await request.get({ path: `/v1/users/${user.userId}/stats`, as: user }));
+		expect(bundle.capitalFamilyWinRate).toEqual([
+			{ family_class: TRADERS, games: 1, wins: 1, rate: 1 },
+		]);
+	});
+});

--- a/cloud/test/integration/games/wonder-stats.test.ts
+++ b/cloud/test/integration/games/wonder-stats.test.ts
@@ -66,7 +66,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, cultureLevel: "CULTURE_WEAK" }],
 			wonders: [{ player_id: 0, wonder: WEAK_WONDER, completed_turn: 30 }],
 		});
 
@@ -93,7 +93,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, cultureLevel: "CULTURE_WEAK" }],
 		});
 
 		expect(
@@ -114,7 +114,7 @@ describe("wonder stats — eligibility", () => {
 		// nothing to any denominator.
 		await upload(user, {
 			winnerIndex: 0,
-			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, cultureLevel: "CULTURE_WEAK" }],
 			wonders: [{ player_id: 0, wonder: WEAK_WONDER, completed_turn: 30 }],
 		});
 
@@ -135,7 +135,7 @@ describe("wonder stats — eligibility", () => {
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
 			// Legendary culture, so both test wonders are within reach and the
 			// only thing separating them is who took them.
-			cities: [{ owner: 0, culture_level: "CULTURE_LEGENDARY" }],
+			cities: [{ owner: 0, cultureLevel: "CULTURE_LEGENDARY" }],
 			aiPlayer: true,
 			// The AI finishes it on turn 12; it's off the board from then on.
 			wonders: [{ player_id: 2, wonder: WEAK_WONDER, completed_turn: 12 }],
@@ -160,7 +160,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, cultureLevel: "CULTURE_WEAK" }],
 			// A null nation is the parser's marker for "couldn't find the tile
 			// owner"; it falls back to player_id 0, so indexing it would credit
 			// whoever holds index 0 with someone else's wonder.

--- a/cloud/test/integration/games/wonder-stats.test.ts
+++ b/cloud/test/integration/games/wonder-stats.test.ts
@@ -66,7 +66,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner_player_xml_id: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
 			wonders: [{ player_id: 0, wonder: WEAK_WONDER, completed_turn: 30 }],
 		});
 
@@ -93,7 +93,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner_player_xml_id: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
 		});
 
 		expect(
@@ -114,7 +114,7 @@ describe("wonder stats — eligibility", () => {
 		// nothing to any denominator.
 		await upload(user, {
 			winnerIndex: 0,
-			cities: [{ owner_player_xml_id: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
 			wonders: [{ player_id: 0, wonder: WEAK_WONDER, completed_turn: 30 }],
 		});
 
@@ -135,7 +135,7 @@ describe("wonder stats — eligibility", () => {
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
 			// Legendary culture, so both test wonders are within reach and the
 			// only thing separating them is who took them.
-			cities: [{ owner_player_xml_id: 0, culture_level: "CULTURE_LEGENDARY" }],
+			cities: [{ owner: 0, culture_level: "CULTURE_LEGENDARY" }],
 			aiPlayer: true,
 			// The AI finishes it on turn 12; it's off the board from then on.
 			wonders: [{ player_id: 2, wonder: WEAK_WONDER, completed_turn: 12 }],
@@ -160,7 +160,7 @@ describe("wonder stats — eligibility", () => {
 			winnerIndex: 0,
 			parserVersion: "2.12.0",
 			disabledImprovements: DISABLE_ALL_BUT_TEST_WONDERS,
-			cities: [{ owner_player_xml_id: 0, culture_level: "CULTURE_WEAK" }],
+			cities: [{ owner: 0, culture_level: "CULTURE_WEAK" }],
 			// A null nation is the parser's marker for "couldn't find the tile
 			// owner"; it falls back to player_id 0, so indexing it would credit
 			// whoever holds index 0 with someone else's wonder.

--- a/docs/aggregate-statistics.md
+++ b/docs/aggregate-statistics.md
@@ -117,9 +117,7 @@ stats:v{BUNDLE_SCHEMA_VERSION}-p{parser_version}:user:{user_id}:{viewerScope}:{s
   entries so a private upload can't leak into the public-scope cache.
 - `parser_version` (`CURRENT_PARSER_VERSION`) in the key means a parser bump
   naturally orphans every old entry — there's no separate `stats_schema_version`.
-- `BUNDLE_SCHEMA_VERSION` (currently **4**) is a manual flush lever: bump it when
-  the `ChartBundle` shape changes in a backwards-incompatible way. Data-only
-  changes (a new chart over existing fields) need no bump.
+- `BUNDLE_SCHEMA_VERSION` is a manual flush lever: bump it when the `ChartBundle` shape changes — a dropped field, or a new one. Data-only changes (a new chart over fields the bundle already carries) need no bump. The current value and what each version changed live in `BUNDLE_SCHEMA_CHANGELOG` (`cloud/src/stats/cache.ts`), which is the source of truth. This doc deliberately doesn't restate the number: it sat four versions stale here before it was noticed.
 - **Invalidation** is a prefix walk (`invalidateStatsCache`) over every
   viewerScope × scope variant for the user, fired on upload, patch, and delete
   in `cloud/src/games.ts`. 24h TTL is the safety net.

--- a/src/lib/stats/FamilyStatsPanel.svelte
+++ b/src/lib/stats/FamilyStatsPanel.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
-	// Families category: pick a nation, see which family classes its players
-	// pick (pick rate) and whether some win more (win rate), as paired bars.
+	// Families category: which family class ran the capital (nation-agnostic —
+	// the earliest of the family decisions), then a nation selector for which
+	// classes that nation's players pick and whether some win more.
 
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import NationSelect from "./NationSelect.svelte";
 	import type { ChartBundle } from "./types";
-	import { familyNations, familyNationPicksOption } from "./charts/families";
+	import {
+		capitalFamilyWinLossOption,
+		familyNations,
+		familyNationPicksOption,
+	} from "./charts/families";
+	import { barChartHeight } from "./charts/helpers";
 	import { ALL_NATIONS, nationLabel } from "./charts/helpers";
 
 	let { bundle }: { bundle: ChartBundle } = $props();
@@ -20,6 +26,14 @@
 		chosen && options.includes(chosen) ? chosen : ALL_NATIONS,
 	);
 </script>
+
+{#if bundle.capitalFamilyWinRate.length > 0}
+	<ChartContainer
+		option={capitalFamilyWinLossOption(bundle)}
+		height={barChartHeight(bundle.capitalFamilyWinRate.length)}
+		title="Capital family"
+	/>
+{/if}
 
 {#if nations.length === 0}
 	<p class="p-8 text-center italic text-brown">No family data available.</p>

--- a/src/lib/stats/FamilyStatsPanel.svelte
+++ b/src/lib/stats/FamilyStatsPanel.svelte
@@ -8,11 +8,11 @@
 	import type { ChartBundleCore } from "./types";
 	import {
 		capitalFamilyWinLossOption,
+		familyClassRowCount,
 		familyNations,
 		familyNationPicksOption,
 	} from "./charts/families";
-	import { barChartHeight } from "./charts/helpers";
-	import { ALL_NATIONS, nationLabel } from "./charts/helpers";
+	import { ALL_NATIONS, barChartHeight, nationLabel } from "./charts/helpers";
 
 	let { bundle }: { bundle: ChartBundleCore } = $props();
 
@@ -27,12 +27,19 @@
 	);
 </script>
 
+<!-- The two charts read from different columns (player_summaries
+     .capital_family_class, .family_classes) and go empty independently, so each
+     carries its own empty state rather than sharing one guard. -->
 {#if bundle.capitalFamilyWinRate.length > 0}
 	<ChartContainer
 		option={capitalFamilyWinLossOption(bundle)}
 		height={barChartHeight(bundle.capitalFamilyWinRate.length)}
 		title="Capital family"
 	/>
+{:else}
+	<p class="p-8 text-center italic text-brown">
+		No capital family data available.
+	</p>
 {/if}
 
 {#if nations.length === 0}
@@ -42,7 +49,7 @@
 
 	<ChartContainer
 		option={familyNationPicksOption(bundle, nation)}
-		height="400px"
+		height={barChartHeight(familyClassRowCount(bundle, nation))}
 		title={nationLabel(nation)}
 	/>
 {/if}

--- a/src/lib/stats/FamilyStatsPanel.svelte
+++ b/src/lib/stats/FamilyStatsPanel.svelte
@@ -5,7 +5,7 @@
 
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import NationSelect from "./NationSelect.svelte";
-	import type { ChartBundle } from "./types";
+	import type { ChartBundleCore } from "./types";
 	import {
 		capitalFamilyWinLossOption,
 		familyNations,
@@ -14,7 +14,7 @@
 	import { barChartHeight } from "./charts/helpers";
 	import { ALL_NATIONS, nationLabel } from "./charts/helpers";
 
-	let { bundle }: { bundle: ChartBundle } = $props();
+	let { bundle }: { bundle: ChartBundleCore } = $props();
 
 	const nations = $derived(familyNations(bundle));
 	// Selector options: the cross-nation aggregate first, then each nation.

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -74,9 +74,9 @@ export function familyNationPicksOption(
 		};
 		e.count += r.count;
 		e.wins += r.wins;
-		if (r.avg_share != null) {
-			e.shareSum += r.avg_share * r.count;
-			e.shareCount += r.count;
+		if (r.avg_share != null && r.share_samples > 0) {
+			e.shareSum += r.avg_share * r.share_samples;
+			e.shareCount += r.share_samples;
 		}
 		for (let i = 0; i < 3; i++) e.slots[i] += r.slot_counts[i] ?? 0;
 		byClass.set(r.class, e);

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -5,64 +5,24 @@ import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
 import type { ChartBundleCore } from "../types";
 import {
 	ALL_NATIONS,
-	CHART_THEME,
-	COMMON_GRID,
-	LOSS_COLOR,
-	WIN_COLOR,
-	crestAxisLabel,
+	type WinLossRow,
 	fmtClass,
 	nationLabel,
+	winLossStackedOption,
 } from "./helpers";
-
-// Family classes reuse the ARCHETYPE crest art (FAMILYCLASS_CHAMPIONS →
-// crests/CREST_ARCHETYPE_CHAMPIONS).
-// The wins/losses stack both family charts draw: bar length is games, the
-// split is how they ended, and a trailing label can hang off the loss segment.
-// Kept local to this module — #155 introduces a catalog-wide
-// `winLossStackedOption` in charts/helpers.ts, and both of these route through
-// it on rebase once that lands.
-function outcomeSeries(opts: {
-	wins: number[];
-	losses: number[];
-	label?: { formatter: (p: { dataIndex: number }) => string };
-}) {
-	return [
-		{
-			name: "Wins",
-			type: "bar" as const,
-			stack: "outcome",
-			data: opts.wins,
-			itemStyle: { color: WIN_COLOR },
-		},
-		{
-			name: "Losses",
-			type: "bar" as const,
-			stack: "outcome",
-			data: opts.losses,
-			itemStyle: { color: LOSS_COLOR },
-			...(opts.label
-				? {
-						label: {
-							show: true,
-							position: "right" as const,
-							color: CHART_THEME.textStyle.color,
-							fontSize: 11,
-							formatter: opts.label.formatter,
-						},
-					}
-				: {}),
-		},
-	];
-}
 
 // Founding-order slots, in order. A player runs three families; which one
 // seeded the first city is a different commitment from the third.
 const SLOT_LABELS = ["1st family", "2nd", "3rd"] as const;
 
+// Family classes reuse the ARCHETYPE crest art (FAMILYCLASS_CHAMPIONS →
+// crests/CREST_ARCHETYPE_CHAMPIONS).
 function classCrestUrl(familyClass: string): string | undefined {
 	const name = familyClass.replace(/^FAMILYCLASS_/, "");
 	return SPRITE_MANIFEST[`crests/CREST_ARCHETYPE_${name}`];
 }
+
+const pct = (v: number) => `${Math.round(v * 100)}%`;
 
 // Nations that have any family-class data, most-played first — drives the
 // selector in FamilyStatsPanel.
@@ -73,14 +33,22 @@ export function familyNations(bundle: ChartBundleCore): string[] {
 	);
 }
 
-// For one nation: paired horizontal bars of pick rate and win rate per
-// pool class, sorted by pick rate. Answers "which families do I pick for
-// this nation" and "do some win more" in one read, with no cross-nation
-// availability confound.
-export function familyNationPicksOption(
+// One family class as the shared outcome bar plus the extras only this chart
+// shows: `games`/`wins`/`rate` are the picks and how they ended, the rest ride
+// along for the tooltip and the trailing label.
+interface ClassRow extends WinLossRow {
+	pickRate: number;
+	avgShare: number | null;
+	slots: [number, number, number];
+}
+
+// Per-class rows for one nation (or the cross-nation aggregate), plus the game
+// count the pick rate is taken over. Shared by the option builder and the
+// panel's container height so the two can't disagree on the row count.
+function nationPickRows(
 	bundle: ChartBundleCore,
 	nation: string,
-): ChartOption {
+): { games: number; rows: ClassRow[] } {
 	const isAll = nation === ALL_NATIONS;
 	// "All nations": aggregate counts/wins per class across every nation; pick
 	// rate is over total games in the corpus. (Across-pool aggregate — handy as
@@ -120,77 +88,68 @@ export function familyNationPicksOption(
 		for (let i = 0; i < 3; i++) e.slots[i] += r.slot_counts[i] ?? 0;
 		byClass.set(r.class, e);
 	}
-	const rows = [...byClass.entries()]
-		.map(([cls, e]) => ({
-			class: cls,
-			pickRate: games > 0 ? e.count / games : 0,
-			count: e.count,
-			wins: e.wins,
-			avgShare: e.shareCount > 0 ? e.shareSum / e.shareCount : null,
-			slots: e.slots,
-		}))
-		// Ascending so the most-picked class sits at the top (ECharts stacks a
-		// category axis bottom-up).
-		.sort((a, b) => a.count - b.count);
-	const classes = rows.map((r) => r.class);
-	const pct = (v: number) => `${Math.round(v * 100)}%`;
-	return {
-		...CHART_THEME,
-		title: {
-			...CHART_THEME.title,
-			text: `${nationLabel(nation)} families`,
+	const rows = [...byClass.entries()].map(([cls, e]) => ({
+		key: cls,
+		games: e.count,
+		wins: e.wins,
+		rate: e.count > 0 ? e.wins / e.count : 0,
+		pickRate: games > 0 ? e.count / games : 0,
+		avgShare: e.shareCount > 0 ? e.shareSum / e.shareCount : null,
+		slots: e.slots,
+	}));
+	return { games, rows };
+}
+
+// Rows the per-nation chart actually draws — the panel sizes the container off
+// the same count, so the chart never scrolls past its box.
+export function familyClassRowCount(
+	bundle: ChartBundleCore,
+	nation: string,
+): number {
+	return nationPickRows(bundle, nation).rows.length;
+}
+
+// For one nation: the shared wins/losses stack per family class its players
+// picked — bar length is how often the class was picked, the split how those
+// games ended — with the share of the empire it ran as a trailing label and the
+// pick rate and founding-order split in the tooltip. Restricting to one nation
+// holds the family pool constant, so the classes are comparable to each other.
+export function familyNationPicksOption(
+	bundle: ChartBundleCore,
+	nation: string,
+): ChartOption {
+	const { games, rows } = nationPickRows(bundle, nation);
+	return winLossStackedOption({
+		rows,
+		label: fmtClass,
+		iconUrl: classCrestUrl,
+		title: `${nationLabel(nation)} families`,
+		tooltipFormatter: (r) => {
+			const lines = [
+				fmtClass(r.key),
+				`Picked in ${r.games} of ${games} games (${pct(r.pickRate)})`,
+				`Wins: ${r.wins} / ${r.games} (${pct(r.rate)})`,
+			];
+			if (r.avgShare != null) {
+				lines.push(`Avg share of cities: ${pct(r.avgShare)}`);
+			}
+			// Founding order — which of the player's three families this was,
+			// by the turn its first city landed.
+			const slotTotal = r.slots.reduce((a, b) => a + b, 0);
+			if (slotTotal > 0) {
+				lines.push(
+					SLOT_LABELS.map(
+						(label, i) => `${label} ${pct(r.slots[i] / slotTotal)}`,
+					).join(" · "),
+				);
+			}
+			return lines.join("<br/>");
 		},
-		tooltip: {
-			trigger: "axis",
-			axisPointer: { type: "shadow" },
-			formatter: (params: unknown) => {
-				const p = (params as { dataIndex: number }[])[0];
-				const r = rows[p.dataIndex];
-				if (!r) return "";
-				const lines = [
-					`${fmtClass(r.class)}`,
-					`Picked in ${r.count} of ${games} games (${pct(r.pickRate)})`,
-					`Wins: ${r.wins} / ${r.count} (${pct(r.count > 0 ? r.wins / r.count : 0)})`,
-				];
-				if (r.avgShare != null) {
-					lines.push(`Avg share of cities: ${pct(r.avgShare)}`);
-				}
-				// Founding order — which of the player's three families this was,
-				// by the turn its first city landed.
-				const slotTotal = r.slots.reduce((a, b) => a + b, 0);
-				if (slotTotal > 0) {
-					lines.push(
-						SLOT_LABELS.map(
-							(label, i) => `${label} ${pct(r.slots[i] / slotTotal)}`,
-						).join(" · "),
-					);
-				}
-				return lines.join("<br/>");
-			},
-		},
-		// Room on the right for the city-share label.
-		grid: { ...COMMON_GRID, left: 140, right: 120, top: 64 },
-		xAxis: { type: "value" },
-		yAxis: {
-			type: "category",
-			data: classes,
-			axisLabel: crestAxisLabel(classes, classCrestUrl, fmtClass, 132, 20, 14),
-		},
-		series: outcomeSeries({
-			wins: rows.map((r) => r.wins),
-			losses: rows.map((r) => r.count - r.wins),
-			// How much of the empire this class ran, at the end of its bar. The
-			// founding-order split is in the tooltip — three percentages would
-			// crowd the axis.
-			label: {
-				formatter: (p: { dataIndex: number }) => {
-					const r = rows[p.dataIndex];
-					if (!r || r.avgShare == null) return "";
-					return `${pct(r.avgShare)} of cities`;
-				},
-			},
-		}),
-	};
+		// How much of the empire this class ran, at the end of its bar. The
+		// founding-order split is in the tooltip — three percentages would
+		// crowd the axis.
+		barLabel: (r) => (r.avgShare == null ? "" : `${pct(r.avgShare)} of cities`),
+	});
 }
 
 // Which family class ran the capital, as a stacked wins/losses bar: length is
@@ -205,37 +164,18 @@ export function familyNationPicksOption(
 export function capitalFamilyWinLossOption(
 	bundle: ChartBundleCore,
 ): ChartOption {
-	// Ascending so the most common capital family sits at the top (ECharts
-	// stacks a category axis bottom-up).
-	const rows = [...bundle.capitalFamilyWinRate].sort(
-		(a, b) => a.games - b.games,
-	);
-	const classes = rows.map((r) => r.family_class);
-	return {
-		...CHART_THEME,
+	return winLossStackedOption({
+		rows: bundle.capitalFamilyWinRate.map((r) => ({
+			key: r.family_class,
+			games: r.games,
+			wins: r.wins,
+			rate: r.rate,
+		})),
+		label: fmtClass,
+		iconUrl: classCrestUrl,
 		// Titled in-chart like the per-nation bars beside it, so the two charts
 		// in the Families panel are self-describing.
-		title: { ...CHART_THEME.title, text: "Capital family" },
-		tooltip: {
-			...CHART_THEME.tooltip,
-			axisPointer: { type: "shadow" },
-			formatter: (params: unknown) => {
-				const p = (params as { dataIndex: number }[])[0];
-				const row = rows[p.dataIndex];
-				if (!row) return "";
-				return `${fmtClass(row.family_class)} capital<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round(row.rate * 100)}%`;
-			},
-		},
-		grid: { ...COMMON_GRID, left: 150 },
-		xAxis: { type: "value" },
-		yAxis: {
-			type: "category",
-			data: classes,
-			axisLabel: crestAxisLabel(classes, classCrestUrl, fmtClass, 142, 20, 14),
-		},
-		series: outcomeSeries({
-			wins: rows.map((r) => r.wins),
-			losses: rows.map((r) => r.games - r.wins),
-		}),
-	};
+		title: "Capital family",
+		labelWidth: 150,
+	});
 }

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -16,6 +16,45 @@ import {
 
 // Family classes reuse the ARCHETYPE crest art (FAMILYCLASS_CHAMPIONS →
 // crests/CREST_ARCHETYPE_CHAMPIONS).
+// The wins/losses stack both family charts draw: bar length is games, the
+// split is how they ended, and a trailing label can hang off the loss segment.
+// Kept local to this module — #155 introduces a catalog-wide
+// `winLossStackedOption` in charts/helpers.ts, and both of these route through
+// it on rebase once that lands.
+function outcomeSeries(opts: {
+	wins: number[];
+	losses: number[];
+	label?: { formatter: (p: { dataIndex: number }) => string };
+}) {
+	return [
+		{
+			name: "Wins",
+			type: "bar" as const,
+			stack: "outcome",
+			data: opts.wins,
+			itemStyle: { color: WIN_COLOR },
+		},
+		{
+			name: "Losses",
+			type: "bar" as const,
+			stack: "outcome",
+			data: opts.losses,
+			itemStyle: { color: LOSS_COLOR },
+			...(opts.label
+				? {
+						label: {
+							show: true,
+							position: "right" as const,
+							color: CHART_THEME.textStyle.color,
+							fontSize: 11,
+							formatter: opts.label.formatter,
+						},
+					}
+				: {}),
+		},
+	];
+}
+
 // Founding-order slots, in order. A player runs three families; which one
 // seeded the first city is a different commitment from the third.
 const SLOT_LABELS = ["1st family", "2nd", "3rd"] as const;
@@ -137,36 +176,20 @@ export function familyNationPicksOption(
 			data: classes,
 			axisLabel: crestAxisLabel(classes, classCrestUrl, fmtClass, 132, 20, 14),
 		},
-		series: [
-			{
-				name: "Wins",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.wins),
-				itemStyle: { color: WIN_COLOR },
-			},
-			{
-				name: "Losses",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.count - r.wins),
-				itemStyle: { color: LOSS_COLOR },
-				// How much of the empire this class ran, at the end of its bar. The
-				// founding-order split is in the tooltip — three percentages would
-				// crowd the axis.
-				label: {
-					show: true,
-					position: "right",
-					color: CHART_THEME.textStyle.color,
-					fontSize: 11,
-					formatter: (p: { dataIndex: number }) => {
-						const r = rows[p.dataIndex];
-						if (!r || r.avgShare == null) return "";
-						return `${pct(r.avgShare)} of cities`;
-					},
+		series: outcomeSeries({
+			wins: rows.map((r) => r.wins),
+			losses: rows.map((r) => r.count - r.wins),
+			// How much of the empire this class ran, at the end of its bar. The
+			// founding-order split is in the tooltip — three percentages would
+			// crowd the axis.
+			label: {
+				formatter: (p: { dataIndex: number }) => {
+					const r = rows[p.dataIndex];
+					if (!r || r.avgShare == null) return "";
+					return `${pct(r.avgShare)} of cities`;
 				},
 			},
-		],
+		}),
 	};
 }
 
@@ -210,21 +233,9 @@ export function capitalFamilyWinLossOption(
 			data: classes,
 			axisLabel: crestAxisLabel(classes, classCrestUrl, fmtClass, 142, 20, 14),
 		},
-		series: [
-			{
-				name: "Wins",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.wins),
-				itemStyle: { color: WIN_COLOR },
-			},
-			{
-				name: "Losses",
-				type: "bar",
-				stack: "outcome",
-				data: rows.map((r) => r.games - r.wins),
-				itemStyle: { color: LOSS_COLOR },
-			},
-		],
+		series: outcomeSeries({
+			wins: rows.map((r) => r.wins),
+			losses: rows.map((r) => r.games - r.wins),
+		}),
 	};
 }

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -3,11 +3,13 @@
 import type { ChartOption } from "$lib/echarts";
 import { getChartColor } from "$lib/config";
 import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
-import type { ChartBundle } from "../types";
+import type { ChartBundle, ChartBundleCore } from "../types";
 import {
 	ALL_NATIONS,
 	CHART_THEME,
 	COMMON_GRID,
+	LOSS_COLOR,
+	WIN_COLOR,
 	crestAxisLabel,
 	fmtClass,
 	nationLabel,
@@ -104,6 +106,65 @@ export function familyNationPicksOption(
 				type: "bar",
 				data: rows.map((r) => r.winRate),
 				itemStyle: { color: getChartColor(5) },
+			},
+		],
+	};
+}
+
+// Which family class ran the capital, as a stacked wins/losses bar: length is
+// how often that class held the capital, the split how those games ended. The
+// same encoding as the nation win-rate bar, and the same reason — one bar
+// answers both "how often" and "how well".
+//
+// Nation-agnostic on purpose: a family class means the same thing whichever
+// nation fields it, and splitting by nation here would shred the sample.
+// Typed against ChartBundleCore (only reads capitalFamilyWinRate) so it renders
+// unchanged at tournament scope.
+export function capitalFamilyWinLossOption(
+	bundle: ChartBundleCore,
+): ChartOption {
+	// Ascending so the most common capital family sits at the top (ECharts
+	// stacks a category axis bottom-up).
+	const rows = [...bundle.capitalFamilyWinRate].sort(
+		(a, b) => a.games - b.games,
+	);
+	const classes = rows.map((r) => r.family_class);
+	return {
+		...CHART_THEME,
+		// Titled in-chart like the per-nation bars beside it, so the two charts
+		// in the Families panel are self-describing.
+		title: { ...CHART_THEME.title, text: "Capital family" },
+		tooltip: {
+			...CHART_THEME.tooltip,
+			axisPointer: { type: "shadow" },
+			formatter: (params: unknown) => {
+				const p = (params as { dataIndex: number }[])[0];
+				const row = rows[p.dataIndex];
+				if (!row) return "";
+				return `${fmtClass(row.family_class)} capital<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round(row.rate * 100)}%`;
+			},
+		},
+		grid: { ...COMMON_GRID, left: 150 },
+		xAxis: { type: "value" },
+		yAxis: {
+			type: "category",
+			data: classes,
+			axisLabel: crestAxisLabel(classes, classCrestUrl, fmtClass, 142, 20, 14),
+		},
+		series: [
+			{
+				name: "Wins",
+				type: "bar",
+				stack: "outcome",
+				data: rows.map((r) => r.wins),
+				itemStyle: { color: WIN_COLOR },
+			},
+			{
+				name: "Losses",
+				type: "bar",
+				stack: "outcome",
+				data: rows.map((r) => r.games - r.wins),
+				itemStyle: { color: LOSS_COLOR },
 			},
 		],
 	};

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -149,7 +149,7 @@ export function familyNationPicksOption(
 				if (!r) return "";
 				const lines = [
 					`${fmtClass(r.class)}`,
-					`Picked in ${r.count} games (${pct(r.pickRate)} of this nation's)`,
+					`Picked in ${r.count} of ${games} games (${pct(r.pickRate)})`,
 					`Wins: ${r.wins} / ${r.count} (${pct(r.count > 0 ? r.wins / r.count : 0)})`,
 				];
 				if (r.avgShare != null) {

--- a/src/lib/stats/charts/families.ts
+++ b/src/lib/stats/charts/families.ts
@@ -1,9 +1,8 @@
 // Families tab option builders.
 
 import type { ChartOption } from "$lib/echarts";
-import { getChartColor } from "$lib/config";
 import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
-import type { ChartBundle, ChartBundleCore } from "../types";
+import type { ChartBundleCore } from "../types";
 import {
 	ALL_NATIONS,
 	CHART_THEME,
@@ -17,6 +16,10 @@ import {
 
 // Family classes reuse the ARCHETYPE crest art (FAMILYCLASS_CHAMPIONS →
 // crests/CREST_ARCHETYPE_CHAMPIONS).
+// Founding-order slots, in order. A player runs three families; which one
+// seeded the first city is a different commitment from the third.
+const SLOT_LABELS = ["1st family", "2nd", "3rd"] as const;
+
 function classCrestUrl(familyClass: string): string | undefined {
 	const name = familyClass.replace(/^FAMILYCLASS_/, "");
 	return SPRITE_MANIFEST[`crests/CREST_ARCHETYPE_${name}`];
@@ -24,7 +27,7 @@ function classCrestUrl(familyClass: string): string | undefined {
 
 // Nations that have any family-class data, most-played first — drives the
 // selector in FamilyStatsPanel.
-export function familyNations(bundle: ChartBundle): string[] {
+export function familyNations(bundle: ChartBundleCore): string[] {
 	const games = new Map(bundle.nationWinRate.map((r) => [r.nation, r.games]));
 	return Array.from(new Set(bundle.familyByNation.map((r) => r.nation))).sort(
 		(a, b) => (games.get(b) ?? 0) - (games.get(a) ?? 0),
@@ -36,7 +39,7 @@ export function familyNations(bundle: ChartBundle): string[] {
 // this nation" and "do some win more" in one read, with no cross-nation
 // availability confound.
 export function familyNationPicksOption(
-	bundle: ChartBundle,
+	bundle: ChartBundleCore,
 	nation: string,
 ): ChartOption {
 	const isAll = nation === ALL_NATIONS;
@@ -47,23 +50,49 @@ export function familyNationPicksOption(
 	const games = isAll
 		? bundle.nationWinRate.reduce((s, r) => s + r.games, 0)
 		: (bundle.nationWinRate.find((r) => r.nation === nation)?.games ?? 0);
-	const byClass = new Map<string, { count: number; wins: number }>();
+	// City share is a per-nation mean, so recombining across nations weights
+	// each nation by how often the class was picked there — the same weighting
+	// the pick/win counts already carry. Slot counts are plain sums.
+	const byClass = new Map<
+		string,
+		{
+			count: number;
+			wins: number;
+			shareSum: number;
+			shareCount: number;
+			slots: [number, number, number];
+		}
+	>();
 	for (const r of bundle.familyByNation) {
 		if (!isAll && r.nation !== nation) continue;
-		const e = byClass.get(r.class) ?? { count: 0, wins: 0 };
+		const e = byClass.get(r.class) ?? {
+			count: 0,
+			wins: 0,
+			shareSum: 0,
+			shareCount: 0,
+			slots: [0, 0, 0] as [number, number, number],
+		};
 		e.count += r.count;
 		e.wins += r.wins;
+		if (r.avg_share != null) {
+			e.shareSum += r.avg_share * r.count;
+			e.shareCount += r.count;
+		}
+		for (let i = 0; i < 3; i++) e.slots[i] += r.slot_counts[i] ?? 0;
 		byClass.set(r.class, e);
 	}
 	const rows = [...byClass.entries()]
 		.map(([cls, e]) => ({
 			class: cls,
 			pickRate: games > 0 ? e.count / games : 0,
-			winRate: e.count > 0 ? e.wins / e.count : 0,
 			count: e.count,
 			wins: e.wins,
+			avgShare: e.shareCount > 0 ? e.shareSum / e.shareCount : null,
+			slots: e.slots,
 		}))
-		.sort((a, b) => a.pickRate - b.pickRate);
+		// Ascending so the most-picked class sits at the top (ECharts stacks a
+		// category axis bottom-up).
+		.sort((a, b) => a.count - b.count);
 	const classes = rows.map((r) => r.class);
 	const pct = (v: number) => `${Math.round(v * 100)}%`;
 	return {
@@ -79,16 +108,30 @@ export function familyNationPicksOption(
 				const p = (params as { dataIndex: number }[])[0];
 				const r = rows[p.dataIndex];
 				if (!r) return "";
-				return `${fmtClass(r.class)}<br/>Picked: ${pct(r.pickRate)} (${r.count} games)<br/>Win rate: ${pct(r.winRate)}`;
+				const lines = [
+					`${fmtClass(r.class)}`,
+					`Picked in ${r.count} games (${pct(r.pickRate)} of this nation's)`,
+					`Wins: ${r.wins} / ${r.count} (${pct(r.count > 0 ? r.wins / r.count : 0)})`,
+				];
+				if (r.avgShare != null) {
+					lines.push(`Avg share of cities: ${pct(r.avgShare)}`);
+				}
+				// Founding order — which of the player's three families this was,
+				// by the turn its first city landed.
+				const slotTotal = r.slots.reduce((a, b) => a + b, 0);
+				if (slotTotal > 0) {
+					lines.push(
+						SLOT_LABELS.map(
+							(label, i) => `${label} ${pct(r.slots[i] / slotTotal)}`,
+						).join(" · "),
+					);
+				}
+				return lines.join("<br/>");
 			},
 		},
-		grid: { ...COMMON_GRID, left: 140, top: 64 },
-		xAxis: {
-			type: "value",
-			min: 0,
-			max: 1,
-			axisLabel: { formatter: (v: number) => pct(v) },
-		},
+		// Room on the right for the city-share label.
+		grid: { ...COMMON_GRID, left: 140, right: 120, top: 64 },
+		xAxis: { type: "value" },
 		yAxis: {
 			type: "category",
 			data: classes,
@@ -96,16 +139,32 @@ export function familyNationPicksOption(
 		},
 		series: [
 			{
-				name: "Pick rate",
+				name: "Wins",
 				type: "bar",
-				data: rows.map((r) => r.pickRate),
-				itemStyle: { color: getChartColor(0) },
+				stack: "outcome",
+				data: rows.map((r) => r.wins),
+				itemStyle: { color: WIN_COLOR },
 			},
 			{
-				name: "Win rate",
+				name: "Losses",
 				type: "bar",
-				data: rows.map((r) => r.winRate),
-				itemStyle: { color: getChartColor(5) },
+				stack: "outcome",
+				data: rows.map((r) => r.count - r.wins),
+				itemStyle: { color: LOSS_COLOR },
+				// How much of the empire this class ran, at the end of its bar. The
+				// founding-order split is in the tooltip — three percentages would
+				// crowd the axis.
+				label: {
+					show: true,
+					position: "right",
+					color: CHART_THEME.textStyle.color,
+					fontSize: 11,
+					formatter: (p: { dataIndex: number }) => {
+						const r = rows[p.dataIndex];
+						if (!r || r.avgShare == null) return "";
+						return `${pct(r.avgShare)} of cities`;
+					},
+				},
 			},
 		],
 	};

--- a/src/lib/stats/charts/helpers.ts
+++ b/src/lib/stats/charts/helpers.ts
@@ -124,10 +124,15 @@ export interface WinLossRow {
 // Horizontal stacked wins/losses bar: bar length = games played, the split
 // shows the rate. Sorted by games ascending so the busiest category sits at
 // the top (ECharts stacks a category axis bottom-up). One builder behind every
-// outcome bar in the catalog — nations, leader archetypes, starting traits —
-// so they stay identical by construction rather than by copy.
-export function winLossStackedOption(opts: {
-	rows: WinLossRow[];
+// outcome bar in the catalog — nations, leader archetypes, starting traits,
+// family classes — so they stay identical by construction rather than by copy.
+//
+// Generic over the row so a caller can hang its own fields off `WinLossRow`
+// (pick rate, city share, founding-order slots) and read them back in
+// `tooltipFormatter` / `barLabel`. Those callbacks receive the *sorted* row
+// rather than an index, so a caller can't mis-index against the pre-sort order.
+export function winLossStackedOption<R extends WinLossRow>(opts: {
+	rows: R[];
 	// Display name for a row key (fmtNation, fmtTrait, …).
 	label: (value: string) => string;
 	// Sprite for a row key, when the category has icon art (nation crests,
@@ -135,12 +140,30 @@ export function winLossStackedOption(opts: {
 	iconUrl?: (value: string) => string | undefined;
 	// Room reserved for the axis labels; widen for long names.
 	labelWidth?: number;
+	// In-chart ECharts title, for the panels that stack several of these with
+	// no HTML heading of their own (Families). The registry-driven charts leave
+	// it off — StatsView titles those from the spec.
+	title?: string;
+	// Replaces the default name / wins / rate tooltip body, for a category with
+	// more to say than the outcome split.
+	tooltipFormatter?: (row: R) => string;
+	// Per-row annotation hung off the end of the bar.
+	barLabel?: (row: R) => string;
 }): ChartOption {
-	const { rows, label, iconUrl, labelWidth = 140 } = opts;
+	const {
+		rows,
+		label,
+		iconUrl,
+		labelWidth = 140,
+		title,
+		tooltipFormatter,
+		barLabel,
+	} = opts;
 	const sorted = [...rows].sort((a, b) => a.games - b.games);
 	const keys = sorted.map((r) => r.key);
 	return {
 		...CHART_THEME,
+		...(title ? { title: { ...CHART_THEME.title, text: title } } : {}),
 		tooltip: {
 			...CHART_THEME.tooltip,
 			axisPointer: { type: "shadow" },
@@ -148,10 +171,18 @@ export function winLossStackedOption(opts: {
 				const p = (params as { dataIndex: number }[])[0];
 				const row = sorted[p.dataIndex];
 				if (!row) return "";
+				if (tooltipFormatter) return tooltipFormatter(row);
 				return `${label(row.key)}<br/>Wins: ${row.wins} / ${row.games}<br/>Rate: ${Math.round(row.rate * 100)}%`;
 			},
 		},
-		grid: { ...COMMON_GRID, left: labelWidth },
+		grid: {
+			...COMMON_GRID,
+			left: labelWidth,
+			// A title needs headroom (the same 64 the titled charts elsewhere
+			// use), a bar label needs room past the end of the longest bar.
+			...(title ? { top: 64 } : {}),
+			...(barLabel ? { right: 120 } : {}),
+		},
 		xAxis: { type: "value" },
 		yAxis: {
 			type: "category",
@@ -183,6 +214,22 @@ export function winLossStackedOption(opts: {
 				stack: "outcome",
 				data: sorted.map((r) => r.games - r.wins),
 				itemStyle: { color: LOSS_COLOR },
+				// Hung off the loss segment so it lands past the end of the whole
+				// bar, whatever the split.
+				...(barLabel
+					? {
+							label: {
+								show: true,
+								position: "right" as const,
+								color: CHART_THEME.textStyle.color,
+								fontSize: 11,
+								formatter: (p: { dataIndex: number }) => {
+									const row = sorted[p.dataIndex];
+									return row ? barLabel(row) : "";
+								},
+							},
+						}
+					: {}),
 			},
 		],
 	};

--- a/src/lib/stats/charts/wonders.ts
+++ b/src/lib/stats/charts/wonders.ts
@@ -157,7 +157,7 @@ export function wonderOverviewOption(bundle: ChartBundleCore): ChartOption {
 						? "No record of which games offered it"
 						: row.eligible === 0
 							? "No eligible players recorded"
-							: `Built in ${row.built} of ${row.eligible} matches (${pct(row.rate ?? 0)}%)`,
+							: `Built in ${row.built} of ${row.eligible} games (${pct(row.rate ?? 0)}%)`,
 				);
 				if (row.built > 0) {
 					facts.push(

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -127,9 +127,12 @@ export interface ChartBundleCore {
 		class: string;
 		count: number;
 		wins: number;
-		// Mean share of the player's end-of-game cities this class held. Null
-		// when no in-scope player has city data for it — older blobs carry no
-		// family on their cities.
+		// Mean share of the player's end-of-game cities this class held. The
+		// denominator counts only cities that carry a family — a city with no
+		// family_class is skipped on both sides of the ratio — so it is a
+		// narrower base than player_summaries.cities_total, which counts every
+		// city matching the player's owner_nation. Null when no in-scope player
+		// has city data for it: older blobs carry no family on their cities.
 		avg_share: Nullable<number>;
 		// Picks behind avg_share (those with city data) — the mean's own sample,
 		// which the frontend weights by when recombining across nations.

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -131,6 +131,9 @@ export interface ChartBundleCore {
 		// when no in-scope player has city data for it — older blobs carry no
 		// family on their cities.
 		avg_share: Nullable<number>;
+		// Picks behind avg_share (those with city data) — the mean's own sample,
+		// which the frontend weights by when recombining across nations.
+		share_samples: number;
 		// Picks where this class was the player's 1st / 2nd / 3rd family, ranked
 		// by when its first city was founded. Sums to at most `count` — a pick
 		// with no founding data contributes to none of them.

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -112,6 +112,16 @@ export interface ChartBundleCore {
 		p75_turn: Nullable<number>;
 	}>;
 
+	// The family class holding each focal player's capital, and how those games
+	// ended — distinct from familyByNation, which only asks whether a class was
+	// among the player's three.
+	capitalFamilyWinRate: Array<{
+		family_class: string;
+		games: number;
+		wins: number;
+		rate: number;
+	}>;
+
 	familyByNation: Array<{
 		nation: string;
 		class: string;

--- a/src/lib/stats/types.ts
+++ b/src/lib/stats/types.ts
@@ -127,6 +127,14 @@ export interface ChartBundleCore {
 		class: string;
 		count: number;
 		wins: number;
+		// Mean share of the player's end-of-game cities this class held. Null
+		// when no in-scope player has city data for it — older blobs carry no
+		// family on their cities.
+		avg_share: Nullable<number>;
+		// Picks where this class was the player's 1st / 2nd / 3rd family, ranked
+		// by when its first city was founded. Sums to at most `count` — a pick
+		// with no founding data contributes to none of them.
+		slot_counts: [number, number, number];
 	}>;
 
 	// `outcome` is the winner/loser split of the same curves, restricted to

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-	// Tournament stats page. Six tabs — Players (standings + nation picks),
+	// Tournament stats page. Seven tabs — Players (standings + nation picks),
 	// Nations (nation win rate), Leaders (starting archetype and traits),
-	// Wonders (build timing and builder win rate), Yields (per-turn curves) and
-	// Casters (caster leaderboard) — spanning both stats
+	// Wonders (build timing and builder win rate), Families (capital family +
+	// per-nation picks), Yields (per-turn curves) and Casters (caster
+	// leaderboard) — spanning both stats
 	// subsystems: Plane A tournament-native (standings + casters) and Plane B1
 	// (the ChartBundle pointed at the tournament's games). Renders the charts
 	// directly (no chart registry) through the shared ChartContainer, reusing the
@@ -54,7 +55,6 @@
 	const startingArchetypes = $derived(data.games.startingArchetypeWinRate);
 	const startingTraits = $derived(data.games.startingTraitWinRate);
 	const wonders = $derived(data.games.wonderStats);
-	const capitalFamilies = $derived(data.games.capitalFamilyWinRate);
 
 	// Circular avatar images for the players/casters axis labels, rasterized
 	// client-side from the Discord CDN (ECharts rich-text labels can't round
@@ -253,13 +253,7 @@
 		     panel the player page uses, pointed at the tournament's games
 		     (Plane B1). -->
 		<Tabs.Content value="families">
-			{#if capitalFamilies.length > 0 || data.games.familyByNation.length > 0}
-				<FamilyStatsPanel bundle={data.games} />
-			{:else}
-				<p class="p-8 text-center italic text-tan opacity-60">
-					No completed games yet.
-				</p>
-			{/if}
+			<FamilyStatsPanel bundle={data.games} />
 		</Tabs.Content>
 
 		<!-- Yields — per-turn yield curves across the tournament's games

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -13,6 +13,7 @@
 	import ChartContainer from "$lib/ChartContainer.svelte";
 	import YieldsStatsPanel from "$lib/stats/YieldsStatsPanel.svelte";
 	import { barChartHeight } from "$lib/stats/charts/helpers";
+	import { capitalFamilyWinLossOption } from "$lib/stats/charts/families";
 	import {
 		ARCHETYPE_EMPTY_MESSAGE,
 		TRAIT_EMPTY_MESSAGE,
@@ -53,6 +54,7 @@
 	const startingArchetypes = $derived(data.games.startingArchetypeWinRate);
 	const startingTraits = $derived(data.games.startingTraitWinRate);
 	const wonders = $derived(data.games.wonderStats);
+	const capitalFamilies = $derived(data.games.capitalFamilyWinRate);
 
 	// Circular avatar images for the players/casters axis labels, rasterized
 	// client-side from the Discord CDN (ECharts rich-text labels can't round
@@ -96,6 +98,7 @@
 		"nations",
 		"leaders",
 		"wonders",
+		"families",
 		"yields",
 		"casters",
 	] as const;
@@ -131,6 +134,8 @@
 			<Tabs.Trigger value="nations" class={triggerClass}>Nations</Tabs.Trigger>
 			<Tabs.Trigger value="leaders" class={triggerClass}>Leaders</Tabs.Trigger>
 			<Tabs.Trigger value="wonders" class={triggerClass}>Wonders</Tabs.Trigger>
+			<Tabs.Trigger value="families" class={triggerClass}>Families</Tabs.Trigger
+			>
 			<Tabs.Trigger value="yields" class={triggerClass}>Yields</Tabs.Trigger>
 			<Tabs.Trigger value="casters" class={triggerClass}>Casters</Tabs.Trigger>
 		</Tabs.List>
@@ -238,6 +243,25 @@
 				{:else}
 					<p class="p-8 text-center italic text-tan opacity-60">
 						{WONDER_EMPTY_MESSAGE}
+					</p>
+				{/if}
+			</section>
+		</Tabs.Content>
+
+		<!-- Families — which family class ran each player's capital, the
+		     earliest of the family decisions (Plane B1). -->
+		<Tabs.Content value="families">
+			<section class="mb-8">
+				<h2 class="mb-3 text-base font-bold text-tan">Capital family</h2>
+				{#if capitalFamilies.length > 0}
+					<ChartContainer
+						option={capitalFamilyWinLossOption(data.games)}
+						height={barChartHeight(capitalFamilies.length)}
+						title="Capital family"
+					/>
+				{:else}
+					<p class="p-8 text-center italic text-tan opacity-60">
+						No completed games yet.
 					</p>
 				{/if}
 			</section>

--- a/src/routes/tournaments/[slug]/stats/+page.svelte
+++ b/src/routes/tournaments/[slug]/stats/+page.svelte
@@ -11,9 +11,9 @@
 	import { goto } from "$app/navigation";
 	import { page } from "$app/state";
 	import ChartContainer from "$lib/ChartContainer.svelte";
+	import FamilyStatsPanel from "$lib/stats/FamilyStatsPanel.svelte";
 	import YieldsStatsPanel from "$lib/stats/YieldsStatsPanel.svelte";
 	import { barChartHeight } from "$lib/stats/charts/helpers";
-	import { capitalFamilyWinLossOption } from "$lib/stats/charts/families";
 	import {
 		ARCHETYPE_EMPTY_MESSAGE,
 		TRAIT_EMPTY_MESSAGE,
@@ -248,23 +248,18 @@
 			</section>
 		</Tabs.Content>
 
-		<!-- Families — which family class ran each player's capital, the
-		     earliest of the family decisions (Plane B1). -->
+		<!-- Families — which class ran the capital, then which classes each
+		     nation's players run and the city footprint behind each. The same
+		     panel the player page uses, pointed at the tournament's games
+		     (Plane B1). -->
 		<Tabs.Content value="families">
-			<section class="mb-8">
-				<h2 class="mb-3 text-base font-bold text-tan">Capital family</h2>
-				{#if capitalFamilies.length > 0}
-					<ChartContainer
-						option={capitalFamilyWinLossOption(data.games)}
-						height={barChartHeight(capitalFamilies.length)}
-						title="Capital family"
-					/>
-				{:else}
-					<p class="p-8 text-center italic text-tan opacity-60">
-						No completed games yet.
-					</p>
-				{/if}
-			</section>
+			{#if capitalFamilies.length > 0 || data.games.familyByNation.length > 0}
+				<FamilyStatsPanel bundle={data.games} />
+			{:else}
+				<p class="p-8 text-center italic text-tan opacity-60">
+					No completed games yet.
+				</p>
+			{/if}
 		</Tabs.Content>
 
 		<!-- Yields — per-turn yield curves across the tournament's games


### PR DESCRIPTION
Three things about families, all on the same panel — which one runs the capital, how much of the empire each ends up holding and where it fell in the founding order, and (finally) any of this on the tournament stats page.

![families](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/stats-families-tournament.png)

## Capital family

Which of a player's three families runs the capital is a different question from which three they have: the capital is the city every early bonus compounds through. The existing panel only answered the latter.

New `player_summaries.capital_family_class` (migration 0035), derived from the blob's `is_capital` city and keyed on `owner_player_xml_id` so a mirror match can't credit one side with the other's capital, plus a stacked wins/losses bar — length is how often that class held the capital, the split how those games ended.

Across a 407-game public sample (805 human capitals) the spread is real: Traders **57%** (n=138) and Riders 52% at the top, Clerics **37%** (n=65) and Artisans 40% at the bottom.

## Family city footprint, and founding order

Knowing a player ran Hunters says nothing about whether they leaned on them. `player_family_cities` (migration 0036) records, per player and family class, how many end-of-game cities it held and when its first was founded. The bundle turns those into the mean share of the empire that class ran (on the bar) and, by ranking each player's families on that first-founding turn, how often it was their **1st / 2nd / 3rd** family (in the tooltip).

![tooltip](https://raw.githubusercontent.com/alcaras/per-ankh/pr-assets/stats-families-tooltip.png)

That split separates roles the pick count can't: Maurya's Sages are the 1st family 80% of the time, while Maurya's Riders are almost never first (0% / 75% / 25%).

## Two consistency fixes

- **The per-nation chart plotted pick rate and win rate as two independent percentage bars** — the only outcome chart in the catalog not using the shared stacked encoding (length = games, split = outcome). It now matches its siblings; the normalized pick rate moved into the tooltip beside the counts it already carried.
- **The tournament stats page never rendered families at all**, even though `familyByNation` has been in the bundle it already fetches (47 rows over 36 games on the live tournament). Rather than fork a second chart, `FamilyStatsPanel` and its option builders are typed against `ChartBundleCore` and the tournament page renders the same component the player page does. That also sets up the general rule that a stat on one stats surface should exist on the other.

## Testing

- 3 new unit tests for the capital-family derivation (reads the capital's class, ignores another player's capital, null when there's no capital or no family on it).
- `npm run lint`, `svelte-check`, `tsc` and the worker suite pass.
- Exercised end-to-end on 68 imported public games: 395 `player_family_cities` rows across 67 games, then the admin reindex sweep over all of them — the screenshots are that corpus.

## Notes for review

- Both new tables/columns backfill through the existing admin reindex sweep; no new operational surface.
- `BUNDLE_SCHEMA_VERSION` 5→6 — entries live 24h and the frontend dereferences the new fields directly.
- **Known limitation, stated in the code:** share and founding order come from the end-of-game city snapshot, so a family whose cities were all captured or razed contributes nothing, and "first founded" is the earliest *surviving* city. The save carries no intermediate ownership history to do better.
- Independent of #155 (leaders) and #157 (wonders); all three touch the stats registry, so whichever lands last takes a small rebase, which I'll handle.

Unrelated heads-up, still open: `cloud/src/tournament/canonical-map-options.test.ts` fails 4 tests on `main` (b39f690 re-baked `map-option-defs.ts` without the matching cloud-mirror entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
