### PR TITLE
perf(cloud): cache parsed-game blobs per-POP in front of R2

### DIFF
--- a/.claude/skills/admin-cli/SKILL.md
+++ b/.claude/skills/admin-cli/SKILL.md
@@ -54,7 +54,9 @@ Build a full local fixture (Swiss + championship via the real planner) with `./p
 ./per-ankh admin cache clear videos                                # Force a YouTube refetch
 ```
 
-Unlike the Worker's `invalidateStatsCache` (which walks only the current `BUNDLE_SCHEMA_VERSION`), `clear` sweeps every schema version under the prefix — that's what reaches entries orphaned by a version bump. Clearing `videos` costs YouTube Data API quota on the next playlist view. Edge-cached responses (`Cache-Control: s-maxage`) are a separate layer and are **not** touched.
+Unlike the Worker's `invalidateStatsCache` (which walks only the current `BUNDLE_SCHEMA_VERSION`), `clear` sweeps every schema version under the prefix — that's what reaches entries orphaned by a version bump. Clearing `videos` costs YouTube Data API quota on the next playlist view.
+
+**The parsed-game blob cache is a different layer and this command cannot reach it.** It caches R2 bytes for `games/{id}.json.gz` in each POP's Cache API storage (`cloud/src/blob-cache.ts`), which has no CLI surface — `wrangler` has no cache command, and zone purge can't address the keys because they're synthetic and belong to no zone. It also needs no operator action: the key carries the game's `parser_version`, so a reparse drifts the key and every POP misses at once. If a game somehow serves stale bytes anyway, that's the D1-batch-rollback path in `handleGameUpload` (the Worker evicts locally there) and the entry expires on its own within 24h. The `Cache-Control: s-maxage` directives on game responses are inert at the edge — Workers run before the cache, so nothing stores them (issue #150).
 
 ## Dev (local only)
 

--- a/cloud/src/blob-cache.ts
+++ b/cloud/src/blob-cache.ts
@@ -1,0 +1,126 @@
+// Per-POP Cache API tier in front of the R2 reads for `games/*`.
+//
+// Workers run *before* Cloudflare's edge cache, so a body built with
+// `new Response()` is never stored at the edge — the `s-maxage` directives on
+// the game routes constrain browsers and intermediaries only. Without a tier
+// here every blob read is a full round trip to the bucket's ENAM region, for
+// every viewer worldwide; R2 buckets are single-region and cannot be
+// replicated, so caching is the only lever available. See issue #150.
+//
+// This caches the *R2 object bytes*, not the HTTP response, and that choice is
+// what keeps the invalidation surface to a single path:
+//
+//   - Authorization is a fresh D1 read on every request, ahead of the R2 read
+//     (handleGameDetail, handleGameDownload, and both admin readers all check
+//     the games row first). The cache holds bytes, never a decision — so an
+//     is_public flip, linkTournamentMatch() forcing a game public, or a delete
+//     needs no invalidation at all: the gate re-evaluates and 404s/403s before
+//     the cache is ever consulted. That covers the admin CLI's out-of-band
+//     `wrangler r2 object delete` too, which drops the games row alongside the
+//     object (scripts/admin/commands/games.ts deleteGames).
+//   - The response body is the blob merged with D1 metadata (display_name,
+//     collection_id, user_nation, user_won, …) *after* the read, and
+//     stripOnlineIds runs per request. So metadata edits never stale an entry,
+//     and the PII strip is never cached in either direction.
+//
+// That leaves exactly one event that stales an entry: a re-import overwriting
+// the blob with fresh parser output. The key carries the game's parser_version
+// so that event *drifts the key* rather than needing a purge — see cacheKey.
+//
+// Only `games/*` reads go through here today. `saves/*` (the raw ZIP download)
+// deliberately does not — see the note at the R2 read in handleGameDownload.
+
+// Synthetic key origin — same idiom as the download rate-limit counter in
+// share-legacy.ts. R2 keys are `games/{id}.json.gz` where id is a nanoid(21)
+// over [A-Za-z0-9_-], so they're URL-path-safe as-is with no escaping.
+const CACHE_ORIGIN = "https://blob-cache.internal/r2/";
+
+// 24h, matching the stats bundle cache. The TTL is purely a retention knob
+// here, not a staleness bound (see cacheKey), and Cache API entries are evicted
+// under POP pressure well before expiry anyway — so a long TTL costs nothing
+// and is what gives a low-traffic game any chance of a second reader in the
+// same colo hitting a warm entry.
+const BLOB_CACHE_TTL_SECONDS = 24 * 60 * 60;
+
+// The game's parser_version is part of the key, mirroring the PARSER_VERSION
+// segment in stats/cache.ts (and the `updated_at` segment its tournament keys
+// use). A re-import is the only path that overwrites a blob in place, and it
+// only runs when the incoming parser_version is strictly newer
+// (compareSemver > 0 in handleGameUpload) — which then lands on the games row.
+// So the version advances exactly when the bytes change, the key drifts with
+// it, and every POP misses at once.
+//
+// That matters because Cache API entries are per-POP and don't replicate: a
+// delete() only clears the colo the Worker ran in, and zone purge can't reach
+// these keys at all (they're synthetic, so they belong to no zone). Key drift
+// is what makes reparse propagation global instead of local, which in turn is
+// what lets the TTL above be long.
+function cacheKey(r2Key: string, parserVersion: string): Request {
+	return new Request(`${CACHE_ORIGIN}p${parserVersion}/${r2Key}`, {
+		method: "GET",
+	});
+}
+
+// Uncached read. Returns null when the object is absent, which callers map to
+// their own BLOB_MISSING response.
+export async function readBlob(
+	bucket: R2Bucket,
+	r2Key: string,
+): Promise<ArrayBuffer | null> {
+	const obj = await bucket.get(r2Key);
+	return obj ? await obj.arrayBuffer() : null;
+}
+
+// Read an R2 object through the per-POP cache, filling it on a miss.
+//
+// Owners must NOT call this. Their response is `private, no-store` precisely so
+// a reload right after a reparse shows the new bytes, and an entry filled in
+// another POP would undercut that guarantee. Gating on isOwner also means
+// cached bytes are only ever read on the path that strips online_id.
+export async function getBlobCached(
+	bucket: R2Bucket,
+	r2Key: string,
+	parserVersion: string,
+	ctx: ExecutionContext,
+): Promise<ArrayBuffer | null> {
+	const cache = caches.default;
+	const key = cacheKey(r2Key, parserVersion);
+
+	const hit = await cache.match(key);
+	if (hit) return await hit.arrayBuffer();
+
+	const bytes = await readBlob(bucket, r2Key);
+	// A missing object isn't cached — negative caching would keep a game
+	// unreadable for the whole TTL after an operator restores a blob.
+	if (!bytes) return null;
+
+	// Cache-Control is what gives the entry its TTL. This response is only ever
+	// handed to the cache, never to a client, so it doesn't interact with the
+	// headers the handler builds. waitUntil keeps the fill off the response path.
+	ctx.waitUntil(
+		cache.put(
+			key,
+			new Response(bytes, {
+				headers: { "Cache-Control": `max-age=${BLOB_CACHE_TTL_SECONDS}` },
+			}),
+		),
+	);
+	return bytes;
+}
+
+// Best-effort eviction of the entry under the *outgoing* parser_version.
+//
+// Key drift (see cacheKey) already handles the successful re-import: nothing
+// reads the old key again. This covers the documented failure path instead —
+// if the D1 batch fails after the R2 put, handleGameUpload deliberately leaves
+// the new bytes in place and the old games row intact, so reads keep resolving
+// to the old key and are meant to render the fresher data. Without this the
+// stale entry would shadow those bytes for the full TTL.
+//
+// Per-POP, so it only clears the colo the Worker ran in; other colos age out.
+export async function invalidateBlob(
+	r2Key: string,
+	parserVersion: string,
+): Promise<void> {
+	await caches.default.delete(cacheKey(r2Key, parserVersion));
+}

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -48,6 +48,7 @@ import {
 	derivePlayerSummary,
 } from "./derive-player-summary";
 import { invalidateStatsCache } from "./stats/cache";
+import { getBlobCached, invalidateBlob, readBlob } from "./blob-cache";
 
 export interface GamesEnv extends SessionEnv {
 	SHARE_BUCKET: R2Bucket;
@@ -1733,6 +1734,23 @@ export async function handleGameUpload(
 		return errorResponse("Storage write failed", 500, cors, "R2_FAILED");
 	}
 
+	// Evict the blob-cache entry under the version this re-import supersedes.
+	// The successful case doesn't need it — the games row below takes the new
+	// parser_version, which drifts the cache key so every POP misses. This is
+	// for the failure path documented in the D1 batch's catch: if that batch
+	// rolls back, the old row (and so the old key) stays live while R2 already
+	// holds the new bytes, and the entry would otherwise shadow them.
+	//
+	// Outside the R2 try above and non-fatal — the bytes are already written,
+	// so an eviction hiccup mustn't fail an upload that succeeded.
+	if (isReimport && existingParserVersion !== undefined) {
+		try {
+			await invalidateBlob(blobKey, existingParserVersion);
+		} catch (e) {
+			logError("blob_cache_invalidate_failed", e, { game_id: gameId });
+		}
+	}
+
 	// D1 inserts as a single transactional batch. On re-import the games
 	// row uses INSERT OR REPLACE — REPLACE fires ON DELETE CASCADE on the
 	// child tables (player_summaries, game_player_turn, tech_events,
@@ -2299,6 +2317,9 @@ export async function handleGameDetail(
 	gameId: string,
 	request: Request,
 	env: GamesEnv,
+	// Carries the blob-cache fill on waitUntil so it stays off the response
+	// path — same reason the video cache takes it.
+	ctx: ExecutionContext,
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
 
@@ -2310,6 +2331,7 @@ export async function handleGameDetail(
 	// players-array fallback now that this query supplies a usable value.
 	const row = await env.SHARE_DB.prepare(
 		`SELECT g.user_id, g.is_public, g.display_name, g.user_won,
+		        g.parser_version,
 		        g.user_nation AS uploader_nation,
 		        COALESCE(g.user_nation, (
 		            SELECT ps.nation FROM player_summaries ps
@@ -2326,6 +2348,8 @@ export async function handleGameDetail(
 			user_id: string;
 			is_public: number;
 			display_name: string | null;
+			// Part of the blob cache key — see cacheKey in blob-cache.ts.
+			parser_version: string;
 			user_nation: string | null;
 			// Raw uploader choice (un-COALESCE'd) for the reparse round-trip;
 			// null = observer upload. Distinct from user_nation above, which
@@ -2387,14 +2411,21 @@ export async function handleGameDetail(
 		}
 	}
 
-	const obj = await env.SHARE_BUCKET.get(`games/${gameId}.json.gz`);
-	if (!obj) {
+	// Non-owner reads go through the per-POP blob cache (see blob-cache.ts):
+	// they're the repeat traffic, and they're the ones paying a full ENAM
+	// round trip on every view. Owners read R2 directly — their response is
+	// `private, no-store` so a reload right after a reparse must show the new
+	// bytes, which a cache entry filled in another POP would break.
+	const blobKey = `games/${gameId}.json.gz`;
+	const compressed = isOwner
+		? await readBlob(env.SHARE_BUCKET, blobKey)
+		: await getBlobCached(env.SHARE_BUCKET, blobKey, row.parser_version, ctx);
+	if (!compressed) {
 		return errorResponse("Blob missing", 404, cors, "BLOB_MISSING");
 	}
 
 	// Decompress in Worker — Cloudflare strips Content-Encoding from Worker
 	// responses, so we can't pass the compressed body through directly.
-	const compressed = await obj.arrayBuffer();
 	const decompressed = await decompressWithLimit(
 		compressed,
 		MAX_BLOB_DECOMPRESSED,
@@ -2800,6 +2831,11 @@ export async function handleGameDownload(
 		);
 	}
 
+	// Deliberately NOT routed through the blob cache (unlike the parsed blob in
+	// handleGameDetail). Caching means buffering or teeing the body, which
+	// costs the streaming guarantee below at the 50MB ceiling — and downloads
+	// are an explicit, rate-limited user action, not the repeat traffic the
+	// cache exists for. See cloud/src/blob-cache.ts.
 	const obj = await env.SHARE_BUCKET.get(`saves/${gameId}.zip`);
 	if (!obj) return errorResponse("Save missing", 404, cors, "BLOB_MISSING");
 

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -3173,11 +3173,17 @@ export async function handleAdminReindex(
 		.first<{ player_index: number }>();
 	const uploaderIndex = uploaderRow?.player_index ?? null;
 
-	// Read + decompress the parsed blob (same path as the detail endpoint).
-	const obj = await env.SHARE_BUCKET.get(`games/${gameId}.json.gz`);
-	if (!obj) return errorResponse("Blob missing", 404, cors, "BLOB_MISSING");
+	// Read + decompress the parsed blob. Uncached, like the owner branch of the
+	// detail endpoint — a rebuild has to read the bytes R2 holds now.
+	const compressed = await readBlob(
+		env.SHARE_BUCKET,
+		`games/${gameId}.json.gz`,
+	);
+	if (!compressed) {
+		return errorResponse("Blob missing", 404, cors, "BLOB_MISSING");
+	}
 	const decompressed = await decompressWithLimit(
-		await obj.arrayBuffer(),
+		compressed,
 		MAX_BLOB_DECOMPRESSED,
 	);
 	const blob = JSON.parse(

--- a/cloud/src/index.ts
+++ b/cloud/src/index.ts
@@ -264,7 +264,8 @@ const ROUTES: RouteSpec[] = [
 		method: "GET",
 		match: { kind: "regex", regex: /^\/v1\/games\/([A-Za-z0-9_-]{21})$/ },
 		route: "GET /v1/games/:id",
-		handler: (r, e, m) => handleGameDetail(m![1], r, e),
+		// Passes ctx so the per-POP blob cache can fill in the background.
+		handler: (r, e, m, c) => handleGameDetail(m![1], r, e, c),
 	},
 	{
 		method: "GET",

--- a/cloud/test/integration/games/blob-cache.test.ts
+++ b/cloud/test/integration/games/blob-cache.test.ts
@@ -1,0 +1,224 @@
+// Integration tests for the per-POP blob cache in front of the R2 read on
+// GET /v1/games/:id (cloud/src/blob-cache.ts, issue #150).
+//
+// The tier is invisible from the response body, so each test proves it by
+// deleting the R2 object out from under the handler while leaving the games
+// row intact, then re-reading:
+//   - served from cache  → still 200
+//   - not cached (owner) → 404 BLOB_MISSING
+//
+// That same trick pins the design's load-bearing property: authorization is
+// re-read from D1 on every request, ahead of the cache, so a cached entry can
+// never outlive the permission to read it.
+
+import { applyD1Migrations, env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
+import { expectErrorCode, expectOk } from "../../helpers/assertions";
+import { makeUser, type TestUser } from "../../helpers/builders";
+import { request } from "../../helpers/requests";
+
+beforeAll(async () => {
+	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
+});
+
+// Minimal FullGameData-shaped blob. handleGameDetail only JSON-parses it and
+// spreads D1 metadata over the top, so the parser-level shape doesn't matter
+// here — player_roster carries an online_id so the PII strip is exercised.
+function makeBlob(gameName: string): Record<string, unknown> {
+	return {
+		match_metadata: { game_name: gameName, winner: null },
+		player_roster: [{ player_index: 0, online_id: "STEAM_SECRET" }],
+	};
+}
+
+async function putBlob(
+	gameId: string,
+	blob: Record<string, unknown>,
+): Promise<void> {
+	const gz = new Response(
+		new Response(JSON.stringify(blob)).body!.pipeThrough(
+			new CompressionStream("gzip"),
+		),
+	);
+	await env.SHARE_BUCKET.put(
+		`games/${gameId}.json.gz`,
+		await gz.arrayBuffer(),
+		{ httpMetadata: { contentType: "application/json" } },
+	);
+}
+
+async function seedGame(
+	user: TestUser,
+	opts: { isPublic: boolean; gameName?: string },
+): Promise<string> {
+	const gameId = nanoid(21);
+	await env.SHARE_DB.prepare(
+		`INSERT INTO games (
+			game_id, user_id, xml_game_id, total_turns, file_hash,
+			game_name, is_public, blob_version, blob_size_bytes, parser_version
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 2, 1024, '1.0.0')`,
+	)
+		.bind(
+			gameId,
+			user.userId,
+			nanoid(36),
+			50,
+			nanoid(64),
+			opts.gameName ?? "Test Game",
+			opts.isPublic ? 1 : 0,
+		)
+		.run();
+	await putBlob(gameId, makeBlob(opts.gameName ?? "Test Game"));
+	return gameId;
+}
+
+interface DetailBody {
+	match_metadata: { game_name: string };
+	player_roster: { online_id: string | null }[];
+	display_name: string | null;
+}
+
+describe("blob cache on GET /v1/games/:id", () => {
+	it("serves an anonymous re-read from cache after the R2 object is gone", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		// Cold: fills the cache.
+		await expectOk(await request.get({ path: `/v1/games/${gameId}` }));
+
+		// Pull the object out of R2. D1 row stays, so the auth gate still
+		// passes and the read falls to the cache.
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		const warm = await expectOk<DetailBody>(
+			await request.get({ path: `/v1/games/${gameId}` }),
+		);
+		expect(warm.match_metadata.game_name).toBe("Test Game");
+	});
+
+	it("still strips online_id when the bytes come from cache", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		await expectOk(await request.get({ path: `/v1/games/${gameId}` }));
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		// The cache holds raw blob bytes; stripOnlineIds runs per request on
+		// the parsed result, so a hit must be just as stripped as a miss.
+		// The key survives with a null value — see stripOnlineIdsDeep.
+		const warm = await expectOk<DetailBody>(
+			await request.get({ path: `/v1/games/${gameId}` }),
+		);
+		expect(warm.player_roster[0].online_id).toBeNull();
+	});
+
+	it("does not cache the owner's read", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		const first = await expectOk<DetailBody>(
+			await request.get({ path: `/v1/games/${gameId}`, as: owner }),
+		);
+		// Owners keep online_id — confirms this really is the owner path.
+		expect(first.player_roster[0].online_id).toBe("STEAM_SECRET");
+
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		// `private, no-store` means a post-reparse reload must see fresh bytes,
+		// so the owner path must never read through the cache.
+		await expectErrorCode(
+			await request.get({ path: `/v1/games/${gameId}`, as: owner }),
+			{ status: 404, code: "BLOB_MISSING" },
+		);
+	});
+
+	it("re-authorizes from D1, so a private flip is not served from cache", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		// Warm the cache as an anonymous viewer.
+		await expectOk(await request.get({ path: `/v1/games/${gameId}` }));
+
+		// Flip to private with no cache invalidation anywhere — the whole
+		// point of caching bytes rather than the response.
+		await env.SHARE_DB.prepare(
+			"UPDATE games SET is_public = 0 WHERE game_id = ?",
+		)
+			.bind(gameId)
+			.run();
+
+		await expectErrorCode(await request.get({ path: `/v1/games/${gameId}` }), {
+			status: 401,
+			code: "UNAUTHORIZED",
+		});
+	});
+
+	it("re-authorizes from D1, so a deleted game is not served from cache", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		await expectOk(await request.get({ path: `/v1/games/${gameId}` }));
+
+		// Mirrors the admin CLI's out-of-band delete: the games row goes away
+		// alongside the R2 object, with no in-Worker hook to invalidate.
+		await env.SHARE_DB.prepare("DELETE FROM games WHERE game_id = ?")
+			.bind(gameId)
+			.run();
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		await expectErrorCode(await request.get({ path: `/v1/games/${gameId}` }), {
+			status: 404,
+			code: "NOT_FOUND",
+		});
+	});
+
+	it("drifts the key when parser_version advances, so a reparse can't serve stale bytes", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+
+		// Warm the cache at the seeded version.
+		await expectOk(await request.get({ path: `/v1/games/${gameId}` }));
+
+		// A re-import overwrites the blob and lands a strictly-newer
+		// parser_version on the games row. Bumping the row alone is enough to
+		// prove the key moved: with the old key still in play the deleted R2
+		// object would be papered over by the warm entry.
+		await env.SHARE_DB.prepare(
+			"UPDATE games SET parser_version = '2.0.0' WHERE game_id = ?",
+		)
+			.bind(gameId)
+			.run();
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		await expectErrorCode(await request.get({ path: `/v1/games/${gameId}` }), {
+			status: 404,
+			code: "BLOB_MISSING",
+		});
+
+		// And the new version caches independently of the orphaned entry.
+		await putBlob(gameId, makeBlob("Reparsed"));
+		const fresh = await expectOk<DetailBody>(
+			await request.get({ path: `/v1/games/${gameId}` }),
+		);
+		expect(fresh.match_metadata.game_name).toBe("Reparsed");
+	});
+
+	it("does not negative-cache a missing blob", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		await env.SHARE_BUCKET.delete(`games/${gameId}.json.gz`);
+
+		await expectErrorCode(await request.get({ path: `/v1/games/${gameId}` }), {
+			status: 404,
+			code: "BLOB_MISSING",
+		});
+
+		// Restoring the object must take effect immediately, not after a TTL.
+		await putBlob(gameId, makeBlob("Restored"));
+		const restored = await expectOk<DetailBody>(
+			await request.get({ path: `/v1/games/${gameId}` }),
+		);
+		expect(restored.match_metadata.game_name).toBe("Restored");
+	});
+});

--- a/scripts/admin/commands/cache.ts
+++ b/scripts/admin/commands/cache.ts
@@ -8,6 +8,15 @@
 // invalidateStatsCache in the Worker walks only `stats:v{BUNDLE_SCHEMA_VERSION}`,
 // leaving entries orphaned by a version bump to age out over 24h. Sweeping
 // those is the point of an operator command.
+//
+// Scope note: the parsed-game blob cache (cloud/src/blob-cache.ts) is NOT
+// reachable from here, and can't be. It lives in each POP's Cache API storage
+// rather than KV — wrangler has no cache command, and zone purge can't address
+// the keys because they're synthetic and belong to no zone. It also doesn't
+// need an operator lever: the cache key carries the game's parser_version, so a
+// reparse drifts the key and every POP misses at once. Stale bytes despite that
+// mean the D1-batch-rollback path in handleGameUpload, which the Worker evicts
+// locally, and which expires on its own inside 24h.
 
 import { kvBulkDelete, kvList, type KvKey } from "../wrangler";
 import { confirmTyping } from "../../lib/confirm";
@@ -80,6 +89,12 @@ function printHelp(): void {
 			"",
 			"Only the stats: and videos: prefixes are reachable — session: and",
 			"oauth: keys share the namespace and are never touched.",
+			"",
+			"The parsed-game blob cache is a separate layer and is NOT reachable",
+			"here: it lives in each POP's Cache API storage, which has no CLI or",
+			"purge surface. It needs no operator action — a reparse advances the",
+			"game's parser_version, which drifts the cache key so every POP misses.",
+			"Anything still stale expires within 24h. See cloud/src/blob-cache.ts.",
 			"",
 		].join("\n"),
 	);


### PR DESCRIPTION
Addresses the non-US blob-read latency in #150.

## The problem

`per-ankh-shares` is in ENAM, R2 buckets are single-region, and Cloudflare has no cross-region replication — so caching is the only lever. But there was nothing to tune: **Workers run before the edge cache**, so a response built with `new Response()` is never stored, and the `s-maxage` directives already on these routes only ever constrained browsers. Every `SHARE_BUCKET.get()` was a full ENAM round trip, for every viewer, worldwide.

## The approach

Cache the **R2 object bytes**, not the HTTP response. That choice is what keeps the invalidation surface to one path instead of the seven #150 enumerated.

Both public readers take a fresh D1 row read *before* the R2 read, and the response body is the blob with D1 metadata (`display_name`, `collection_id`, `user_nation`, …) merged in *after* it, with `stripOnlineIds` running per request. So the cache holds bytes and never a decision:

- **Visibility flips** — `is_public` PATCH, `linkTournamentMatch()` forcing public (including the dedup-hit branch that writes no R2 at all) — need no invalidation. The gate re-evaluates and 403/401s before the cache is consulted.
- **Deletes** likewise, including the admin CLI's out-of-band `wrangler r2 object delete`: it drops the games row alongside the object, so the cached bytes become unreachable.
- **Metadata edits** never stale an entry, because they're merged post-read.

That leaves the re-import overwrite, and the cache key handles it structurally.

## Key drift instead of purge

The key carries the game's `parser_version`, mirroring the `PARSER_VERSION` segment in `stats/cache.ts`. A re-import is the only path that overwrites a blob in place, it only runs on a strictly-newer version (`compareSemver > 0`), and that version lands on the games row — so the key drifts exactly when the bytes change, and **every POP misses at once** rather than only the colo that ran the upload.

This matters because Cache API entries are per-POP and don't replicate, and zone purge can't reach these keys at all (synthetic, so they belong to no zone). Key drift makes reparse propagation global, which is what lets the TTL be **24h** — and at this request volume, a long TTL is what gives a distant colo any chance of a second reader landing on a warm entry.

One explicit eviction survives, keyed on the *outgoing* version: if the D1 batch rolls back after the R2 put, `handleGameUpload` deliberately keeps the new bytes with the old row and intends the old row to render them. Without it a warm entry would shadow those bytes for the full TTL.

## Deliberate exclusions

- **Owners bypass the cache.** Their response is `private, no-store` specifically so a reload right after a reparse shows the new bytes. Side benefit: cached bytes are only ever read on the path that strips `online_id`.
- **`saves/{id}.zip` is not cached.** It streams straight from R2 today; caching means buffering or teeing, which costs that memory-safety guarantee at the 50 MB ceiling — for an explicit, rate-limited user action rather than the repeat traffic the cache exists for. Recorded at the read site.

## Not covered by this PR

#150's other opportunities are untouched, so this **refs** rather than closes it: the ZIP path (#1), `GET /v1/games/public-recent` (#3), and the legacy `/v1/share/:id` viewer (#4).

Also worth flagging: there's still no runtime instrumentation separating the R2 hop from the D1 queries that run serially ahead of it (D1 is ENAM-primary too — #149). `setLogField()` plus the `cf_ray` colo suffix already in the access log would answer that, and would show real hit/miss rates. Not in scope here.

## Testing

7 new integration tests in `cloud/test/integration/games/blob-cache.test.ts`. Since the tier is invisible from the response body, each proves itself by deleting the R2 object while leaving the games row intact — a cached read still 200s, an owner read 404s. Three pin the load-bearing design claim directly: an `is_public` flip 401s, a deleted game 404s, and a restored blob is visible immediately, all with **zero** cache invalidation anywhere. One pins key drift: bumping `parser_version` on the row orphans the warm entry.

Full `cloud` suite 337/337 across 45 files, `tsc --noEmit` clean, lint and prettier clean.