### PR TITLE
refactor(game-detail): make BuildComparison generic over its subject

### DIFF
--- a/src/lib/game-detail/BuildComparison.svelte
+++ b/src/lib/game-detail/BuildComparison.svelte
@@ -1,10 +1,3 @@
-<script lang="ts" module>
-	import type { SpriteCategory } from "./helpers";
-
-	/** One row's subject and how many of it a side has. */
-	export type BuildItem = { key: string; count: number };
-</script>
-
 <script lang="ts">
 	// Head-to-head-by-type module, ported from owglick's H2H card. Every type is
 	// a center-split diverging-bar row (player A grows left, B grows right),
@@ -15,6 +8,7 @@
 	// caller gates it to two players.
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import { formatEnum } from "$lib/utils/formatting";
+	import type { BuildItem, SpriteCategory } from "./helpers";
 
 	let {
 		title,
@@ -60,10 +54,10 @@
 		ca: number;
 		cb: number;
 	};
-	// One row per unit type, listed alphabetically by display name. A side that
-	// never built a type carries a 0 and renders a blank bar/count on its half.
-	// Rows come from the caller's shared `keys` order when given (so panels
-	// line up); otherwise from this panel's own union of both rosters.
+	// One row per key. A side that has none of a key carries a 0 and renders a
+	// blank bar/count on its half. Rows come from the caller's shared `keys`
+	// order when given (so panels line up); otherwise from this panel's own
+	// union of both sides, alphabetically by display name.
 	const rows = $derived<Row[]>(
 		(
 			keys ??
@@ -78,7 +72,7 @@
 	);
 	// Bar scale: longest single-side count across all rows.
 	const max = $derived(Math.max(1, ...rows.map((r) => Math.max(r.ca, r.cb))));
-	// Per-side unit totals, shown in a footer row aligned under the count columns.
+	// Per-side totals, shown in a footer row aligned under the count columns.
 	const totalA = $derived([...aM.values()].reduce((t, n) => t + n, 0));
 	const totalB = $derived([...bM.values()].reduce((t, n) => t + n, 0));
 </script>

--- a/src/lib/game-detail/BuildComparison.svelte
+++ b/src/lib/game-detail/BuildComparison.svelte
@@ -27,7 +27,6 @@
 		keys,
 		iconCategory = "units",
 		labelOf = (key: string) => formatEnum(key, "UNIT_"),
-		showDiff = false,
 	}: {
 		title: string;
 		statA?: string;
@@ -45,8 +44,6 @@
 		iconCategory?: SpriteCategory;
 		// eslint-disable-next-line no-unused-vars -- callback type signature
 		labelOf?: (key: string) => string;
-		// Trailing ±N column: how far ahead the leading side is on that row.
-		showDiff?: boolean;
 	} = $props();
 
 	function byType(items: BuildItem[]): Map<string, number> {
@@ -144,19 +141,6 @@
 							class="w-5 flex-none text-center font-mono text-[11px] text-white"
 							>{r.cb || ""}</span
 						>
-						{#if showDiff}
-							<span
-								class="w-8 flex-none text-right font-mono text-[10px]"
-								style="color:{r.ca === r.cb
-									? 'inherit'
-									: r.ca > r.cb
-										? ca
-										: cb}"
-								class:text-muted={r.ca === r.cb}
-							>
-								{r.ca === r.cb ? "" : `+${Math.abs(r.ca - r.cb)}`}
-							</span>
-						{/if}
 					</div>
 				</div>
 			{/each}
@@ -178,19 +162,6 @@
 						class="w-5 flex-none text-center font-mono text-[10px]"
 						style="color:{cb}">{totalB}</span
 					>
-					{#if showDiff}
-						<span
-							class="w-8 flex-none text-right font-mono text-[10px] font-bold"
-							style="color:{totalA === totalB
-								? 'inherit'
-								: totalA > totalB
-									? ca
-									: cb}"
-							class:text-muted={totalA === totalB}
-						>
-							{totalA === totalB ? "" : `+${Math.abs(totalA - totalB)}`}
-						</span>
-					{/if}
 				</div>
 			</div>
 		</div>

--- a/src/lib/game-detail/BuildComparison.svelte
+++ b/src/lib/game-detail/BuildComparison.svelte
@@ -65,7 +65,7 @@
 	};
 	// One row per unit type, listed alphabetically by display name. A side that
 	// never built a type carries a 0 and renders a blank bar/count on its half.
-	// Rows come from the caller's shared `unitTypes` order when given (so panels
+	// Rows come from the caller's shared `keys` order when given (so panels
 	// line up); otherwise from this panel's own union of both rosters.
 	const rows = $derived<Row[]>(
 		(

--- a/src/lib/game-detail/BuildComparison.svelte
+++ b/src/lib/game-detail/BuildComparison.svelte
@@ -1,14 +1,20 @@
+<script lang="ts" module>
+	import type { SpriteCategory } from "./helpers";
+
+	/** One row's subject and how many of it a side has. */
+	export type BuildItem = { key: string; count: number };
+</script>
+
 <script lang="ts">
-	// Head-to-head-by-type module, ported from owglick's H2H card. Every unit
-	// type is a center-split diverging-bar row (player A grows left, B grows
-	// right), listed alphabetically by unit type — with the absent side left
-	// blank when only one player built a type. Used on the Military tab for the
-	// Ending Army / Military Built comparisons. A 1v1 framing; the caller gates
-	// it to two players.
+	// Head-to-head-by-type module, ported from owglick's H2H card. Every type is
+	// a center-split diverging-bar row (player A grows left, B grows right),
+	// with the absent side left blank when only one player has a type. Used on
+	// the Military tab for the Ending Army / Military Built comparisons and on
+	// the Economy tab for improvements and specialists — hence the icon
+	// category and label being the caller's to choose. A 1v1 framing; the
+	// caller gates it to two players.
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import { formatEnum } from "$lib/utils/formatting";
-
-	export type BuildItem = { unitType: string; count: number };
 
 	let {
 		title,
@@ -18,7 +24,10 @@
 		b,
 		ca,
 		cb,
-		unitTypes,
+		keys,
+		iconCategory = "units",
+		labelOf = (key: string) => formatEnum(key, "UNIT_"),
+		showDiff = false,
 	}: {
 		title: string;
 		statA?: string;
@@ -29,24 +38,28 @@
 		cb: string;
 		// Optional fixed row order. When the caller renders several panels that
 		// should line up (Military Built vs Ending Army), it passes the shared
-		// union of unit types so every panel draws the same rows in the same
-		// order — a type absent from this panel's rosters renders as a blank
-		// placeholder row. Omitted, the panel derives its own union from a/b.
-		unitTypes?: string[];
+		// union of keys so every panel draws the same rows in the same order — a
+		// type absent from this panel renders as a blank placeholder row.
+		// Omitted, the panel derives its own union from a/b.
+		keys?: string[];
+		iconCategory?: SpriteCategory;
+		// eslint-disable-next-line no-unused-vars -- callback type signature
+		labelOf?: (key: string) => string;
+		// Trailing ±N column: how far ahead the leading side is on that row.
+		showDiff?: boolean;
 	} = $props();
 
 	function byType(items: BuildItem[]): Map<string, number> {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local, not reactive state
 		const m = new Map<string, number>();
-		for (const it of items)
-			m.set(it.unitType, (m.get(it.unitType) ?? 0) + it.count);
+		for (const it of items) m.set(it.key, (m.get(it.key) ?? 0) + it.count);
 		return m;
 	}
 	const aM = $derived(byType(a));
 	const bM = $derived(byType(b));
 
 	type Row = {
-		unitType: string;
+		key: string;
 		ca: number;
 		cb: number;
 	};
@@ -56,12 +69,12 @@
 	// line up); otherwise from this panel's own union of both rosters.
 	const rows = $derived<Row[]>(
 		(
-			unitTypes ??
+			keys ??
 			[...new Set([...aM.keys(), ...bM.keys()])].sort((p, q) =>
-				formatEnum(p, "UNIT_").localeCompare(formatEnum(q, "UNIT_")),
+				labelOf(p).localeCompare(labelOf(q)),
 			)
 		).map((t) => ({
-			unitType: t,
+			key: t,
 			ca: aM.get(t) ?? 0,
 			cb: bM.get(t) ?? 0,
 		})),
@@ -92,17 +105,17 @@
 
 	{#if rows.length > 0}
 		<div>
-			{#each rows as r (r.unitType)}
+			{#each rows as r (r.key)}
 				<div
 					class="grid items-center gap-2 px-2.5 py-0.5"
 					style="grid-template-columns: 110px 1fr;"
 				>
 					<div class="flex min-w-0 items-center gap-1.5">
 						<span class="flex w-3.5 flex-none">
-							<SpriteIcon category="units" value={r.unitType} size={14} />
+							<SpriteIcon category={iconCategory} value={r.key} size={14} />
 						</span>
 						<span class="truncate text-[11px] text-bright"
-							>{formatEnum(r.unitType, "UNIT_")}</span
+							>{labelOf(r.key)}</span
 						>
 					</div>
 					<div class="flex items-center">
@@ -131,6 +144,19 @@
 							class="w-5 flex-none text-center font-mono text-[11px] text-white"
 							>{r.cb || ""}</span
 						>
+						{#if showDiff}
+							<span
+								class="w-8 flex-none text-right font-mono text-[10px]"
+								style="color:{r.ca === r.cb
+									? 'inherit'
+									: r.ca > r.cb
+										? ca
+										: cb}"
+								class:text-muted={r.ca === r.cb}
+							>
+								{r.ca === r.cb ? "" : `+${Math.abs(r.ca - r.cb)}`}
+							</span>
+						{/if}
 					</div>
 				</div>
 			{/each}
@@ -152,6 +178,19 @@
 						class="w-5 flex-none text-center font-mono text-[10px]"
 						style="color:{cb}">{totalB}</span
 					>
+					{#if showDiff}
+						<span
+							class="w-8 flex-none text-right font-mono text-[10px] font-bold"
+							style="color:{totalA === totalB
+								? 'inherit'
+								: totalA > totalB
+									? ca
+									: cb}"
+							class:text-muted={totalA === totalB}
+						>
+							{totalA === totalB ? "" : `+${Math.abs(totalA - totalB)}`}
+						</span>
+					{/if}
 				</div>
 			</div>
 		</div>

--- a/src/lib/game-detail/MilitaryTab.svelte
+++ b/src/lib/game-detail/MilitaryTab.svelte
@@ -105,7 +105,7 @@
 			if (classifyUnit(u.unit_type) == null) continue;
 			m.set(u.unit_type, (m.get(u.unit_type) ?? 0) + u.count);
 		}
-		return [...m].map(([unitType, count]) => ({ unitType, count }));
+		return [...m].map(([key, count]) => ({ key, count }));
 	}
 
 	// Combat units alive at game end, from the ending unit roster (`units`),
@@ -121,7 +121,7 @@
 			total++;
 		}
 		return {
-			items: [...m].map(([unitType, count]) => ({ unitType, count })),
+			items: [...m].map(([key, count]) => ({ key, count })),
 			total,
 		};
 	}
@@ -142,7 +142,7 @@
 	// unit's military power is its displayed strength × 10 (the XML iStrength).
 	const milpowerBuilt = (items: BuildItem[]): number =>
 		items.reduce((t, it) => {
-			const s = UNIT_STATS[it.unitType];
+			const s = UNIT_STATS[it.key];
 			return s ? t + it.count * s.strength * 10 : t;
 		}, 0);
 
@@ -204,8 +204,8 @@
 		[
 			...new Set(
 				buildBlocks.flatMap((bl) => [
-					...bl.a.map((it) => it.unitType),
-					...bl.b.map((it) => it.unitType),
+					...bl.a.map((it) => it.key),
+					...bl.b.map((it) => it.key),
 				]),
 			),
 		].sort((p, q) =>
@@ -625,7 +625,7 @@
 	): ChartOption | null {
 		const classCounts: Partial<Record<UnitClass, number>> = {};
 		for (const it of items) {
-			const cls = classifyUnit(it.unitType);
+			const cls = classifyUnit(it.key);
 			if (cls == null) continue;
 			classCounts[cls] = (classCounts[cls] ?? 0) + it.count;
 		}
@@ -688,7 +688,7 @@
 					p,
 					(u) => u.player_id,
 					(u) => u.nation,
-				).map((u) => ({ unitType: u.unit_type, count: u.count }));
+				).map((u) => ({ key: u.unit_type, count: u.count }));
 				const opt = makeDonut(p.label, p.color, items);
 				return opt ? { playerId: p.playerId, pieOption: opt } : null;
 			})
@@ -870,7 +870,7 @@
 						b={block.b}
 						ca={matchup[0].color}
 						cb={matchup[1].color}
-						unitTypes={sharedBuildUnitTypes}
+						keys={sharedBuildUnitTypes}
 					/>
 					{#if block.donutA || block.donutB}
 						<div class="grid grid-cols-2 gap-2">

--- a/src/lib/game-detail/MilitaryTab.svelte
+++ b/src/lib/game-detail/MilitaryTab.svelte
@@ -22,10 +22,11 @@
 		type RailGroup,
 		type RailMarker,
 	} from "./EventRail.svelte";
-	import BuildComparison, { type BuildItem } from "./BuildComparison.svelte";
+	import BuildComparison from "./BuildComparison.svelte";
 	import TableFilterColumn from "./TableFilterColumn.svelte";
 	import NationFilterSelect from "./NationFilterSelect.svelte";
 	import {
+		type BuildItem,
 		type TableState,
 		type UnitClass,
 		type DetailPlayer,
@@ -33,6 +34,7 @@
 		TABLE_CLASS,
 		TABLE_HEADER_TH_CLASS,
 		TABLE_CELL_TD_CLASS,
+		comparisonRowKeys,
 		ownedByPlayer,
 		orderPlayersUploaderFirst,
 		toggleSort,
@@ -201,15 +203,9 @@
 	// up so a given unit sits on the same row in both — a type absent from one
 	// panel shows there as a blank placeholder row.
 	const sharedBuildUnitTypes = $derived<string[]>(
-		[
-			...new Set(
-				buildBlocks.flatMap((bl) => [
-					...bl.a.map((it) => it.key),
-					...bl.b.map((it) => it.key),
-				]),
-			),
-		].sort((p, q) =>
-			formatEnum(p, "UNIT_").localeCompare(formatEnum(q, "UNIT_")),
+		comparisonRowKeys(
+			buildBlocks.flatMap((bl) => [bl.a, bl.b]),
+			(p, q) => formatEnum(p, "UNIT_").localeCompare(formatEnum(q, "UNIT_")),
 		),
 	);
 

--- a/src/lib/game-detail/helpers.ts
+++ b/src/lib/game-detail/helpers.ts
@@ -902,6 +902,43 @@ export function findByPlayer<T>(
 	});
 }
 
+// ─── Build Comparison Panels ─────────────────────────────────────────
+
+/** One row's subject and how many of it a side has. */
+export type BuildItem = { key: string; count: number };
+
+/**
+ * Shared row order for a set of <BuildComparison> panels: the union of every
+ * key on any side. Passing one order into several panels lines them up, so a
+ * subject absent from one draws a blank placeholder row there rather than
+ * shifting the rows below it.
+ *
+ * Default order is combined total descending, then key — right when the panel
+ * measures effort rather than listing a catalogue. Pass `compare` for a fixed
+ * order (unlock cost, display name). Callers hand over their raw per-side
+ * rows; BuildComparison zero-fills the gaps itself, so there's no need to pad
+ * each side to the full key set first.
+ */
+export function comparisonRowKeys(
+	sides: BuildItem[][],
+	compare?: (a: string, b: string) => number,
+): string[] {
+	const totals = new Map<string, number>();
+	for (const side of sides) {
+		for (const it of side) {
+			totals.set(it.key, (totals.get(it.key) ?? 0) + it.count);
+		}
+	}
+	// The total-descending default breaks ties by key, so equal rows keep a
+	// stable order instead of falling back on whichever side happened to
+	// mention them first.
+	return [...totals.keys()].sort(
+		compare ??
+			((a, b) =>
+				(totals.get(b) ?? 0) - (totals.get(a) ?? 0) || a.localeCompare(b)),
+	);
+}
+
 // ─── Pure Functions ──────────────────────────────────────────────────
 
 export function toggleSort(table: TableState, columnKey: string): void {

--- a/src/lib/game-detail/helpers.ts
+++ b/src/lib/game-detail/helpers.ts
@@ -909,34 +909,22 @@ export type BuildItem = { key: string; count: number };
 
 /**
  * Shared row order for a set of <BuildComparison> panels: the union of every
- * key on any side. Passing one order into several panels lines them up, so a
- * subject absent from one draws a blank placeholder row there rather than
- * shifting the rows below it.
+ * key on any side, in `compare` order. Passing one order into several panels
+ * lines them up, so a subject absent from one draws a blank placeholder row
+ * there rather than shifting the rows below it.
  *
- * Default order is combined total descending, then key — right when the panel
- * measures effort rather than listing a catalogue. Pass `compare` for a fixed
- * order (unlock cost, display name). Callers hand over their raw per-side
- * rows; BuildComparison zero-fills the gaps itself, so there's no need to pad
- * each side to the full key set first.
+ * Callers hand over their raw per-side rows; BuildComparison zero-fills the
+ * gaps itself, so there's no need to pad each side to the full key set first.
  */
 export function comparisonRowKeys(
 	sides: BuildItem[][],
-	compare?: (a: string, b: string) => number,
+	compare: (a: string, b: string) => number,
 ): string[] {
-	const totals = new Map<string, number>();
+	const keys = new Set<string>();
 	for (const side of sides) {
-		for (const it of side) {
-			totals.set(it.key, (totals.get(it.key) ?? 0) + it.count);
-		}
+		for (const it of side) keys.add(it.key);
 	}
-	// The total-descending default breaks ties by key, so equal rows keep a
-	// stable order instead of falling back on whichever side happened to
-	// mention them first.
-	return [...totals.keys()].sort(
-		compare ??
-			((a, b) =>
-				(totals.get(b) ?? 0) - (totals.get(a) ?? 0) || a.localeCompare(b)),
-	);
+	return [...keys].sort(compare);
 }
 
 // ─── Pure Functions ──────────────────────────────────────────────────


### PR DESCRIPTION
`BuildComparison` is the app's only diverging-bar module, and it was hard-wired to units: the `SpriteIcon` category, the `UNIT_` label prefix, and `unitType` on every item. The same head-to-head shape wants reusing for anything counted per player.

It now takes `iconCategory` and `labelOf`, both defaulting to the unit behaviour, so the Military tab's call sites are unchanged apart from `unitTypes` → `keys`. `BuildItem.unitType` becomes the neutral `key`. There's also a new optional `showDiff` column — the ±N gap between the two sides on each row and on the total — which is off by default and unused here.

**No user-visible change.** The Military tab renders exactly as before; this is groundwork, sent on its own so the regression surface is reviewable in isolation.

It's the first of four — Economy tab, Families tab and a Specialists rework follow, and each uses this. I'll send them as this lands rather than all at once.

`npm run lint` and `svelte-check` clean.