### PR TITLE
feat(game-detail): specialist coverage split by slot kind, and a side-by-side view

### DIFF
--- a/scripts/bake-specialists.ts
+++ b/scripts/bake-specialists.ts
@@ -17,9 +17,15 @@
 //                                          (EFFECTCITY_SPECIALIST_RURAL for the
 //                                          8 rural lines; the urban tiers carry
 //                                          a _1/_2/_3 suffix on the zType).
-//   Reference/XML/Infos/improvement.xml  — <Entry> with <zType> (IMPROVEMENT_*),
+//   Reference/XML/Infos/improvement*.xml — <Entry> with <zType> (IMPROVEMENT_*),
 //                                          a <Specialist> tag iff the improvement
 //                                          can hold a specialist, and <bUrban>1.
+//                                          improvement-event*.xml carry the
+//                                          event/DLC entries (LAURION_MINE takes
+//                                          a Miner) and must be read too: an
+//                                          eligible improvement missing here is
+//                                          missing from both halves of the
+//                                          coverage ratio, not just one.
 //   Reference/XML/Infos/text-*.xml       — <Entry> with <zType>TEXT_*</> and
 //                                          <en-US>. text-specialistClass.xml has
 //                                          the class line names ("Priest"); the
@@ -50,6 +56,10 @@ const REPO_ROOT = resolve(__dirname, "..");
 const SIDECAR = resolve(REPO_ROOT, ".bake/specialists.json");
 
 const RURAL_MARKER = "EFFECTCITY_SPECIALIST_RURAL";
+
+// The base improvement catalogue plus its event/DLC adds, mirroring
+// bake-improvement-builds.ts so both tables are built from the same files.
+const IMPROVEMENT_FILE = /^improvement(-event.*)?\.xml$/;
 
 interface SpecialistEntry {
 	zType?: string;
@@ -120,13 +130,20 @@ async function main(): Promise<void> {
 	const textFiles = allFiles
 		.filter((f) => /^text-.*\.xml$/.test(f))
 		.map((f) => resolve(infosDir, f));
+	const improvementFiles = allFiles
+		.filter((f) => IMPROVEMENT_FILE.test(f))
+		.sort()
+		.map((f) => resolve(infosDir, f));
 
-	const [specialistEntries, improvementEntries, ...textFileEntries] =
+	const [specialistEntries, improvementEntryLists, textFileEntries] =
 		await Promise.all([
 			loadEntries<SpecialistEntry>(resolve(infosDir, "specialist.xml")),
-			loadEntries<ImprovementEntry>(resolve(infosDir, "improvement.xml")),
-			...textFiles.map((p) => loadEntries<TextEntry>(p)),
+			Promise.all(
+				improvementFiles.map((p) => loadEntries<ImprovementEntry>(p)),
+			),
+			Promise.all(textFiles.map((p) => loadEntries<TextEntry>(p))),
 		]);
+	const improvementEntries = improvementEntryLists.flat();
 
 	const textByKey = new Map<string, string>();
 	for (const entries of textFileEntries) {

--- a/src/lib/game-detail/BuildComparison.svelte
+++ b/src/lib/game-detail/BuildComparison.svelte
@@ -2,10 +2,10 @@
 	// Head-to-head-by-type module, ported from owglick's H2H card. Every type is
 	// a center-split diverging-bar row (player A grows left, B grows right),
 	// with the absent side left blank when only one player has a type. Used on
-	// the Military tab for the Ending Army / Military Built comparisons and on
-	// the Economy tab for improvements and specialists — hence the icon
-	// category and label being the caller's to choose. A 1v1 framing; the
-	// caller gates it to two players.
+	// the Military tab for the Ending Army / Military Built comparisons, on the
+	// Economy tab for improvements and worker-turns, and on the Specialists tab
+	// for rural / urban specialists — hence the icon category and label being
+	// the caller's to choose. A 1v1 framing; the caller gates it to two players.
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import { formatEnum } from "$lib/utils/formatting";
 	import type { BuildItem, SpriteCategory } from "./helpers";

--- a/src/lib/game-detail/EconomyTab.svelte
+++ b/src/lib/game-detail/EconomyTab.svelte
@@ -464,11 +464,12 @@
 
 	// ─── Side-by-side comparisons ─────────────────────────────────────
 	// The Military tab's diverging-bar module, pointed at what this tab counts.
-	// One panel per kind — rural / urban / wonders, and rural / urban for
-	// specialists — because that split is the strategic axis: a wide farm
-	// empire and a tall urban one show up as different blocks rather than one
-	// undifferentiated list. 1v1 like the Military panels, so it renders only
-	// for a two-sided game.
+	// One panel per kind — rural / urban / wonders — because that split is the
+	// strategic axis: a wide farm empire and a tall urban one show up as
+	// different blocks rather than one undifferentiated list. 1v1 like the
+	// Military panels, so it renders only for a two-sided game. (Specialists
+	// get the same treatment on the Specialists tab, next to the coverage
+	// numbers they explain.)
 	const matchup = $derived(orderedPlayers.length === 2 ? orderedPlayers : null);
 
 	type ComparisonPanel = {

--- a/src/lib/game-detail/GameDetailView.svelte
+++ b/src/lib/game-detail/GameDetailView.svelte
@@ -685,6 +685,7 @@
 		<SpecialistsTab
 			players={resolvedPlayers}
 			{improvementData}
+			{userNation}
 			bind:tableState={tables.specialists}
 		/>
 	</Tabs.Content>

--- a/src/lib/game-detail/SpecialistsTab.svelte
+++ b/src/lib/game-detail/SpecialistsTab.svelte
@@ -2,7 +2,7 @@
 	import type { ImprovementData } from "$lib/types/ImprovementData";
 	import type { ChartOption } from "$lib/echarts";
 	import { formatEnum } from "$lib/utils/formatting";
-	import { CHART_THEME, getNationChartColor } from "$lib/config";
+	import { CHART_THEME } from "$lib/config";
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import { ToggleGroup } from "bits-ui";
 	import ChartContainer from "$lib/ChartContainer.svelte";
@@ -12,10 +12,13 @@
 	import {
 		type TableState,
 		type DetailPlayer,
+		type BuildItem,
 		TABLE_FRAME_CLASS,
 		TABLE_CLASS,
 		TABLE_HEADER_TH_CLASS,
 		TABLE_CELL_TD_CLASS,
+		comparisonRowKeys,
+		orderPlayersUploaderFirst,
 		ownedByPlayer,
 		toggleSort,
 	} from "./helpers";
@@ -23,14 +26,18 @@
 		type KindFilter,
 		specialistInfo,
 		classLabel,
+		slotCoverage,
 		specialistName,
 		summarizeForPlayer,
 		levelBreakdownForPlayer,
 	} from "./specialists";
+	import BuildComparison from "./BuildComparison.svelte";
+	import { specialistSortKey } from "./science-techs";
 
 	let {
 		players,
 		improvementData,
+		userNation = null,
 		tableState = $bindable<TableState>({
 			search: "",
 			sortColumn: "specialist",
@@ -40,6 +47,7 @@
 	}: {
 		players: DetailPlayer[];
 		improvementData: ImprovementData;
+		userNation?: string | null;
 		tableState?: TableState;
 	} = $props();
 
@@ -213,51 +221,121 @@
 		};
 	});
 
-	// Coverage: staffed share of specialist-eligible improvements built, per
-	// player, colored by nation.
-	const coverageOption: ChartOption = $derived.by(() => {
-		const data = displayedPlayers.map((p, i) => ({
-			value:
-				summaries[i].coverage != null
-					? Math.round(summaries[i].coverage * 1000) / 10
-					: 0,
-			itemStyle: { color: getNationChartColor(p.nation, i) },
-		}));
-		return {
-			...CHART_THEME,
-			title: { ...CHART_THEME.title, text: "Coverage" },
-			tooltip: {
-				...CHART_THEME.tooltip,
-				axisPointer: { type: "shadow" },
-				formatter: (params: unknown) => {
-					const p = (params as { dataIndex: number }[])[0];
-					const player = displayedPlayers[p.dataIndex];
-					const s = summaries[p.dataIndex];
-					if (!player || !s) return "";
-					return `${player.label}<br/>Coverage: ${coveragePct(s.coverage)}<br/>${s.total} specialists`;
-				},
+	// Coverage, split by the kind of slot: rural tiles and urban buildings are
+	// staffed by different economies, and the combined number hid which one a
+	// player had actually kept up with.
+	// Colours come from SEGMENTS above rather than repeated literals, looked up
+	// by key so reordering the ramp can't silently repaint them. This chart has
+	// one bar for urban against the ramp's three, and it draws that bar in the
+	// middle tier's copper — the midpoint reads as "urban" where either end
+	// would read as a particular tier.
+	const SEGMENT_COLOR: Record<string, string> = Object.fromEntries(
+		SEGMENTS.map((s) => [s.key, s.color]),
+	);
+	const COVERAGE_SERIES = [
+		{ key: "rural", name: "Rural", color: SEGMENT_COLOR.rural },
+		{ key: "urban", name: "Urban", color: SEGMENT_COLOR.urban2 },
+	] as const;
+
+	const coverageOption: ChartOption = $derived.by(() => ({
+		...CHART_THEME,
+		title: { ...CHART_THEME.title, text: "Slots filled" },
+		legend: { show: true, bottom: 0, textStyle: { color: "#FFFFFF" } },
+		tooltip: {
+			...CHART_THEME.tooltip,
+			axisPointer: { type: "shadow" },
+			formatter: (params: unknown) => {
+				const p = (params as { dataIndex: number }[])[0];
+				const player = displayedPlayers[p.dataIndex];
+				const s = summaries[p.dataIndex];
+				if (!player || !s) return "";
+				const line = (kind: "rural" | "urban", label: string) =>
+					`${label}: <b>${s.slots[kind].staffed} / ${s.slots[kind].built}</b> (${coveragePct(slotCoverage(s.slots[kind]))})`;
+				return `${player.label}<br/>${line("rural", "Rural")}<br/>${line("urban", "Urban")}`;
 			},
-			grid: { left: 16, right: 16, top: 56, bottom: 24, containLabel: true },
-			xAxis: {
-				type: "category",
-				data: displayedPlayers.map((p) => p.label),
-				// Bars are colored by nation, so the per-bar labels are redundant.
-				axisLabel: { show: false },
-			},
-			yAxis: {
-				type: "value",
-				max: 100,
-				axisLabel: { formatter: "{value}%" },
-			},
-			series: [{ type: "bar", data, barMaxWidth: 56 }],
-		};
+		},
+		grid: { left: 16, right: 16, top: 56, bottom: 48, containLabel: true },
+		xAxis: { type: "category", data: displayedPlayers.map((p) => p.label) },
+		yAxis: { type: "value", max: 100, axisLabel: { formatter: "{value}%" } },
+		series: COVERAGE_SERIES.map((sc) => ({
+			name: sc.name,
+			type: "bar" as const,
+			data: summaries.map((s) => {
+				const c = slotCoverage(s.slots[sc.key]);
+				return c == null ? 0 : Math.round(c * 1000) / 10;
+			}),
+			itemStyle: { color: sc.color },
+			barMaxWidth: 40,
+		})),
+	}));
+
+	// ─── Side-by-side comparison ──────────────────────────────────────
+	// The Military tab's diverging-bar module, split rural / urban and sorted
+	// the way the Techs tab sorts specialists — unlock cost, class contiguous,
+	// then tier. 1v1 framing, so it renders only for a two-sided game.
+	// Built from displayedPlayers, not the raw roster, so the tab's nation
+	// filter governs every surface on it: filtering down to one nation leaves
+	// no matchup and hides the comparison rather than showing two sides the
+	// cards above no longer list.
+	const orderedPlayers = $derived(
+		orderPlayersUploaderFirst(displayedPlayers, userNation),
+	);
+	const matchup = $derived(orderedPlayers.length === 2 ? orderedPlayers : null);
+
+	const KIND_LABELS: Record<string, string> = {
+		rural: "Rural",
+		urban: "Urban",
+	};
+
+	const comparisonPanels = $derived.by(() => {
+		const sides = orderedPlayers.map((player) => {
+			// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local, not reactive state
+			const counts = new Map<string, Map<string, number>>();
+			for (const imp of ownedByPlayer(
+				improvementData.improvements,
+				player,
+				(i) => i.owner_player_xml_id,
+				(i) => i.nation,
+			)) {
+				const info = specialistInfo(imp.specialist);
+				if (info == null || imp.specialist == null) continue;
+				// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local, not reactive state
+				const rows = counts.get(info.kind) ?? new Map<string, number>();
+				rows.set(imp.specialist, (rows.get(imp.specialist) ?? 0) + 1);
+				counts.set(info.kind, rows);
+			}
+			return counts;
+		});
+		return (["rural", "urban"] as const)
+			.map((kind) => {
+				// Raw per-side rows: BuildComparison re-aggregates these and
+				// gap-fills against the shared `keys`, so a side that lacks a key
+				// just omits it.
+				const items = sides.map((s) =>
+					[...(s.get(kind)?.entries() ?? [])].map(
+						([key, count]): BuildItem => ({ key, count }),
+					),
+				);
+				// Ties break on the displayed name — the order the Economy tab's
+				// panels already use — so specialists the table doesn't know, which
+				// all share a sort key, don't fall back on whichever side happened
+				// to mention them first.
+				const keys = comparisonRowKeys(
+					items,
+					(a, b) =>
+						specialistSortKey(a) - specialistSortKey(b) ||
+						specialistName(a).localeCompare(specialistName(b)),
+				);
+				return { label: kind, keys, items };
+			})
+			.filter((p) => p.keys.length > 0);
 	});
 </script>
 
 {#if placedCount === 0}
 	<p class="p-8 text-center italic text-tan">No specialists found</p>
 {:else}
-	<!-- Per-player headline metrics: breadth (total), coverage %, depth (avg urban level). -->
+	<!-- Per-player headline metrics: breadth, slots filled per kind, depth. -->
 	{#if displayedPlayers.length > 0}
 		<div class="mb-4 flex flex-wrap gap-3">
 			{#each displayedPlayers as player, i (player.playerId)}
@@ -281,8 +359,24 @@
 							<dd class="font-bold">{summaries[i].total}</dd>
 						</div>
 						<div class="flex justify-between">
-							<dt class="opacity-70">Coverage</dt>
-							<dd class="font-bold">{coveragePct(summaries[i].coverage)}</dd>
+							<dt class="opacity-70">Rural filled</dt>
+							<dd class="font-bold">
+								{summaries[i].slots.rural.staffed}/{summaries[i].slots.rural
+									.built}
+								<span class="opacity-70"
+									>{coveragePct(slotCoverage(summaries[i].slots.rural))}</span
+								>
+							</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt class="opacity-70">Urban filled</dt>
+							<dd class="font-bold">
+								{summaries[i].slots.urban.staffed}/{summaries[i].slots.urban
+									.built}
+								<span class="opacity-70"
+									>{coveragePct(slotCoverage(summaries[i].slots.urban))}</span
+								>
+							</dd>
 						</div>
 						<div class="flex justify-between">
 							<dt class="opacity-70">Avg urban level</dt>
@@ -303,7 +397,38 @@
 				height="320px"
 				title="Specialists by level"
 			/>
-			<ChartContainer option={coverageOption} height="320px" title="Coverage" />
+			<ChartContainer
+				option={coverageOption}
+				height="320px"
+				title="Slots filled"
+			/>
+		</div>
+	{/if}
+
+	{#if !matchup}
+		<p class="mb-6 rounded-lg bg-surface p-4 text-sm italic text-tan">
+			Side-by-side comparison needs exactly two nations. The table below covers
+			every player.
+		</p>
+	{/if}
+	{#if matchup && comparisonPanels.length > 0}
+		<div class="mb-6 rounded-lg bg-surface p-4">
+			<h3 class="mb-3 text-base font-bold text-tan">Side by side</h3>
+			<div class="grid gap-3 lg:grid-cols-2">
+				{#each comparisonPanels as panel (panel.label)}
+					<BuildComparison
+						title={KIND_LABELS[panel.label]}
+						a={panel.items[0]}
+						b={panel.items[1]}
+						ca={matchup[0].color}
+						cb={matchup[1].color}
+						keys={panel.keys}
+						iconCategory="specialists"
+						labelOf={specialistName}
+						showDiff
+					/>
+				{/each}
+			</div>
 		</div>
 	{/if}
 

--- a/src/lib/game-detail/science-techs.ts
+++ b/src/lib/game-detail/science-techs.ts
@@ -491,6 +491,22 @@ const SPECIALIST_CLASS_ORDINAL: Readonly<Record<string, number>> =
 			.map((cls, i) => [cls, i]),
 	);
 
+/**
+ * Sort key for a specialist row: unlock cost first, then the class as a
+ * contiguous block, then the tier — so two classes sharing a cost (Officers
+ * and Poets, both 160) don't intermingle and each line reads Apprentice →
+ * Master → Elder. Shared with the Economy tab so specialists sort the same way
+ * wherever they're listed.
+ */
+export function specialistSortKey(zType: string): number {
+	const info = SPECIALISTS[zType];
+	return (
+		(SPECIALIST_UNLOCK_COST[zType] ?? 0) * 10_000 +
+		(SPECIALIST_CLASS_ORDINAL[info?.class ?? ""] ?? 99) * 10 +
+		(info?.level ?? 0)
+	);
+}
+
 // Culture levels in game order — index+1 is the level multiplier
 // aiYieldRateCulture uses (City.cs:11916 adds getCultureStep() on top for
 // post-Legendary growth, which the blob doesn't record, so Centralization
@@ -666,9 +682,7 @@ export function scienceBreakdown(
 				staff,
 				0,
 				{ category: "specialists", value: i.specialist },
-				(SPECIALIST_UNLOCK_COST[i.specialist] ?? 0) * 10_000 +
-					(SPECIALIST_CLASS_ORDINAL[info?.class ?? ""] ?? 99) * 10 +
-					(info?.level ?? 0),
+				specialistSortKey(i.specialist),
 			);
 		}
 		if (i.city_name != null) {

--- a/src/lib/game-detail/specialists.ts
+++ b/src/lib/game-detail/specialists.ts
@@ -41,19 +41,24 @@ export function specialistName(zType: string): string {
 	return SPECIALISTS[zType]?.name ?? formatEnum(zType, "SPECIALIST_");
 }
 
-function isEligibleImprovement(improvement: string): boolean {
-	return ELIGIBLE_IMPROVEMENTS[improvement] !== undefined;
+/** Specialist-eligible improvements of one kind, and how many are staffed. */
+export type SpecialistSlots = { built: number; staffed: number };
+
+/** Staffed share of a slot bucket; null when nothing eligible was built. */
+export function slotCoverage(slots: SpecialistSlots): number | null {
+	return slots.built > 0 ? slots.staffed / slots.built : null;
 }
 
-// Per-player headline metrics. `coverage` is the staffed share of the
-// specialist-eligible improvements the player has built (null when they've built
-// none); `avgUrbanLevel` is the mean tier across their urban specialists (null
-// when they have none).
+// Per-player headline metrics. `slots` is the coverage denominator split by the
+// ELIGIBLE improvement's kind rather than the placed specialist's — the question
+// is "of the farms I built that can take a specialist, how many are staffed",
+// which is a different one for rural tiles and urban buildings. `avgUrbanLevel`
+// is the mean tier across urban specialists (null when there are none).
 export type SpecialistSummary = {
 	total: number;
 	urban: number;
 	rural: number;
-	coverage: number | null;
+	slots: Record<SpecialistKind, SpecialistSlots>;
 	avgUrbanLevel: number | null;
 };
 
@@ -71,13 +76,17 @@ export function summarizeForPlayer(
 	let urban = 0;
 	let rural = 0;
 	let urbanLevelSum = 0;
-	let eligibleBuilt = 0;
-	let staffed = 0;
+	const slots: Record<SpecialistKind, SpecialistSlots> = {
+		rural: { built: 0, staffed: 0 },
+		urban: { built: 0, staffed: 0 },
+	};
 
 	for (const imp of owned) {
-		if (isEligibleImprovement(imp.improvement)) {
-			eligibleBuilt++;
-			if (imp.specialist) staffed++;
+		const eligible = ELIGIBLE_IMPROVEMENTS[imp.improvement];
+		if (eligible !== undefined) {
+			const bucket = slots[eligible.urban ? "urban" : "rural"];
+			bucket.built++;
+			if (imp.specialist) bucket.staffed++;
 		}
 		const info = specialistInfo(imp.specialist);
 		if (!info) continue;
@@ -93,7 +102,7 @@ export function summarizeForPlayer(
 		total: urban + rural,
 		urban,
 		rural,
-		coverage: eligibleBuilt > 0 ? staffed / eligibleBuilt : null,
+		slots,
 		avgUrbanLevel: urban > 0 ? urbanLevelSum / urban : null,
 	};
 }

--- a/src/lib/generated/specialists.ts
+++ b/src/lib/generated/specialists.ts
@@ -295,6 +295,7 @@ export const ELIGIBLE_IMPROVEMENTS: Readonly<
 	IMPROVEMENT_COURTHOUSE_3: { urban: true },
 	IMPROVEMENT_FARM: { urban: false },
 	IMPROVEMENT_GROVE: { urban: false },
+	IMPROVEMENT_LAURION_MINE: { urban: false },
 	IMPROVEMENT_LIBRARY_1: { urban: true },
 	IMPROVEMENT_LIBRARY_2: { urban: true },
 	IMPROVEMENT_LIBRARY_3: { urban: true },


### PR DESCRIPTION
Two changes to the Specialists tab, both consequences of the Economy tab landing next door.

> **Stacked on #168, #169 and #170.** Their commits lead this diff and disappear as they land.

## Coverage was measuring two different things at once

`coverage` was the staffed share of *every* specialist-eligible improvement, which mixes two economies that behave nothing alike: rural specialists sit one-per-tile on farms and mines, urban ones fill graded buildings you have to build first. The denominator now splits on the eligible improvement's own kind — `ELIGIBLE_IMPROVEMENTS` already carried the `urban` flag — so the headline reads **rural filled a/b** and **urban filled a/b**, and the chart plots both.

The combined number was hiding the interesting half. One reference game:

| | overall | rural | urban |
|---|---|---|---|
| Kush | 27% | 25% | 37% |
| Persia | 46% | 41% | 68% |

Persia staffed two-thirds of their buildings against Kush's third — a completely different specialist economy than "27% vs 46%" suggests.

## The side-by-side view belongs here

`BuildComparison` (generalised in #168) now renders specialists as rural/urban diverging bars on this tab. Sorted the way the Techs tab sorts specialists — unlock cost, class contiguous, then tier — so a reader moving between the two tabs sees the same order. That rule was inline in `science-techs.ts`; it's now an exported `specialistSortKey` shared by both rather than a second copy.

1v1 like the Military tab's comparisons, and it says so in FFA instead of silently rendering nothing.

## Also

`SpecialistSummary.coverage` is removed rather than left computed-for-nobody, and the coverage chart's rural/urban colours now derive from the `SEGMENTS` table above it instead of repeating the same two hexes as literals.

Last of the four.

`npm run lint` and `svelte-check` clean.