### PR TITLE
feat(game-detail): Wonders tab — the catalogue with this game painted on

### DIFF
--- a/src/lib/game-detail/EconomyTab.svelte
+++ b/src/lib/game-detail/EconomyTab.svelte
@@ -548,7 +548,7 @@
 
 	const improvementPanels = $derived(
 		panels(
-			["rural", "urban", "wonder"],
+			["rural", "urban"],
 			(imp) => IMPROVEMENT_BUILDS[imp.improvement]?.kind ?? null,
 			(imp) => (IMPROVEMENT_BUILDS[imp.improvement] ? imp.improvement : null),
 			(key) => IMPROVEMENT_UNLOCK_COST[key] ?? 0,
@@ -561,7 +561,7 @@
 	// cost, since that's the question this panel answers.
 	const workerTurnPanels = $derived(
 		panels(
-			["rural", "urban", "wonder"],
+			["rural", "urban"],
 			(imp) => IMPROVEMENT_BUILDS[imp.improvement]?.kind ?? null,
 			(imp) => (IMPROVEMENT_BUILDS[imp.improvement] ? imp.improvement : null),
 			null,
@@ -664,10 +664,10 @@
 		})),
 	);
 
+	// Wonders have their own tab; the Built panels carry only worker economy.
 	const PANEL_LABELS: Record<string, string> = {
 		rural: "Rural",
 		urban: "Urban",
-		wonder: "Wonders",
 	};
 </script>
 

--- a/src/lib/game-detail/EconomyTab.svelte
+++ b/src/lib/game-detail/EconomyTab.svelte
@@ -470,9 +470,9 @@
 
 	// ─── Side-by-side comparisons ─────────────────────────────────────
 	// The Military tab's diverging-bar module, pointed at what this tab counts.
-	// One panel per kind — rural / urban / wonders — because that split is the
-	// strategic axis: a wide farm empire and a tall urban one show up as
-	// different blocks rather than one undifferentiated list. 1v1 like the
+	// One panel per kind — rural / urban — because that split is the strategic
+	// axis: a wide farm empire and a tall urban one show up as different
+	// blocks rather than one undifferentiated list. 1v1 like the
 	// Military panels, so it renders only for a two-sided game. (Specialists
 	// get the same treatment on the Specialists tab, next to the coverage
 	// numbers they explain.)

--- a/src/lib/game-detail/GameDetailView.svelte
+++ b/src/lib/game-detail/GameDetailView.svelte
@@ -58,6 +58,7 @@
 	import MilitaryTab from "./MilitaryTab.svelte";
 	import CitiesTab from "./CitiesTab.svelte";
 	import EconomyTab from "./EconomyTab.svelte";
+	import WondersTab from "./WondersTab.svelte";
 	import FamiliesTab from "./FamiliesTab.svelte";
 	import SpecialistsTab from "./SpecialistsTab.svelte";
 	import MapTab from "./MapTab.svelte";
@@ -509,6 +510,8 @@
 
 		<Tabs.Trigger value="economy" class={triggerClass}>Economy</Tabs.Trigger>
 
+		<Tabs.Trigger value="wonders" class={triggerClass}>Wonders</Tabs.Trigger>
+
 		<Tabs.Trigger value="families" class={triggerClass}>Families</Tabs.Trigger>
 
 		<Tabs.Trigger value="specialists" class={triggerClass}>
@@ -669,6 +672,15 @@
 			totalTurns={gameDetails.total_turns}
 			{userNation}
 			bind:tableState={tables.improvements}
+		/>
+	</Tabs.Content>
+
+	<!-- Tab Content: Wonders -->
+	<Tabs.Content value="wonders" class="tab-pane min-h-[400px]">
+		<WondersTab
+			players={resolvedPlayers}
+			{playerWonders}
+			disabledImprovements={gameDetails.disabled_improvements}
 		/>
 	</Tabs.Content>
 

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -106,10 +106,11 @@
 					class="w-48 rounded-lg border-2 bg-surface-raised p-2 text-center"
 					style="border-color: {card.builderColor ?? 'transparent'};"
 				>
-					<!-- Reserve the slot: five wonders ship no improvement sprite, and
-					     SpriteIcon draws nothing when the path is missing, which would
-					     pull their name up to the card's top edge and break the row's
-					     alignment. Same idiom as BuildComparison's icon column. -->
+					<!-- The wrapper is what the disabled dim applies to, so the art
+					     fades while the name and the "Not in this game" note stay
+					     legible — the states differ by what they say, not by a filter
+					     over all of it. Sized to the icon's square, the same way
+					     BuildComparison's icon column is. -->
 					<span
 						class="mx-auto flex h-14 w-14 flex-none items-center {card.state ===
 						'disabled'

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -11,11 +11,7 @@
 	} from "$lib/generated/wonders";
 	import { formatEnum } from "$lib/utils/formatting";
 	import SpriteIcon from "./SpriteIcon.svelte";
-	import {
-		type DetailPlayer,
-		findByPlayer,
-		improvementDisplayName,
-	} from "./helpers";
+	import { type DetailPlayer, improvementDisplayName } from "./helpers";
 
 	let {
 		players,
@@ -57,15 +53,11 @@
 				.map((wonder): WonderCard => {
 					const built = builtBy.get(wonder);
 					if (built) {
-						// Resolve the builder to the mirror-match-safe player list
-						// (id match, nation fallback); the wonder row's own
-						// name/nation cover blobs where neither resolves.
-						const player = findByPlayer(
-							players,
-							{ playerId: built.player_id, nation: built.nation },
-							(p) => p.playerId,
-							(p) => p.nation,
-						);
+						// Id match and nothing else: the wonder row always carries its
+						// builder's id, and in a mirror match nation can't tell the two
+						// players apart. Same join the Economy tab's wonder rail makes;
+						// the row's own nation/name cover a blob that matches nothing.
+						const player = players.find((p) => p.playerId === built.player_id);
 						return {
 							wonder,
 							state: "built",

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -116,12 +116,18 @@
 					style="background-color: rgb(var(--color-surface)); border-color: {card.builderColor ??
 						'transparent'};"
 				>
-					<SpriteIcon
-						category="improvements"
-						value={card.wonder}
-						size={56}
-						alt={improvementDisplayName(card.wonder)}
-					/>
+					<!-- Reserve the slot: five wonders ship no improvement sprite, and
+					     SpriteIcon draws nothing when the path is missing, which would
+					     pull their name up to the card's top edge and break the row's
+					     alignment. Same idiom as BuildComparison's icon column. -->
+					<span class="mx-auto flex h-14 w-14 flex-none items-center">
+						<SpriteIcon
+							category="improvements"
+							value={card.wonder}
+							size={56}
+							alt={improvementDisplayName(card.wonder)}
+						/>
+					</span>
 					<div class="mt-1.5 text-xs font-semibold text-white">
 						{improvementDisplayName(card.wonder)}
 					</div>

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -1,0 +1,143 @@
+<script lang="ts">
+	// Wonders tab — the whole catalogue, one row per culture tier, with this
+	// game's reality painted on: wonders the save disabled are faded, wonders
+	// still open are plain, and a built wonder carries its builder's colour,
+	// nation and completion turn. One glance answers "what was in the pool,
+	// and who got what".
+	import type { PlayerWonder } from "$lib/types/PlayerWonder";
+	import {
+		CULTURE_LEVELS,
+		WONDER_CULTURE_PREREQ,
+	} from "$lib/generated/wonders";
+	import { formatEnum } from "$lib/utils/formatting";
+	import SpriteIcon from "./SpriteIcon.svelte";
+	import {
+		type DetailPlayer,
+		findByPlayer,
+		improvementDisplayName,
+	} from "./helpers";
+
+	let {
+		players,
+		playerWonders,
+		disabledImprovements = null,
+	}: {
+		players: DetailPlayer[];
+		playerWonders: PlayerWonder[];
+		// Wonders the save switched off. Null on pre-2.12.0 blobs, where the
+		// pool is unknown — which is not the same claim as "nothing disabled",
+		// so nothing fades and a note says why.
+		disabledImprovements?: string[] | null;
+	} = $props();
+
+	const disabled = $derived(new Set(disabledImprovements ?? []));
+
+	type WonderCard = {
+		wonder: string;
+		state: "disabled" | "available" | "built";
+		// Set when built.
+		turn?: number;
+		builderLabel?: string;
+		builderColor?: string;
+	};
+
+	// One row per culture tier, in game order, each tier's wonders A→Z by
+	// display name. `built` wins over `disabled`: a wonder that demonstrably
+	// completed was in the pool whatever the end-state list says.
+	const rows = $derived.by<{ level: string; cards: WonderCard[] }[]>(() => {
+		const builtBy = new Map(playerWonders.map((w) => [w.wonder, w]));
+		return CULTURE_LEVELS.map((level) => ({
+			level,
+			cards: Object.keys(WONDER_CULTURE_PREREQ)
+				.filter((wonder) => WONDER_CULTURE_PREREQ[wonder] === level)
+				.sort((a, b) =>
+					improvementDisplayName(a).localeCompare(improvementDisplayName(b)),
+				)
+				.map((wonder): WonderCard => {
+					const built = builtBy.get(wonder);
+					if (built) {
+						// Resolve the builder to the mirror-match-safe player list
+						// (id match, nation fallback); the wonder row's own
+						// name/nation cover blobs where neither resolves.
+						const player = findByPlayer(
+							players,
+							{ playerId: built.player_id, nation: built.nation },
+							(p) => p.playerId,
+							(p) => p.nation,
+						);
+						return {
+							wonder,
+							state: "built",
+							turn: built.completed_turn,
+							builderLabel:
+								player?.label ??
+								(built.nation
+									? formatEnum(built.nation, "NATION_")
+									: built.player_name),
+							builderColor: player?.color,
+						};
+					}
+					return {
+						wonder,
+						state: disabled.has(wonder) ? "disabled" : "available",
+					};
+				}),
+		})).filter((row) => row.cards.length > 0);
+	});
+</script>
+
+{#if disabledImprovements == null}
+	<p class="mb-3 text-xs italic text-tan">
+		This save predates the wonder-pool data, so which wonders were disabled is
+		unknown — nothing is faded.
+	</p>
+{/if}
+
+{#each rows as row (row.level)}
+	<section class="mb-5">
+		<h2 class="mb-2 text-base font-bold text-bright">
+			<span class="inline-flex items-center gap-1.5">
+				<SpriteIcon
+					category="icons"
+					value={row.level}
+					size={16}
+					alt={formatEnum(row.level, "CULTURE_")}
+				/>
+				{formatEnum(row.level, "CULTURE_")}
+			</span>
+		</h2>
+		<div class="flex flex-wrap gap-3">
+			{#each row.cards as card (card.wonder)}
+				<div
+					class="w-36 rounded-lg border-2 p-3 text-center {card.state ===
+					'disabled'
+						? 'opacity-35 grayscale'
+						: ''}"
+					style="background-color: rgb(var(--color-surface)); border-color: {card.builderColor ??
+						'transparent'};"
+				>
+					<SpriteIcon
+						category="improvements"
+						value={card.wonder}
+						size={56}
+						alt={improvementDisplayName(card.wonder)}
+					/>
+					<div class="mt-1.5 text-xs font-semibold text-white">
+						{improvementDisplayName(card.wonder)}
+					</div>
+					{#if card.state === "built"}
+						<div
+							class="mt-1 text-[11px] font-bold"
+							style="color: {card.builderColor ?? 'rgb(var(--color-tan))'};"
+						>
+							{card.builderLabel}
+						</div>
+						<div class="text-[10px] text-tan">Turn {card.turn}</div>
+					{:else if card.state === "disabled"}
+						<div class="mt-1 text-[10px] italic text-tan">Not in this game</div>
+					{/if}
+				</div>
+			{/each}
+		</div>
+	</section>
+{/each}

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -89,7 +89,7 @@
 
 {#each rows as row (row.level)}
 	<section class="mb-4 rounded-lg bg-surface p-4">
-		<h2 class="mb-2 text-base font-bold text-bright">
+		<h2 class="mb-2 text-lg font-bold text-bright">
 			<span class="inline-flex items-center gap-1.5">
 				<SpriteIcon
 					category="icons"

--- a/src/lib/game-detail/WondersTab.svelte
+++ b/src/lib/game-detail/WondersTab.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	// Wonders tab — the whole catalogue, one row per culture tier, with this
-	// game's reality painted on: wonders the save disabled are faded, wonders
-	// still open are plain, and a built wonder carries its builder's colour,
-	// nation and completion turn. One glance answers "what was in the pool,
-	// and who got what".
+	// game's reality painted on: wonders the save disabled carry dimmed art and
+	// a muted name, wonders still open are full-strength, and a built wonder
+	// carries its builder's colour, nation and completion turn. One glance
+	// answers "what was in the pool, and who got what".
 	import type { PlayerWonder } from "$lib/types/PlayerWonder";
 	import {
 		CULTURE_LEVELS,
@@ -26,7 +26,7 @@
 		playerWonders: PlayerWonder[];
 		// Wonders the save switched off. Null on pre-2.12.0 blobs, where the
 		// pool is unknown — which is not the same claim as "nothing disabled",
-		// so nothing fades and a note says why.
+		// so nothing is dimmed and a note says why.
 		disabledImprovements?: string[] | null;
 	} = $props();
 
@@ -39,6 +39,7 @@
 		turn?: number;
 		builderLabel?: string;
 		builderColor?: string;
+		builderNation?: string | null;
 	};
 
 	// One row per culture tier, in game order, each tier's wonders A→Z by
@@ -75,6 +76,7 @@
 									? formatEnum(built.nation, "NATION_")
 									: built.player_name),
 							builderColor: player?.color,
+							builderNation: player?.nation ?? built.nation,
 						};
 					}
 					return {
@@ -89,12 +91,12 @@
 {#if disabledImprovements == null}
 	<p class="mb-3 text-xs italic text-tan">
 		This save predates the wonder-pool data, so which wonders were disabled is
-		unknown — nothing is faded.
+		unknown — nothing is marked as out of the pool.
 	</p>
 {/if}
 
 {#each rows as row (row.level)}
-	<section class="mb-5">
+	<section class="mb-4 rounded-lg bg-surface p-4">
 		<h2 class="mb-2 text-base font-bold text-bright">
 			<span class="inline-flex items-center gap-1.5">
 				<SpriteIcon
@@ -109,18 +111,19 @@
 		<div class="flex flex-wrap gap-3">
 			{#each row.cards as card (card.wonder)}
 				<div
-					class="w-36 rounded-lg border-2 p-3 text-center {card.state ===
-					'disabled'
-						? 'opacity-35 grayscale'
-						: ''}"
-					style="background-color: rgb(var(--color-surface)); border-color: {card.builderColor ??
-						'transparent'};"
+					class="w-48 rounded-lg border-2 bg-surface-raised p-2 text-center"
+					style="border-color: {card.builderColor ?? 'transparent'};"
 				>
 					<!-- Reserve the slot: five wonders ship no improvement sprite, and
 					     SpriteIcon draws nothing when the path is missing, which would
 					     pull their name up to the card's top edge and break the row's
 					     alignment. Same idiom as BuildComparison's icon column. -->
-					<span class="mx-auto flex h-14 w-14 flex-none items-center">
+					<span
+						class="mx-auto flex h-14 w-14 flex-none items-center {card.state ===
+						'disabled'
+							? 'opacity-35'
+							: ''}"
+					>
 						<SpriteIcon
 							category="improvements"
 							value={card.wonder}
@@ -128,17 +131,42 @@
 							alt={improvementDisplayName(card.wonder)}
 						/>
 					</span>
-					<div class="mt-1.5 text-xs font-semibold text-white">
+					<div
+						class="mt-1.5 text-xs font-semibold {card.state === 'disabled'
+							? 'text-muted'
+							: 'text-white'}"
+					>
 						{improvementDisplayName(card.wonder)}
 					</div>
 					{#if card.state === "built"}
+						<!-- Builder and turn read as one phrase ("Egypt Turn 81"), so they
+						     share a line. Only the nation carries its colour; the turn
+						     stays tan. The card is sized for the longest wonder name, which
+						     leaves room for every plain nation label — but a mirror match
+						     labels its players "Babylonia (name)", which no fixed width
+						     fits, so that one truncates rather than wrapping the card
+						     taller. The turn never gives up space; the label does. -->
 						<div
-							class="mt-1 text-[11px] font-bold"
-							style="color: {card.builderColor ?? 'rgb(var(--color-tan))'};"
+							class="mt-1 flex items-center justify-center gap-x-1 text-[11px] leading-tight"
 						>
-							{card.builderLabel}
+							<span
+								class="flex min-w-0 items-center gap-1 font-bold"
+								style="color: {card.builderColor ?? 'rgb(var(--color-tan))'};"
+							>
+								{#if card.builderNation}
+									<SpriteIcon
+										category="crests"
+										value={card.builderNation}
+										size={13}
+										alt=""
+									/>
+								{/if}
+								<span class="truncate" title={card.builderLabel}>
+									{card.builderLabel}
+								</span>
+							</span>
+							<span class="shrink-0 text-tan">Turn {card.turn}</span>
 						</div>
-						<div class="text-[10px] text-tan">Turn {card.turn}</div>
 					{:else if card.state === "disabled"}
 						<div class="mt-1 text-[10px] italic text-tan">Not in this game</div>
 					{/if}


### PR DESCRIPTION
A Wonders tab on game detail: one row per culture tier, every wonder in the catalogue, with this game's reality painted on — wonders the save **disabled are faded** ("Not in this game"), wonders still open are plain, and a **built** wonder carries its builder's colour, nation and completion turn. One glance answers what was in the pool and who got what.

> **Stacked on #168 → #169 → #172.** Their commits lead this diff and disappear as they land.

## No new data

Everything already ships: `WONDER_CULTURE_PREREQ` + `CULTURE_LEVELS` from the wonders bake (#157), `disabled_improvements` from 2.12.0 blobs (#157), `player_wonders` for builds, and the 2D wonder art. `disabled_improvements` sits on `gameDetails`, so there's no new prop threading at the page level.

## Two semantics worth checking

- **Unknown ≠ nothing-disabled.** Pre-2.12.0 blobs carry `disabled_improvements: null` — the pool is unknown, which is a different claim from the empty list. Nothing fades on those saves, and a one-line note says why.
- **Built beats disabled.** A wonder that demonstrably completed was in the pool, whatever the end-state list says (captures/edge cases). The card shows the build.

Builder resolution goes through the mirror-match-safe list (`findByPlayer`: id match, nation fallback), with the wonder row's own nation/name covering blobs where neither resolves.

Wonders also **leave the Economy tab's Built comparisons** — they were the odd group out among rural/urban worker economy, and they have a home now.

`npm run lint` and `svelte-check` clean; screenshot-verified against a live game (Pyramids → Egypt T21 bordered orange, Yazilikaya/Musaeum → Maurya T84/T58 purple, disabled pool faded per tier).

Heads-up on merge order: this and #170 both touch the `GameDetailView` tab list on adjacent lines, so whichever lands second will need a trivial rebase.