### PR TITLE
perf: cut the blocking D1 round trips on the anonymous game-detail path

### DIFF
--- a/cloud/src/auth.ts
+++ b/cloud/src/auth.ts
@@ -36,7 +36,6 @@ import {
 	sessionFromRequest,
 } from "./session";
 import type { SessionEnv } from "./session";
-import { isSiteAdmin } from "./admin";
 import { displayNameSql } from "./identity";
 import { logError, setSecurityReason } from "./log";
 import type { QueryableD1, EventsEnv } from "./d1";
@@ -754,25 +753,45 @@ export async function handleMe(
 	// their last login. The OAuth-callback claim only fires on re-auth; running
 	// it here too means an already-logged-in player is linked on their next app
 	// load. Fire-and-forget inside the helper; cheap indexed UPDATEs.
-	await claimTournamentSlots(
-		env.SHARE_DB,
-		row.user_id,
-		row.discord_id,
-		session.data.discord_username,
-	);
-
+	//
 	// is_beta gates the create-tournament button on the frontend (allowlisted
 	// users only). Not load-bearing for authz — the worker re-checks create
 	// on the server.
-	const beta = await env.SHARE_DB.prepare(
-		"SELECT 1 AS ok FROM tournament_beta_users WHERE user_id = ? LIMIT 1",
-	)
-		.bind(row.user_id)
-		.first<{ ok: number }>();
+	//
+	// The two run concurrently: both need only the users row above, and
+	// neither reads the other's output, so the sequence they used to run in
+	// cost this handler an extra cross-region round trip for nothing.
+	// Promise.all rather than db.batch() deliberately — batch() is
+	// transactional, so a claim failure would take the beta read down with
+	// it, and claimTournamentSlots swallows its own errors precisely so a
+	// claim hiccup can't break /v1/auth/me. Deferring the claim to waitUntil
+	// is also not an option: +layout.ts calls getMyTournaments right after
+	// this, and that handler reads exactly what the claim writes.
+	const [, beta] = await Promise.all([
+		claimTournamentSlots(
+			env.SHARE_DB,
+			row.user_id,
+			row.discord_id,
+			session.data.discord_username,
+		),
+		env.SHARE_DB.prepare(
+			"SELECT 1 AS ok FROM tournament_beta_users WHERE user_id = ? LIMIT 1",
+		)
+			.bind(row.user_id)
+			.first<{ ok: number }>(),
+	]);
 
 	// is_admin gates the /admin/* SvelteKit routes. Not load-bearing for
 	// authz either — every admin endpoint re-checks via isSiteAdmin.
-	const admin = await isSiteAdmin(env, session);
+	//
+	// Compared inline rather than through isSiteAdmin(): that helper selects
+	// discord_id for a user_id, and this handler already holds that exact
+	// value on `row` from the query above — calling it here was a second
+	// round trip for a column in hand. ADMIN_DISCORD_ID reaches us on
+	// SessionEnv, which AuthEnv extends. Boolean() mirrors the helper's own
+	// guard, so an unset secret still makes nobody an admin.
+	const admin =
+		Boolean(env.ADMIN_DISCORD_ID) && row.discord_id === env.ADMIN_DISCORD_ID;
 
 	return jsonResponse(
 		{

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -69,7 +69,9 @@ const MAX_BLOB_DECOMPRESSED = 50 * 1024 * 1024; // 50 MB
 const MAX_ZIP_BYTES = 50 * 1024 * 1024; // 50 MB
 
 // Anonymous public-game read limit (per-IP, global via D1 `events` table).
-const ANON_READS_PER_HOUR = 200;
+// Exported so the integration test pins the gate against the real cap rather
+// than a copy of the number — same reason tournament/limits.ts exports its own.
+export const ANON_READS_PER_HOUR = 200;
 
 // Per-user PATCH limit on visibility toggles. Generous — one toggle per
 // minute for an hour straight is well past human use.

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -2329,6 +2329,28 @@ export async function handleGameDetail(
 
 	const session = await sessionFromRequest(env, request);
 
+	// Anonymous public reads pay a per-IP rate-limit count (the gate below).
+	// A sessionless request cannot be the owner, so for those the count is
+	// issued here, alongside the games-row read, instead of after it: the two
+	// are independent, and running them in sequence charged the anonymous
+	// read two blocking cross-region round trips where one wave suffices.
+	// This is exact rather than speculative — non-ownership is already certain
+	// before either query. Signed-in requests keep the sequential path: they
+	// may be the owner, and owners aren't counted at all, so issuing the
+	// query for them would be waste. Scrapers are exempt from the gate, so
+	// they're exempt from the read too.
+	const ip = getClientIp(request) ?? "untrusted";
+	const ua = request.headers.get("User-Agent");
+	const anonReadCount =
+		session === null && !isScraperUA(ua)
+			? countEventsSince(env.EVENTS_DB, "anon_read", "ip_address", ip)
+			: null;
+	// The 404/401/403 returns below discard this result, so attach a handler
+	// now to keep a D1 failure on those paths from surfacing as an unhandled
+	// rejection. The awaits at the gate still see the original promise and
+	// still throw — a failed count must 500 rather than fail the limiter open.
+	anonReadCount?.catch(() => {});
+
 	// COALESCE(g.user_nation, …): see listGames for the rationale — same
 	// fallback so the H1 title and sidebar agree on a save's nation when the
 	// uploader didn't pick one. The header also drops its client-side
@@ -2380,39 +2402,36 @@ export async function handleGameDetail(
 	// (Discord/Slack/Twitter/etc.). Untrusted IP (CF-RAY missing) → shared
 	// "untrusted" bucket so per-IP enforcement doesn't silently degrade in
 	// a misconfigured topology.
-	if (!isOwner) {
-		const ip = getClientIp(request) ?? "untrusted";
-		const ua = request.headers.get("User-Agent");
-		if (!isScraperUA(ua)) {
-			const count = await countEventsSince(
-				env.EVENTS_DB,
-				"anon_read",
-				"ip_address",
-				ip,
+	//
+	// Gate order is unchanged — 404, then 401/403, then 429, then the audit
+	// insert — so hoisting the count above the row read shifts no decision.
+	if (!isOwner && !isScraperUA(ua)) {
+		// Sessionless requests reuse the count already in flight; signed-in
+		// non-owners issue it here, now that ownership is known.
+		const count = await (anonReadCount ??
+			countEventsSince(env.EVENTS_DB, "anon_read", "ip_address", ip));
+		if (count >= ANON_READS_PER_HOUR) {
+			return errorResponse(
+				"Rate limit exceeded. Try again later.",
+				429,
+				cors,
+				"RATE_LIMIT",
 			);
-			if (count >= ANON_READS_PER_HOUR) {
-				return errorResponse(
-					"Rate limit exceeded. Try again later.",
-					429,
-					cors,
-					"RATE_LIMIT",
-				);
-			}
-			// Audit-log fire-and-forget — same pattern as the download path.
-			// A logging hiccup mustn't 500 a public-game view.
-			env.EVENTS_DB.prepare(
-				`INSERT INTO events (event_type, game_id, ip_address)
-				 VALUES ('anon_read', ?, ?)`,
-			)
-				.bind(gameId, ip)
-				.run()
-				.catch((e: unknown) => {
-					logError("audit_event_log_failed", e, {
-						event_type: "anon_read",
-						game_id: gameId,
-					});
-				});
 		}
+		// Audit-log fire-and-forget — same pattern as the download path.
+		// A logging hiccup mustn't 500 a public-game view.
+		env.EVENTS_DB.prepare(
+			`INSERT INTO events (event_type, game_id, ip_address)
+			 VALUES ('anon_read', ?, ?)`,
+		)
+			.bind(gameId, ip)
+			.run()
+			.catch((e: unknown) => {
+				logError("audit_event_log_failed", e, {
+					event_type: "anon_read",
+					game_id: gameId,
+				});
+			});
 	}
 
 	// Non-owner reads go through the per-POP blob cache (see blob-cache.ts):

--- a/cloud/test/helpers/games.ts
+++ b/cloud/test/helpers/games.ts
@@ -1,0 +1,64 @@
+// Game seeding for the games/* integration tests — a games row plus the R2
+// blob that `GET /v1/games/:id` reads.
+//
+// Direct INSERT rather than driving handleGameUpload: the upload path wants a
+// real parsed FullGameData payload and a multipart ZIP, neither of which the
+// read-path tests care about. Everything these tests exercise happens after
+// the row and the object exist.
+
+import { env } from "cloudflare:test";
+import { nanoid } from "nanoid";
+import type { TestUser } from "./builders";
+
+// Minimal FullGameData-shaped blob. handleGameDetail only JSON-parses it and
+// spreads D1 metadata over the top, so the parser-level shape doesn't matter
+// here — player_roster carries an online_id so the PII strip is exercised.
+export function makeBlob(gameName: string): Record<string, unknown> {
+	return {
+		match_metadata: { game_name: gameName, winner: null },
+		player_roster: [{ player_index: 0, online_id: "STEAM_SECRET" }],
+	};
+}
+
+export async function putBlob(
+	gameId: string,
+	blob: Record<string, unknown>,
+): Promise<void> {
+	const gz = new Response(
+		new Response(JSON.stringify(blob)).body!.pipeThrough(
+			new CompressionStream("gzip"),
+		),
+	);
+	await env.SHARE_BUCKET.put(
+		`games/${gameId}.json.gz`,
+		await gz.arrayBuffer(),
+		{
+			httpMetadata: { contentType: "application/json" },
+		},
+	);
+}
+
+export async function seedGame(
+	user: TestUser,
+	opts: { isPublic: boolean; gameName?: string },
+): Promise<string> {
+	const gameId = nanoid(21);
+	await env.SHARE_DB.prepare(
+		`INSERT INTO games (
+			game_id, user_id, xml_game_id, total_turns, file_hash,
+			game_name, is_public, blob_version, blob_size_bytes, parser_version
+		) VALUES (?, ?, ?, ?, ?, ?, ?, 2, 1024, '1.0.0')`,
+	)
+		.bind(
+			gameId,
+			user.userId,
+			nanoid(36),
+			50,
+			nanoid(64),
+			opts.gameName ?? "Test Game",
+			opts.isPublic ? 1 : 0,
+		)
+		.run();
+	await putBlob(gameId, makeBlob(opts.gameName ?? "Test Game"));
+	return gameId;
+}

--- a/cloud/test/integration/games/anon-read-rate-limit.test.ts
+++ b/cloud/test/integration/games/anon-read-rate-limit.test.ts
@@ -1,0 +1,241 @@
+// Per-IP anonymous-read rate limit on GET /v1/games/:id — ANON_READS_PER_HOUR
+// counted from the D1 `events` table, shared with /v1/games/public-recent
+// under the `anon_read` event type.
+//
+// These tests pin the *order* of the gate, not just the cap. handleGameDetail
+// issues the backing count concurrently with the games-row read whenever the
+// request carries no session (issue #150): non-ownership is certain for those,
+// so the two queries need not be sequential. That hoist must not move any
+// decision. What has to stay true:
+//
+//   * 404 (no such game) and 401/403 (not visible to this caller) are still
+//     decided BEFORE 429, so an over-limit IP asking for a game it could never
+//     read gets the same answer as an under-limit one.
+//   * The audit INSERT that consumes a budget slot still sits behind the
+//     visibility gate — a request that was never served must not spend one.
+//     Only the read-only COUNT was hoisted.
+//   * Callers the hoist skips are still enforced: a signed-in non-owner may be
+//     the owner as far as the preamble knows, so its count is issued later, in
+//     the gate itself. Losing that fallback would silently stop rate-limiting
+//     every logged-in viewer.
+//   * Owners and scraper User-Agents remain exempt entirely.
+
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
+import { ANON_READS_PER_HOUR } from "../../../src/games";
+import { expectErrorCode, expectOk } from "../../helpers/assertions";
+import { makeUser, type TestUser } from "../../helpers/builders";
+import { seedGame } from "../../helpers/games";
+
+beforeAll(async () => {
+	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
+});
+
+// Fill an IP's hourly bucket to the cap without firing N real reads.
+//
+// One statement, not the await-per-row loop its sibling
+// (tournament/rate-limit-view.test.ts seedViewEvents) uses. Most tests in this
+// file need a full bucket, and per-row seeding — as a loop or as a batch of N
+// statements — put enough extra work through the shared test runtime to start
+// tipping already-marginal timing-sensitive tests in *other* files into
+// timeouts. A recursive CTE generates the rows server-side instead.
+async function seedAnonReads(ip: string, count: number): Promise<void> {
+	await env.SHARE_DB.prepare(
+		`INSERT INTO events (event_type, ip_address)
+		 WITH RECURSIVE seq(i) AS (
+		   SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < ?
+		 )
+		 SELECT 'anon_read', ? FROM seq`,
+	)
+		.bind(count, ip)
+		.run();
+}
+
+async function countAnonReads(ip: string): Promise<number> {
+	const row = await env.SHARE_DB.prepare(
+		`SELECT COUNT(*) AS n FROM events
+		 WHERE event_type = 'anon_read' AND ip_address = ?`,
+	)
+		.bind(ip)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+// The audit INSERT is fire-and-forget — the handler starts it and returns
+// without awaiting, so it can land after the response does.
+//
+// Presence polls; absence can't. A poll that finds nothing proves only that
+// nothing has landed *yet*, which is exactly what a broken implementation
+// looks like for the first few milliseconds. So the absence assertions wait a
+// fixed, generous window instead: the INSERT is *issued* synchronously inside
+// the handler, so if the gate ever moved above it, local D1 would have the row
+// well inside this budget.
+const SETTLE_MS = 150;
+
+async function expectAnonReadsToReach(
+	ip: string,
+	expected: number,
+): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if ((await countAnonReads(ip)) >= expected) break;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	expect(await countAnonReads(ip)).toBe(expected);
+}
+
+async function expectAnonReadsToStayAt(
+	ip: string,
+	expected: number,
+): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+	expect(await countAnonReads(ip)).toBe(expected);
+}
+
+// The shared `request` helper sends no CF headers, and getClientIp ignores
+// CF-Connecting-IP unless CF-RAY is present (an untrusted topology collapses
+// to one shared bucket, which would make these tests interfere). So per-IP
+// tests go through SELF.fetch directly, same as rate-limit-view.test.ts.
+function get(
+	path: string,
+	opts: { ip: string; as?: TestUser; ua?: string },
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		Origin: "http://localhost:1420",
+		"CF-Connecting-IP": opts.ip,
+		"CF-RAY": "test-ray",
+	};
+	if (opts.as) headers["Cookie"] = `session=${opts.as.sessionToken}`;
+	if (opts.ua) headers["User-Agent"] = opts.ua;
+	return SELF.fetch(`http://test${path}`, { headers });
+}
+
+interface DetailBody {
+	match_metadata: { game_name: string };
+}
+
+describe("anon_read rate limit on GET /v1/games/:id", () => {
+	it("429s an anonymous read once the per-IP cap is reached", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		const ip = "203.0.113.20";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		await expectErrorCode(await get(`/v1/games/${gameId}`, { ip }), {
+			status: 429,
+			code: "RATE_LIMIT",
+		});
+	});
+
+	it("records exactly one anon_read for a served anonymous read", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, {
+			isPublic: true,
+			gameName: "Served",
+		});
+		const ip = "203.0.113.21";
+
+		const body = await expectOk<DetailBody>(
+			await get(`/v1/games/${gameId}`, { ip }),
+		);
+		expect(body.match_metadata.game_name).toBe("Served");
+
+		// Reading consumes a budget slot — the guard that keeps the limit from
+		// being a no-op on this route.
+		await expectAnonReadsToReach(ip, 1);
+	});
+
+	it("404s a missing game ahead of the limit, spending no budget", async () => {
+		const ip = "203.0.113.22";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		// Over the cap, but the row read decides first — as it did before the
+		// count was hoisted alongside it.
+		await expectErrorCode(await get(`/v1/games/${nanoid(21)}`, { ip }), {
+			status: 404,
+			code: "NOT_FOUND",
+		});
+		await expectAnonReadsToStayAt(ip, ANON_READS_PER_HOUR);
+	});
+
+	it("401s a private game ahead of the limit, spending no budget", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: false });
+		const ip = "203.0.113.23";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		await expectErrorCode(await get(`/v1/games/${gameId}`, { ip }), {
+			status: 401,
+			code: "UNAUTHORIZED",
+		});
+		await expectAnonReadsToStayAt(ip, ANON_READS_PER_HOUR);
+	});
+
+	it("403s a signed-in non-owner of a private game, spending no budget", async () => {
+		const owner = await makeUser();
+		const viewer = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: false });
+		const ip = "203.0.113.24";
+
+		await expectErrorCode(
+			await get(`/v1/games/${gameId}`, { ip, as: viewer }),
+			{
+				status: 403,
+				code: "FORBIDDEN",
+			},
+		);
+		await expectAnonReadsToStayAt(ip, 0);
+	});
+
+	it("still enforces the cap for a signed-in non-owner", async () => {
+		const owner = await makeUser();
+		const viewer = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		const ip = "203.0.113.25";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		// This caller never gets the hoisted count — the preamble can't rule out
+		// ownership while a session is present, so the gate issues its own.
+		await expectErrorCode(
+			await get(`/v1/games/${gameId}`, { ip, as: viewer }),
+			{
+				status: 429,
+				code: "RATE_LIMIT",
+			},
+		);
+	});
+
+	it("counts a served signed-in non-owner read", async () => {
+		const owner = await makeUser();
+		const viewer = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		const ip = "203.0.113.26";
+
+		await expectOk(await get(`/v1/games/${gameId}`, { ip, as: viewer }));
+		await expectAnonReadsToReach(ip, 1);
+	});
+
+	it("exempts the owner from the cap and records nothing", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		const ip = "203.0.113.27";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		await expectOk(await get(`/v1/games/${gameId}`, { ip, as: owner }));
+		await expectAnonReadsToStayAt(ip, ANON_READS_PER_HOUR);
+	});
+
+	it("exempts a scraper User-Agent from the cap and records nothing", async () => {
+		const owner = await makeUser();
+		const gameId = await seedGame(owner, { isPublic: true });
+		const ip = "203.0.113.28";
+		await seedAnonReads(ip, ANON_READS_PER_HOUR);
+
+		// Link unfurls must always resolve, so scrapers bypass both the gate and
+		// the audit insert — which means the count is never even issued for them.
+		await expectOk(
+			await get(`/v1/games/${gameId}`, { ip, ua: "Twitterbot/1.0" }),
+		);
+		await expectAnonReadsToStayAt(ip, ANON_READS_PER_HOUR);
+	});
+});

--- a/cloud/test/integration/games/blob-cache.test.ts
+++ b/cloud/test/integration/games/blob-cache.test.ts
@@ -13,65 +13,14 @@
 
 import { applyD1Migrations, env } from "cloudflare:test";
 import { beforeAll, describe, expect, it } from "vitest";
-import { nanoid } from "nanoid";
 import { expectErrorCode, expectOk } from "../../helpers/assertions";
-import { makeUser, type TestUser } from "../../helpers/builders";
+import { makeUser } from "../../helpers/builders";
+import { makeBlob, putBlob, seedGame } from "../../helpers/games";
 import { request } from "../../helpers/requests";
 
 beforeAll(async () => {
 	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
 });
-
-// Minimal FullGameData-shaped blob. handleGameDetail only JSON-parses it and
-// spreads D1 metadata over the top, so the parser-level shape doesn't matter
-// here — player_roster carries an online_id so the PII strip is exercised.
-function makeBlob(gameName: string): Record<string, unknown> {
-	return {
-		match_metadata: { game_name: gameName, winner: null },
-		player_roster: [{ player_index: 0, online_id: "STEAM_SECRET" }],
-	};
-}
-
-async function putBlob(
-	gameId: string,
-	blob: Record<string, unknown>,
-): Promise<void> {
-	const gz = new Response(
-		new Response(JSON.stringify(blob)).body!.pipeThrough(
-			new CompressionStream("gzip"),
-		),
-	);
-	await env.SHARE_BUCKET.put(
-		`games/${gameId}.json.gz`,
-		await gz.arrayBuffer(),
-		{ httpMetadata: { contentType: "application/json" } },
-	);
-}
-
-async function seedGame(
-	user: TestUser,
-	opts: { isPublic: boolean; gameName?: string },
-): Promise<string> {
-	const gameId = nanoid(21);
-	await env.SHARE_DB.prepare(
-		`INSERT INTO games (
-			game_id, user_id, xml_game_id, total_turns, file_hash,
-			game_name, is_public, blob_version, blob_size_bytes, parser_version
-		) VALUES (?, ?, ?, ?, ?, ?, ?, 2, 1024, '1.0.0')`,
-	)
-		.bind(
-			gameId,
-			user.userId,
-			nanoid(36),
-			50,
-			nanoid(64),
-			opts.gameName ?? "Test Game",
-			opts.isPublic ? 1 : 0,
-		)
-		.run();
-	await putBlob(gameId, makeBlob(opts.gameName ?? "Test Game"));
-	return gameId;
-}
 
 interface DetailBody {
 	match_metadata: { game_name: string };

--- a/src/routes/games/[id]/+page.ts
+++ b/src/routes/games/[id]/+page.ts
@@ -88,6 +88,17 @@ function mapApiErrorToPage(err: unknown): never {
 // (or signed-in non-owner of a private game gets 403, handled separately
 // — anonymous+private is the only 401 case the load needs to redirect on).
 export const load: PageLoad = async ({ params, fetch, url }) => {
+	// Start the tournament-link read before awaiting the game. It takes only
+	// params.id and reads nothing from the game payload, so the sequence these
+	// two used to run in was a false dependency — it charged the page the link
+	// handler's D1 round trips *after* the game read's instead of alongside
+	// them. The .catch() is attached here rather than at the await below so a
+	// getGame throw can't leave this promise rejecting unhandled.
+	const linkPromise = cloudApi
+		.getGameTournamentLink(params.id, { fetch })
+		.then((res) => res.link)
+		.catch(() => null);
+
 	let game;
 	try {
 		game = await cloudApi.getGame(params.id, { fetch });
@@ -119,14 +130,8 @@ export const load: PageLoad = async ({ params, fetch, url }) => {
 	// Tournament link: cheap public read that returns the linked
 	// tournament/match (or null) for any game. Used by the preTabs banner
 	// on GameDetailView. Failure here just hides the banner — don't block
-	// the page render.
-	let tournamentLink = null;
-	try {
-		const linkRes = await cloudApi.getGameTournamentLink(params.id, { fetch });
-		tournamentLink = linkRes.link;
-	} catch {
-		// fall through
-	}
+	// the page render. Issued above, concurrently with the game read.
+	const tournamentLink = await linkPromise;
 
 	return {
 		game,


### PR DESCRIPTION
Implements items 1–3 of the closing plan on #150, plus test coverage for the one that reorders a gate.

Static reading establishes which queries are *independent*; it cannot establish payoff. No latency claim here is measured — #150's instrumentation item is still blocked on a Logpush destination. What these changes do is remove sequencing that was never required, which is verifiable by reading.

## The changes

**1. `getGame` + `getGameTournamentLink` run concurrently** (`src/routes/games/[id]/+page.ts`)

`getGameTournamentLink` takes only `params.id` and reads nothing from the game payload, so awaiting it after `getGame` was a false dependency. The `.catch()` is attached where the promise is created rather than at the await, so a `getGame` throw can't leave it rejecting unhandled. Error semantics are otherwise unchanged.

**2. `handleMe`: 4 D1 round trips → 2** (`cloud/src/auth.ts`)

- `isSiteAdmin()` re-selected `discord_id` for a user_id the handler already holds on `row`. Comparing inline deletes that round trip. `isSiteAdmin` is unchanged and keeps its six other call sites.
- `claimTournamentSlots` and the beta lookup both need only the users row and neither reads the other, so they run concurrently. `Promise.all`, not `db.batch()` — batch is transactional, and a claim failure must not take the beta read with it. Deferring the claim to `waitUntil` is also not an option: `+layout.ts` calls `getMyTournaments` straight after, and that handler reads exactly what the claim writes.

No behavior change.

**3. `handleGameDetail`: the anon read-limit count overlaps the games-row read** (`cloud/src/games.ts`)

A sessionless request cannot be the owner, so non-ownership is certain before either query runs — exact, not speculative. Signed-in requests keep the sequential path (they may be the owner, and owners aren't counted), falling back to the query at the gate.

Only the read-only `COUNT` moved. Gate order is untouched — 404, then 401/403, then 429, then the audit insert — and the insert still sits behind the visibility gate, so a request that was never served still spends no budget.

## Tests

`cloud/test/integration/games/anon-read-rate-limit.test.ts` — 9 tests. The 429 path on this route had no coverage at all, and change 3 reorders the queries behind it, so these pin the *order*, not just the cap.

Both load-bearing properties were confirmed by mutation:

| Mutation | Tests red |
|---|---|
| Drop the signed-in fallback count | 1 |
| Move the audit insert above the visibility gate | 6 |

The game seeder was extracted from `blob-cache.test.ts` into `cloud/test/helpers/games.ts` rather than copy-pasted (`blob-cache.test.ts` is a pure move, asserting exactly what it did before).

Seeding fills the bucket with one recursive-CTE statement rather than per-row inserts. The row-at-a-time version put enough extra work through the shared test runtime to tip already-marginal timing-sensitive tests in *other* files into timeouts; the CTE version measures at the clean-tree baseline over 5 full-suite runs.

## Not in scope

- The `countEventsSince` → per-POP counter swap (#150 plan item 2) — a real accuracy-for-latency trade.
- KV-caching `/v1/games/public-recent` (plan item 4).
- Instrumentation and Smart Placement — operator/config decisions.

## Verification

- `cloud/` `tsc --noEmit` — clean
- `npm run lint`, `svelte-check` (1284 files, 0 errors) — clean
- `prettier --check` on all changed files — clean
- `cloud/` `npm test` — 525 passing

Two pre-existing failures on `main` are unaffected and unrelated: the 4 `canonical-map-options` tests (DOTA schema drift, #115/#141), and `users/search.test.ts > does NOT count q<2 searches`, which flakes at 2/5 runs on a clean tree and at the same rate here.

Refs #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxG2y1YZXmKYKQMSBR3Rhw