### PR TITLE
feat: Techs tab — full science-source itemization + leader/knowledge rail markers

### DIFF
--- a/cloud/src/schemas/game.ts
+++ b/cloud/src/schemas/game.ts
@@ -108,12 +108,13 @@ export const MAX_DISABLED_IMPROVEMENTS = 1_000;
 //         player who owned the wonder's tile on the turn it completed, read
 //         from the ownership history, rather than whoever holds the tile at
 //         the end. Blobs below 2.12.0 credit a captured wonder to its captor.
-// 2.14.0: adds per-city religion presence, project counts, and governor
-//         xml_id on city_statistics.cities, plus theologies on
-//         game_religions — the Techs tab's science-source breakdown reads
-//         all four. Purely additive; older blobs lack the fields and the
-//         new breakdown rows are omitted. (2.13.0 is reserved by the open
-//         projects_produced PR; this PR deliberately skips over it.)
+// 2.14.0: adds per-city religion presence, project counts, governor
+//         xml_id, and happiness_level on city_statistics.cities, plus
+//         theologies on game_religions — the Techs tab's science-source
+//         breakdown reads all five. Purely additive; older blobs lack the
+//         fields and the new breakdown rows are omitted. (2.13.0 is
+//         reserved by the open projects_produced PR; this PR deliberately
+//         skips over it.)
 export const KNOWN_PARSER_VERSIONS = new Set([
 	"2.0.0",
 	"2.1.0",

--- a/cloud/src/schemas/game.ts
+++ b/cloud/src/schemas/game.ts
@@ -108,6 +108,12 @@ export const MAX_DISABLED_IMPROVEMENTS = 1_000;
 //         player who owned the wonder's tile on the turn it completed, read
 //         from the ownership history, rather than whoever holds the tile at
 //         the end. Blobs below 2.12.0 credit a captured wonder to its captor.
+// 2.14.0: adds per-city religion presence, project counts, and governor
+//         xml_id on city_statistics.cities, plus theologies on
+//         game_religions — the Techs tab's science-source breakdown reads
+//         all four. Purely additive; older blobs lack the fields and the
+//         new breakdown rows are omitted. (2.13.0 is reserved by the open
+//         projects_produced PR; this PR deliberately skips over it.)
 export const KNOWN_PARSER_VERSIONS = new Set([
 	"2.0.0",
 	"2.1.0",
@@ -127,13 +133,14 @@ export const KNOWN_PARSER_VERSIONS = new Set([
 	"2.10.0",
 	"2.11.0",
 	"2.12.0",
+	"2.14.0",
 ]);
 
 // The latest accepted version. Echoed back on stats responses and
 // embedded in stats cache keys so a parser bump (after the matching
 // extraction code lands) naturally orphans every old entry. Bump in
 // lockstep with the `KNOWN_PARSER_VERSIONS` addition above.
-export const CURRENT_PARSER_VERSION = "2.12.0";
+export const CURRENT_PARSER_VERSION = "2.14.0";
 
 // ----- Reusable atoms -----
 

--- a/scripts/bake-science-yields.ts
+++ b/scripts/bake-science-yields.ts
@@ -79,6 +79,7 @@ interface Entry {
 	iValue?: string;
 	iPercent?: string;
 	iTriangleOffset?: string;
+	iNegativeHappinessModifier?: string;
 	aiYieldOutput?: { Pair?: YieldPair | YieldPair[] };
 	aiYieldRate?: { Pair?: YieldPair | YieldPair[] };
 	aiYieldModifier?: { Pair?: YieldPair | YieldPair[] };
@@ -194,6 +195,18 @@ async function main(): Promise<void> {
 		findEntry(yields, "YIELD_SCIENCE", "yield.xml").iTriangleOffset,
 		"YIELD_SCIENCE iTriangleOffset",
 	);
+	// Percent science per city discontent level (yield.xml
+	// <iNegativeHappinessModifier>, applied ×|happiness level| when the level
+	// is negative — InfoHelpers.getHappinessLevelYieldModifier). Negative.
+	const scienceDiscontentModifier = requireInt(
+		findEntry(yields, "YIELD_SCIENCE", "yield.xml").iNegativeHappinessModifier,
+		"YIELD_SCIENCE iNegativeHappinessModifier",
+	);
+	if (scienceDiscontentModifier >= 0) {
+		throw new Error(
+			"bake-science-yields: YIELD_SCIENCE iNegativeHappinessModifier is not negative",
+		);
+	}
 	const competitiveEquivalentRating = requireInt(
 		findEntry(
 			globalInts,
@@ -648,6 +661,17 @@ async function main(): Promise<void> {
 	lines.push("// around COMPETITIVE_EQUIVALENT_RATING — to get the city's %.");
 	lines.push(
 		`export const WISDOM_GOVERNOR_SCIENCE_MODIFIER = ${wisdomGovernorScienceModifier};`,
+	);
+	lines.push("");
+	lines.push(
+		"// Percent city science PER DISCONTENT LEVEL (yield.xml",
+	);
+	lines.push(
+		"// iNegativeHappinessModifier ×|level| — getHappinessLevelYieldModifier).",
+	);
+	lines.push("// Negative: an unhappy city genuinely earns less.");
+	lines.push(
+		`export const SCIENCE_DISCONTENT_MODIFIER = ${scienceDiscontentModifier};`,
 	);
 	lines.push("");
 	lines.push(

--- a/scripts/bake-science-yields.ts
+++ b/scripts/bake-science-yields.ts
@@ -70,17 +70,22 @@ interface Entry {
 	AssetVariation?: string;
 	EffectCity?: string;
 	EffectCityExtra?: string;
+	EffectPlayer?: string;
 	TechPrereq?: string;
 	LawClass?: string;
 	Specialist?: string;
 	zIconName?: string;
 	iCost?: string;
 	iValue?: string;
+	iPercent?: string;
 	iTriangleOffset?: string;
 	aiYieldOutput?: { Pair?: YieldPair | YieldPair[] };
 	aiYieldRate?: { Pair?: YieldPair | YieldPair[] };
 	aiYieldModifier?: { Pair?: YieldPair | YieldPair[] };
 	aiYieldCourtRate?: { Pair?: YieldPair | YieldPair[] };
+	aiYieldGovernorModifier?: { Pair?: YieldPair | YieldPair[] };
+	aiYieldRateSpecialist?: { Pair?: YieldPair | YieldPair[] };
+	aiYieldRateReligion?: { Pair?: YieldPair | YieldPair[] };
 	aiImprovementClassModifier?: { Pair?: YieldPair | YieldPair[] };
 	aaiResourceYieldOutput?: { Pair?: ResourceYieldPair | ResourceYieldPair[] };
 }
@@ -126,6 +131,11 @@ async function main(): Promise<void> {
 		laws,
 		lawClasses,
 		techs,
+		familyClasses,
+		nations,
+		theologies,
+		projects,
+		knowledges,
 	] = await Promise.all([
 		loadEntries(resolve(infosDir, "improvement.xml")),
 		loadEntries(resolve(infosDir, "improvementClass.xml")),
@@ -138,6 +148,11 @@ async function main(): Promise<void> {
 		loadEntries(resolve(infosDir, "law.xml")),
 		loadEntries(resolve(infosDir, "lawClass.xml")),
 		loadEntries(resolve(infosDir, "tech.xml")),
+		loadEntries(resolve(infosDir, "familyClass.xml")),
+		loadEntries(resolve(infosDir, "nation.xml")),
+		loadEntries(resolve(infosDir, "theology.xml")),
+		loadEntries(resolve(infosDir, "project.xml")),
+		loadEntries(resolve(infosDir, "knowledge.xml")),
 	]);
 
 	const effectByType = new Map(effects.map((e) => [e.zType, e]));
@@ -198,6 +213,101 @@ async function main(): Promise<void> {
 			),
 			"YIELD_SCIENCE",
 		) / 10;
+
+	// Percent city science per boosted point of the governor's Wisdom
+	// (rating.xml <aiYieldGovernorModifier>). RAW percent — the consumer
+	// multiplies by Utils.triangleBoost(wisdom) (or the Competitive
+	// linearization), so this is NOT ÷10 fixed point.
+	const wisdomGovernorScienceModifier = yieldValue(
+		pairs(
+			findEntry(ratings, "RATING_WISDOM", "rating.xml")
+				.aiYieldGovernorModifier,
+		),
+		"YIELD_SCIENCE",
+	);
+	if (wisdomGovernorScienceModifier === 0) {
+		throw new Error(
+			"bake-science-yields: RATING_WISDOM has no YIELD_SCIENCE aiYieldGovernorModifier",
+		);
+	}
+
+	// Family classes whose city effect pays flat science per placed specialist
+	// (effectCity <aiYieldRateSpecialist> — any specialist, unlike
+	// Constitution's urban-only tag). Sages is the only one today; baking the
+	// whole table keeps the authority in the XML.
+	const familyClassSciencePerSpecialist: Record<string, number> = {};
+	for (const fc of familyClasses) {
+		if (!fc.zType) continue;
+		const e = fc.EffectCity ? effectByType.get(fc.EffectCity) : undefined;
+		const v = e
+			? yieldValue(pairs(e.aiYieldRateSpecialist), "YIELD_SCIENCE")
+			: 0;
+		if (v > 0) familyClassSciencePerSpecialist[fc.zType] = v / 10;
+	}
+
+	// Nations whose player effect grants flat city science (nation.xml
+	// EffectPlayer → effectPlayer.xml EffectCity → effectCity <aiYieldRate>,
+	// applied to every city). Babylonia is the only one today.
+	const effectPlayerByType = new Map(effectPlayers.map((e) => [e.zType, e]));
+	const nationCityScience: Record<string, number> = {};
+	for (const n of nations) {
+		if (!n.zType) continue;
+		const ep = n.EffectPlayer
+			? effectPlayerByType.get(n.EffectPlayer)
+			: undefined;
+		const e = ep?.EffectCity ? effectByType.get(ep.EffectCity) : undefined;
+		const v = e ? yieldValue(pairs(e.aiYieldRate), "YIELD_SCIENCE") : 0;
+		if (v > 0) nationCityScience[n.zType] = v / 10;
+	}
+
+	// Theologies whose city effect pays science per religion PRESENT in the
+	// city (effectCity <aiYieldRateReligion> × City.getReligionCount()). The
+	// effect lands on every city where a religion holding the theology is
+	// present. Dualism is the only one today.
+	const theologySciencePerReligion: Record<string, number> = {};
+	for (const t of theologies) {
+		if (!t.zType) continue;
+		const e = t.EffectCity ? effectByType.get(t.EffectCity) : undefined;
+		const v = e ? yieldValue(pairs(e.aiYieldRateReligion), "YIELD_SCIENCE") : 0;
+		if (v > 0) theologySciencePerReligion[t.zType] = v / 10;
+	}
+
+	// City projects whose effect pays flat science (project.xml EffectCity +
+	// EffectCityExtra → effectCity <aiYieldRate>): the Archive tiers
+	// (+1/+2/+4/+8) and friends. City.cs:5058 keeps both effect counts equal
+	// to the project count, but a <bSingle> effect pays once no matter the
+	// count — `single` tells the consumer to cap the count at 1 (Archives,
+	// the no-characters Governor project) vs. multiply (Convoys).
+	const projectScience: Record<string, { science: number; single: boolean }> =
+		{};
+	for (const p of projects) {
+		if (!p.zType) continue;
+		let science = 0;
+		let single = false;
+		for (const name of [p.EffectCity, p.EffectCityExtra]) {
+			const e = name ? effectByType.get(name) : undefined;
+			const v = e ? yieldValue(pairs(e.aiYieldRate), "YIELD_SCIENCE") : 0;
+			if (v > 0) {
+				science += v;
+				single ||= (e as { bSingle?: string } | undefined)?.bSingle === "1";
+			}
+		}
+		if (science > 0) projectScience[p.zType] = { science: science / 10, single };
+	}
+
+	// Knowledge tiers (knowledge.xml), in file order. `percent` is the tier's
+	// inclusive upper bound on (their science total × 100 / ours), integer
+	// division; the entry with no iPercent (Erudite) is the catch-all —
+	// InfoPercentBase defaults miPercent to int.MaxValue.
+	const knowledgeTiers = knowledges
+		.filter((k) => k.zType)
+		.map((k) => ({
+			type: k.zType!,
+			percent: k.iPercent != null ? Number(k.iPercent) : null,
+		}));
+	if (knowledgeTiers.length === 0) {
+		throw new Error("bake-science-yields: knowledge.xml yielded no tiers");
+	}
 
 	// Per-resource science of resource-sited improvement classes (groves):
 	// class → { RESOURCE_* → display science }.
@@ -520,6 +630,82 @@ async function main(): Promise<void> {
 	lines.push("// lowered character yields above.");
 	lines.push(
 		`export const COMPETITIVE_SCIENCE_STIPEND = ${competitiveScienceStipend};`,
+	);
+	lines.push("");
+	lines.push(
+		"// ─── Governor / city-effect science (City.cs yield derivation) ──────",
+	);
+	lines.push("");
+	lines.push(
+		"// Percent city science per boosted point of the governor's Wisdom",
+	);
+	lines.push(
+		"// (rating.xml <aiYieldGovernorModifier>). RAW percent: multiply by",
+	);
+	lines.push(
+		"// Utils.triangleBoost(wisdom) — or the Competitive linearization",
+	);
+	lines.push("// around COMPETITIVE_EQUIVALENT_RATING — to get the city's %.");
+	lines.push(
+		`export const WISDOM_GOVERNOR_SCIENCE_MODIFIER = ${wisdomGovernorScienceModifier};`,
+	);
+	lines.push("");
+	lines.push(
+		"// Family class → flat science per placed specialist in its cities",
+	);
+	lines.push(
+		"// (effectCity <aiYieldRateSpecialist>, any specialist — Sages).",
+	);
+	lines.push(
+		`export const FAMILY_CLASS_SCIENCE_PER_SPECIALIST: Readonly<Record<string, number>> = ${JSON.stringify(sorted(familyClassSciencePerSpecialist))};`,
+	);
+	lines.push("");
+	lines.push(
+		"// Nation → flat science per city from its player effect (Babylonia).",
+	);
+	lines.push(
+		`export const NATION_CITY_SCIENCE: Readonly<Record<string, number>> = ${JSON.stringify(sorted(nationCityScience))};`,
+	);
+	lines.push("");
+	lines.push(
+		"// Theology → science per religion present, in each city where a",
+	);
+	lines.push(
+		"// religion holding the theology is present (City.cs ×getReligionCount).",
+	);
+	lines.push(
+		`export const THEOLOGY_SCIENCE_PER_RELIGION: Readonly<Record<string, number>> = ${JSON.stringify(sorted(theologySciencePerReligion))};`,
+	);
+	lines.push("");
+	lines.push(
+		"// City project → flat science: `single` effects (bSingle — Archives)",
+	);
+	lines.push(
+		"// pay once regardless of count; the rest multiply (Convoys).",
+	);
+	lines.push(
+		`export const PROJECT_SCIENCE: Readonly<Record<string, { readonly science: number; readonly single: boolean }>> = ${JSON.stringify(sorted(projectScience))};`,
+	);
+	lines.push("");
+	lines.push(
+		"// ─── Knowledge tiers (Player.calculateKnowledgeOf) ──────────────────",
+	);
+	lines.push("");
+	lines.push(
+		"// knowledge.xml in file order. A player's knowledge OF another is",
+	);
+	lines.push(
+		"// bucketed by percent = theirScienceTotal × 100 / ourScienceTotal",
+	);
+	lines.push(
+		"// (integer division): the tier with the smallest percent ≥ that value",
+	);
+	lines.push(
+		"// wins (InfoHelpers.getBestPercentValue); `percent: null` (Erudite) is",
+	);
+	lines.push("// the catch-all — InfoPercentBase defaults to int.MaxValue.");
+	lines.push(
+		`export const KNOWLEDGE_TIERS: readonly { readonly type: string; readonly percent: number | null }[] = ${JSON.stringify(knowledgeTiers)};`,
 	);
 	lines.push("");
 

--- a/src/lib/game-detail/EventRail.svelte
+++ b/src/lib/game-detail/EventRail.svelte
@@ -9,16 +9,19 @@
 
 	// One marker on the rail: an icon at its event's turn-x with a rich hover
 	// tooltip. A null iconValue renders a colored dot instead of a sprite.
-	// `glyph` renders the unit flag-glyph variant (units category only).
-	// `gold` gives the marker a gold glow (the app's gold accent) — the
-	// bonus-card highlight on the Military rail; propagated across a proximity
-	// merge so a cluster stays gold when any of its markers is a bonus card.
+	// `label` renders a small text chip instead of either (the Techs rail's
+	// knowledge shifts, "N→C"). `glyph` renders the unit flag-glyph variant
+	// (units category only). `gold` gives the marker a gold glow (the app's
+	// gold accent) — the bonus-card highlight on the Military rail; propagated
+	// across a proximity merge so a cluster stays gold when any of its markers
+	// is a bonus card.
 	export type RailMarker = {
 		turn: number;
 		iconCategory: SpriteCategory;
 		iconValue: string | null;
 		color: string;
 		tooltipHtml: string;
+		label?: string;
 		glyph?: boolean;
 		gold?: boolean;
 	};
@@ -246,7 +249,13 @@
 								onmousemove={(e) => enterEvent(icon, e)}
 								onmouseleave={leaveEvent}
 							>
-								{#if v}
+								{#if icon.label}
+									<span
+										class="whitespace-nowrap rounded-sm px-0.5 text-[9px] font-bold leading-tight"
+										style="color: {icon.color}; background-color: rgb(var(--color-surface));"
+										>{icon.label}</span
+									>
+								{:else if v}
 									<SpriteIcon
 										category={icon.iconCategory}
 										value={v}

--- a/src/lib/game-detail/GameDetailView.svelte
+++ b/src/lib/game-detail/GameDetailView.svelte
@@ -581,6 +581,7 @@
 			{memoryData}
 			{storyEvents}
 			{characters}
+			{gameReligions}
 			gameOptions={gameDetails.game_options}
 			{userNation}
 			bind:chartFilter={chartFilters.techs}

--- a/src/lib/game-detail/LeaderCard.svelte
+++ b/src/lib/game-detail/LeaderCard.svelte
@@ -9,10 +9,11 @@
 	import Popover from "$lib/ui/Popover.svelte";
 	import {
 		archetypeSpriteKey,
+		deathReasonLabel,
 		formatArchetype,
 		formatEnum,
 		isArchetypeTrait,
-		toRomanNumeral,
+		rulerDisplayName,
 	} from "$lib/utils/formatting";
 	import { getCivilizationColor } from "$lib/config";
 	import { GOAL_NAMES } from "$lib/generated/goal-names";
@@ -38,14 +39,8 @@
 	);
 
 	// ─── Display helpers ──────────────────────────────────────────────
-	// First name plus the regnal numeral when the leader shares a name with an
-	// earlier ruler (suffix > 1). The first of a name carries no numeral, matching
-	// Old World. The numeral is appended after formatEnum so its trailing-digit
-	// strip can't eat it (and it's Roman letters anyway).
-	const rulerName = (c: CharacterInfo): string => {
-		const name = formatEnum(c.first_name, "NAME_") || "Unknown";
-		return c.suffix > 1 ? `${name} ${toRomanNumeral(c.suffix)}` : name;
-	};
+	const rulerName = (c: CharacterInfo): string =>
+		rulerDisplayName(c.first_name, c.suffix);
 
 	const cognomen = (c: CharacterInfo): string | null =>
 		c.cognomen ? formatEnum(c.cognomen, "COGNOMEN_") : null;
@@ -58,12 +53,7 @@
 		c.archetype ? archetypeSpriteKey(c.archetype) : null;
 
 	const deathLabel = (reason: string | null): string | null =>
-		reason
-			? formatEnum(
-					reason.replace(/^TEXT_(TRAIT_)?/, "").replace(/_(F|M)$/, ""),
-					"",
-				)
-			: null;
+		reason ? deathReasonLabel(reason) : null;
 
 	// Age at death, or at game end if the ruler outlived the save — using the
 	// same turn-as-year convention as the reign length. birth_turn can be

--- a/src/lib/game-detail/MilitaryTab.svelte
+++ b/src/lib/game-detail/MilitaryTab.svelte
@@ -38,6 +38,7 @@
 		toggleSort,
 		classifyUnit,
 		getSpritePath,
+		ratingChipsRowHtml,
 		techName,
 		UNIT_CLASS_COLORS,
 		filledLineStyle,
@@ -224,23 +225,9 @@
 		playerHistory[0]?.history.map((h) => h.turn) ?? [],
 	);
 
-	// Rating chip for the leader tooltip: the in-game stat icon + value.
-	function ratingChip(
-		label: string,
-		key: string,
-		value: number | null,
-	): string {
-		if (value == null) return "";
-		const url = getSpritePath("icons", key);
-		const ic = url
-			? `<img src="${url}" alt="${label}" style="width:13px;height:13px"/>`
-			: `${label}`;
-		return `<span style="display:inline-flex;align-items:center;gap:3px">${ic}${value}</span>`;
-	}
-
 	// Rich tooltip for a leader marker, borrowing LeaderCard's field set: name
 	// (+ cognomen), archetype, crowned turn, and the four character ratings,
-	// each shown with its in-game stat icon.
+	// each shown with its in-game stat icon (the shared ratingChipsRowHtml).
 	function leaderTooltip(
 		c: CharacterInfo,
 		turn: number,
@@ -249,19 +236,11 @@
 		const name = c.first_name ? formatEnum(c.first_name, "NAME_") : "New ruler";
 		const cog = c.cognomen ? ` ‘${formatEnum(c.cognomen, "COGNOMEN_")}’` : "";
 		const arch = c.archetype ? formatArchetype(c.archetype) : null;
-		const ratings = [
-			ratingChip("Wis", "RATING_WISDOM", c.wisdom),
-			ratingChip("Cha", "RATING_CHARISMA", c.charisma),
-			ratingChip("Cou", "RATING_COURAGE", c.courage),
-			ratingChip("Dis", "RATING_DISCIPLINE", c.discipline),
-		].join("");
 		return (
 			`<div style="font-size:12px;line-height:1.5">` +
 			`<div style="font-weight:700;color:${color}">${name}${cog}</div>` +
 			`<div style="color:${TOOLTIP_TEXT}">${arch ? `${arch} · ` : ""}crowned T${turn}</div>` +
-			(ratings
-				? `<div style="display:flex;gap:11px;margin-top:4px">${ratings}</div>`
-				: "") +
+			ratingChipsRowHtml(c) +
 			`</div>`
 		);
 	}

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -16,7 +16,12 @@
 	import type { ChartOption, ECharts } from "$lib/echarts";
 	import Chart from "$lib/Chart.svelte";
 	import ChartContainer from "$lib/ChartContainer.svelte";
-	import { formatEnum } from "$lib/utils/formatting";
+	import {
+		archetypeSpriteKey,
+		deathReasonLabel,
+		formatEnum,
+		rulerDisplayName,
+	} from "$lib/utils/formatting";
 	import { CHART_THEME, getNationChartColor } from "$lib/config";
 	import SpriteIcon from "./SpriteIcon.svelte";
 	import EventRail, {
@@ -348,13 +353,53 @@
 		);
 	}
 
+	// Inline Wisdom glyph for the leader-change lines, same trick as SCI_ICON.
+	const WIS_ICON = (() => {
+		const url = getSpritePath("icons", "RATING_WISDOM");
+		return url
+			? `<img src="${url}" alt="wisdom" style="display:inline;width:12px;height:12px;vertical-align:-1px"/>`
+			: "Wisdom";
+	})();
+
+	// Inline archetype glyph (the `traits` sprite the Leaders tab uses).
+	function archetypeIconHtml(c: CharacterInfo): string {
+		const url = c.archetype
+			? getSpritePath("traits", archetypeSpriteKey(c.archetype))
+			: null;
+		return url
+			? `<img src="${url}" alt="" style="display:inline;width:13px;height:13px;vertical-align:-2px;margin-right:2px"/>`
+			: "";
+	}
+
+	// "[archetype] Name — 6 [wisdom]" — the shared ruler line fragment.
+	function rulerHtml(c: CharacterInfo): string {
+		const wis = c.wisdom != null ? ` ${c.wisdom} ${WIS_ICON}` : "";
+		return `${archetypeIconHtml(c)}<b>${rulerDisplayName(c.first_name, c.suffix)}</b>${wis}`;
+	}
+
 	function leaderChangeTooltip(m: LeaderChangeMarker, color: string): string {
-		const wis = (w: number | null) => (w == null ? "" : ` — Wisdom ${w}`);
 		const lines: string[] = [];
-		if (m.prev) lines.push(`${m.prev.name} ${m.prev.end}${wis(m.prev.wisdom)}`);
+		if (m.prev) {
+			const c = m.prev.character;
+			const verb =
+				m.prev.end === "died"
+					? `died, aged ${m.prev.age},`
+					: `${m.prev.end}, aged ${m.prev.age},`;
+			// "[archetype] Name died, aged 25, 6 [wisdom]" — the wisdom trails
+			// the line, per the rail's compact ruler format.
+			lines.push(
+				`${archetypeIconHtml(c)}<b>${rulerDisplayName(c.first_name, c.suffix)}</b> ${verb}${c.wisdom != null ? ` ${c.wisdom} ${WIS_ICON}` : ""}`,
+			);
+			if (m.prev.end === "died" && c.death_reason) {
+				lines.push(`Cause of death: ${deathReasonLabel(c.death_reason)}`);
+			}
+			lines.push(
+				`Reigned for ${m.prev.reignYears} ${m.prev.reignYears === 1 ? "year" : "years"}`,
+			);
+		}
 		lines.push(
 			m.next
-				? `Succeeded by ${m.next.name}${wis(m.next.wisdom)}`
+				? `Succeeded by ${rulerHtml(m.next.character)}`
 				: "No successor took the throne",
 		);
 		return (

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -10,6 +10,7 @@
 	import type {
 		CharacterInfo,
 		FamilyInfo,
+		GameReligion,
 		MemoryInfo,
 	} from "$lib/parser/types";
 	import type { ChartOption, ECharts } from "$lib/echarts";
@@ -45,12 +46,16 @@
 		scienceSpikes,
 		scienceBreakdown,
 		expeditionEvents,
+		leaderChangeMarkers,
+		knowledgeFlipMarkers,
 		STEAL_RESEARCH_MEMORY,
 		type ScienceTechMarker,
 		type FreeTechMarker,
 		type ScienceSpike,
 		type ScienceBreakdown,
 		type NamedCount,
+		type LeaderChangeMarker,
+		type KnowledgeFlipMarker,
 	} from "./science-techs";
 
 	let {
@@ -66,6 +71,7 @@
 		memoryData = [],
 		storyEvents = [],
 		characters = [],
+		gameReligions = [],
 		gameOptions = null,
 		userNation = null,
 		chartFilter = $bindable<Record<string, boolean>>({}),
@@ -82,6 +88,9 @@
 		memoryData?: MemoryInfo[];
 		storyEvents?: StoryEvent[];
 		characters?: CharacterInfo[];
+		// Founded religions with their theologies (2.14.0+) — the science
+		// breakdown's Dualism rows. Defaults to [] for legacy callers.
+		gameReligions?: GameReligion[];
 		// Set <GameOptions> flags. Null on pre-2.11.0 blobs (and from the frozen
 		// web/ viewer) — "unknown", not "none set".
 		gameOptions?: Record<string, true> | null;
@@ -339,8 +348,49 @@
 		);
 	}
 
-	// Row order within each player's band: key techs, free techs, one-off gains.
-	const SCIENCE_RAIL_KINDS = ["key", "free", "event"] as const;
+	function leaderChangeTooltip(m: LeaderChangeMarker, color: string): string {
+		const wis = (w: number | null) => (w == null ? "" : ` — Wisdom ${w}`);
+		const lines: string[] = [];
+		if (m.prev) lines.push(`${m.prev.name} ${m.prev.end}${wis(m.prev.wisdom)}`);
+		lines.push(
+			m.next
+				? `Succeeded by ${m.next.name}${wis(m.next.wisdom)}`
+				: "No successor took the throne",
+		);
+		return (
+			`<div style="font-size:12px;line-height:1.55">` +
+			`<div style="font-weight:700;color:${color}">Leader change · T${m.turn}</div>` +
+			lines
+				.map((t) => `<div style="color:${TOOLTIP_TEXT}">${t}</div>`)
+				.join("") +
+			`</div>`
+		);
+	}
+
+	function knowledgeFlipTooltip(
+		m: KnowledgeFlipMarker,
+		opponent: string,
+		color: string,
+	): string {
+		const tier = (t: string) => formatEnum(t, "KNOWLEDGE_");
+		return (
+			`<div style="font-size:12px;line-height:1.55">` +
+			`<div style="font-weight:700;color:${color}">${tier(m.from)} → ${tier(m.to)} · T${m.turn}</div>` +
+			`<div style="color:${TOOLTIP_TEXT}">Science total at ${m.pct}% of ${opponent}'s</div>` +
+			`<div style="color:${TOOLTIP_MUTED};margin-top:3px">The game's knowledge rating (cumulative science, knowledge.xml thresholds)</div>` +
+			`</div>`
+		);
+	}
+
+	// Row order within each player's band: key techs, free techs, one-off
+	// gains, leader changes, knowledge-standing flips.
+	const SCIENCE_RAIL_KINDS = [
+		"key",
+		"free",
+		"event",
+		"leader",
+		"knowledge",
+	] as const;
 
 	// Per-player slices feeding both the rail markers and the one-off totals.
 	const scienceRailData = $derived.by(() =>
@@ -399,15 +449,22 @@
 		if (orderedPlayers.length !== 2) return [];
 		return scienceRailData
 			.map(
-				({
-					player,
-					techs,
-					improvements,
-					laws,
-					stealTurns,
-					expeditions,
-					spikes,
-				}) => {
+				(
+					{
+						player,
+						techs,
+						improvements,
+						laws,
+						stealTurns,
+						expeditions,
+						science,
+						spikes,
+					},
+					index,
+				) => {
+					// The knowledge standing is vs the one opponent (the rail
+					// only renders for two-player matchups).
+					const opponent = scienceRailData[1 - index];
 					const markers: Record<
 						(typeof SCIENCE_RAIL_KINDS)[number],
 						RailMarker[]
@@ -447,6 +504,31 @@
 							color: player.color,
 							tooltipHtml: spikeTooltip(s, player.color),
 						})),
+						leader: leaderChangeMarkers(player.playerId, characters).map(
+							(m) => ({
+								turn: m.turn,
+								iconCategory: "icons" as const,
+								iconValue: "RATING_WISDOM",
+								color: player.color,
+								tooltipHtml: leaderChangeTooltip(m, player.color),
+							}),
+						),
+						knowledge: knowledgeFlipMarkers(
+							science,
+							opponent?.science ?? [],
+						).map((m) => ({
+							turn: m.turn,
+							// No knowledge sprite exists — null renders the
+							// player-coloured fallback dot.
+							iconCategory: "icons" as const,
+							iconValue: null,
+							color: player.color,
+							tooltipHtml: knowledgeFlipTooltip(
+								m,
+								opponent?.player.label ?? "the opponent",
+								player.color,
+							),
+						})),
 					};
 					return {
 						player,
@@ -473,11 +555,12 @@
 	// ─── Where the science comes from ─────────────────────────────────
 	// End-state itemized decomposition of each player's science/turn, side
 	// by side: specialists and buildings/resources by name, science laws,
-	// the exact percent modifiers (libraries, Musaeum) with their points
-	// computed against each city's base, and the leader's court science.
-	// Governors and the rest of the court (spouses, successors, courtiers,
-	// council) are scaled by each character's opinion of the player, which
-	// the save doesn't store — they stay in the signed "Other" remainder.
+	// per-city effects (Sages, Babylonia, Dualism, Archives), the exact
+	// percent modifiers (libraries, Musaeum, governors' Wisdom) with their
+	// points computed against each city's base, and the leader's court
+	// science. The rest of the court (spouses, successors, courtiers,
+	// council) is scaled by each character's opinion of the player, which
+	// the save doesn't store — it stays in the signed "Other" remainder.
 
 	// Null when the blob predates 2.11.0: UNKNOWN, not "not competitive".
 	const competitive = $derived(
@@ -486,6 +569,11 @@
 			: gameOptions.GAMEOPTION_COMPETITIVE_MODE === true,
 	);
 	const characterById = $derived(new Map(characters.map((c) => [c.xml_id, c])));
+	// religion → theologies established, for the breakdown's Dualism rows.
+	// Empty lists on pre-2.14.0 blobs, which simply produce no rows.
+	const theologiesByReligion = $derived(
+		new Map(gameReligions.map((r) => [r.religion_name, r.theologies ?? []])),
+	);
 
 	type BreakdownColumn = { player: DetailPlayer; b: ScienceBreakdown };
 	const scienceBreakdowns = $derived.by<BreakdownColumn[]>(() => {
@@ -541,6 +629,13 @@
 					finalRate,
 					leaderWisdom,
 					competitive,
+					{
+						cities,
+						nation: player.nation,
+						theologiesByReligion,
+						governorWisdom: (xmlId) =>
+							characterById.get(xmlId)?.wisdom ?? null,
+					},
 					specialistName,
 					improvementDisplayName,
 				),
@@ -557,6 +652,7 @@
 		{ key: "specialistsUrban", label: "Urban specialists" },
 		{ key: "buildings", label: "Buildings & resources" },
 		{ key: "laws", label: "Laws" },
+		{ key: "cityEffects", label: "Nation, family & religion" },
 		{ key: "modifiers", label: "Modifiers" },
 		{ key: "court", label: "Court" },
 	] as const;

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -367,23 +367,23 @@
 		);
 	}
 
+	const knowledgeName = (t: string) => formatEnum(t, "KNOWLEDGE_");
+
 	function knowledgeFlipTooltip(
 		m: KnowledgeFlipMarker,
 		opponent: string,
 		color: string,
 	): string {
-		const tier = (t: string) => formatEnum(t, "KNOWLEDGE_");
 		return (
 			`<div style="font-size:12px;line-height:1.55">` +
-			`<div style="font-weight:700;color:${color}">${tier(m.from)} → ${tier(m.to)} · T${m.turn}</div>` +
+			`<div style="font-weight:700;color:${color}">${knowledgeName(m.from)} → ${knowledgeName(m.to)} · T${m.turn}</div>` +
 			`<div style="color:${TOOLTIP_TEXT}">Science total at ${m.pct}% of ${opponent}'s</div>` +
-			`<div style="color:${TOOLTIP_MUTED};margin-top:3px">The game's knowledge rating (cumulative science, knowledge.xml thresholds)</div>` +
 			`</div>`
 		);
 	}
 
 	// Row order within each player's band: key techs, free techs, one-off
-	// gains, leader changes, knowledge-standing flips.
+	// gains, leader changes, knowledge-standing shifts.
 	const SCIENCE_RAIL_KINDS = [
 		"key",
 		"free",
@@ -513,15 +513,17 @@
 								tooltipHtml: leaderChangeTooltip(m, player.color),
 							}),
 						),
+						// Knowledge shifts render as text chips — "N→C", the tier
+						// initials — since neither a sprite nor a bare dot can say
+						// which of the five states the player moved between.
 						knowledge: knowledgeFlipMarkers(
 							science,
 							opponent?.science ?? [],
 						).map((m) => ({
 							turn: m.turn,
-							// No knowledge sprite exists — null renders the
-							// player-coloured fallback dot.
 							iconCategory: "icons" as const,
 							iconValue: null,
+							label: `${knowledgeName(m.from)[0]}→${knowledgeName(m.to)[0]}`,
 							color: player.color,
 							tooltipHtml: knowledgeFlipTooltip(
 								m,

--- a/src/lib/game-detail/TechsTab.svelte
+++ b/src/lib/game-detail/TechsTab.svelte
@@ -19,6 +19,7 @@
 	import {
 		archetypeSpriteKey,
 		deathReasonLabel,
+		formatArchetype,
 		formatEnum,
 		rulerDisplayName,
 	} from "$lib/utils/formatting";
@@ -40,6 +41,7 @@
 		orderPlayersUploaderFirst,
 		filledLineStyle,
 		getSpritePath,
+		ratingChipsRowHtml,
 		techName,
 		improvementDisplayName,
 		createYieldChartOption,
@@ -353,63 +355,48 @@
 		);
 	}
 
-	// Inline Wisdom glyph for the leader-change lines, same trick as SCI_ICON.
-	const WIS_ICON = (() => {
-		const url = getSpritePath("icons", "RATING_WISDOM");
-		return url
-			? `<img src="${url}" alt="wisdom" style="display:inline;width:12px;height:12px;vertical-align:-1px"/>`
-			: "Wisdom";
-	})();
-
-	// Inline archetype glyph (the `traits` sprite the Leaders tab uses).
-	function archetypeIconHtml(c: CharacterInfo): string {
-		const url = c.archetype
-			? getSpritePath("traits", archetypeSpriteKey(c.archetype))
-			: null;
-		return url
-			? `<img src="${url}" alt="" style="display:inline;width:13px;height:13px;vertical-align:-2px;margin-right:2px"/>`
-			: "";
-	}
-
-	// "[archetype] Name — 6 [wisdom]" — the shared ruler line fragment.
-	function rulerHtml(c: CharacterInfo): string {
-		const wis = c.wisdom != null ? ` ${c.wisdom} ${WIS_ICON}` : "";
-		return `${archetypeIconHtml(c)}<b>${rulerDisplayName(c.first_name, c.suffix)}</b>${wis}`;
+	// Leader-change tooltip, in the Military rail's leader-marker style: bold
+	// name (+ cognomen) header, "Archetype · <event> T<n>" line, and the full
+	// four-rating stat row — one block per ruler, the outgoing one first with
+	// its death/reign detail.
+	function rulerBlockHtml(
+		c: CharacterInfo,
+		color: string,
+		eventLine: string,
+	): string {
+		const cog = c.cognomen ? ` ‘${formatEnum(c.cognomen, "COGNOMEN_")}’` : "";
+		const arch = c.archetype ? formatArchetype(c.archetype) : null;
+		return (
+			`<div style="font-weight:700;color:${color}">${rulerDisplayName(c.first_name, c.suffix)}${cog}</div>` +
+			`<div style="color:${TOOLTIP_TEXT}">${arch ? `${arch} · ` : ""}${eventLine}</div>` +
+			ratingChipsRowHtml(c)
+		);
 	}
 
 	function leaderChangeTooltip(m: LeaderChangeMarker, color: string): string {
-		const lines: string[] = [];
+		const parts: string[] = [];
 		if (m.prev) {
 			const c = m.prev.character;
-			const verb =
-				m.prev.end === "died"
-					? `died, aged ${m.prev.age},`
-					: `${m.prev.end}, aged ${m.prev.age},`;
-			// "[archetype] Name died, aged 25, 6 [wisdom]" — the wisdom trails
-			// the line, per the rail's compact ruler format.
-			lines.push(
-				`${archetypeIconHtml(c)}<b>${rulerDisplayName(c.first_name, c.suffix)}</b> ${verb}${c.wisdom != null ? ` ${c.wisdom} ${WIS_ICON}` : ""}`,
+			const years = `reigned ${m.prev.reignYears} ${m.prev.reignYears === 1 ? "year" : "years"}`;
+			parts.push(
+				rulerBlockHtml(
+					c,
+					color,
+					`${m.prev.end} T${m.turn}, aged ${m.prev.age} · ${years}`,
+				),
 			);
 			if (m.prev.end === "died" && c.death_reason) {
-				lines.push(`Cause of death: ${deathReasonLabel(c.death_reason)}`);
+				parts.push(
+					`<div style="color:${TOOLTIP_MUTED}">Cause of death: ${deathReasonLabel(c.death_reason)}</div>`,
+				);
 			}
-			lines.push(
-				`Reigned for ${m.prev.reignYears} ${m.prev.reignYears === 1 ? "year" : "years"}`,
-			);
 		}
-		lines.push(
+		parts.push(
 			m.next
-				? `Succeeded by ${rulerHtml(m.next.character)}`
-				: "No successor took the throne",
+				? `<div style="margin-top:6px">${rulerBlockHtml(m.next.character, color, `crowned T${m.turn}`)}</div>`
+				: `<div style="margin-top:6px;color:${TOOLTIP_TEXT}">No successor took the throne</div>`,
 		);
-		return (
-			`<div style="font-size:12px;line-height:1.55">` +
-			`<div style="font-weight:700;color:${color}">Leader change · T${m.turn}</div>` +
-			lines
-				.map((t) => `<div style="color:${TOOLTIP_TEXT}">${t}</div>`)
-				.join("") +
-			`</div>`
-		);
+		return `<div style="font-size:12px;line-height:1.5">${parts.join("")}</div>`;
 	}
 
 	const knowledgeName = (t: string) => formatEnum(t, "KNOWLEDGE_");
@@ -550,13 +537,21 @@
 							tooltipHtml: spikeTooltip(s, player.color),
 						})),
 						leader: leaderChangeMarkers(player.playerId, characters).map(
-							(m) => ({
-								turn: m.turn,
-								iconCategory: "icons" as const,
-								iconValue: "RATING_WISDOM",
-								color: player.color,
-								tooltipHtml: leaderChangeTooltip(m, player.color),
-							}),
+							(m) => {
+								// The incoming ruler's archetype glyph (the Military
+								// rail's leader-marker icon); the fall-of-the-line
+								// marker shows the outgoing ruler's.
+								const face = (m.next ?? m.prev)?.character;
+								return {
+									turn: m.turn,
+									iconCategory: "traits-trimmed" as const,
+									iconValue: face?.archetype
+										? archetypeSpriteKey(face.archetype)
+										: null,
+									color: player.color,
+									tooltipHtml: leaderChangeTooltip(m, player.color),
+								};
+							},
 						),
 						// Knowledge shifts render as text chips — "N→C", the tier
 						// initials — since neither a sprite nor a bare dot can say

--- a/src/lib/game-detail/helpers.ts
+++ b/src/lib/game-detail/helpers.ts
@@ -565,6 +565,38 @@ export function getSpritePath(
 	return SPRITE_MANIFEST[`${category}/${enumValue}`] ?? null;
 }
 
+// One rating chip for a character tooltip: the in-game stat icon + value.
+function ratingChipHtml(
+	label: string,
+	key: string,
+	value: number | null,
+): string {
+	if (value == null) return "";
+	const url = getSpritePath("icons", key);
+	const ic = url
+		? `<img src="${url}" alt="${label}" style="width:13px;height:13px"/>`
+		: `${label}`;
+	return `<span style="display:inline-flex;align-items:center;gap:3px">${ic}${value}</span>`;
+}
+
+/**
+ * The four-rating stat line for a character tooltip (Wis/Cha/Cou/Dis, each
+ * with its in-game icon), or "" when no rating is known — the row the
+ * Military rail's leader markers show, shared with the Techs rail's
+ * leader-change markers.
+ */
+export function ratingChipsRowHtml(c: CharacterInfo): string {
+	const chips = [
+		ratingChipHtml("Wis", "RATING_WISDOM", c.wisdom),
+		ratingChipHtml("Cha", "RATING_CHARISMA", c.charisma),
+		ratingChipHtml("Cou", "RATING_COURAGE", c.courage),
+		ratingChipHtml("Dis", "RATING_DISCIPLINE", c.discipline),
+	].join("");
+	return chips
+		? `<div style="display:flex;gap:11px;margin-top:4px">${chips}</div>`
+		: "";
+}
+
 // ─── Unit Classification ────────────────────────────────────────────
 //
 // Chart labels follow the game's own military UnitCycle names: Infantry,

--- a/src/lib/game-detail/science-techs.ts
+++ b/src/lib/game-detail/science-techs.ts
@@ -50,6 +50,7 @@ import {
 	WISDOM_COURT_SCIENCE_RATE,
 	WISDOM_GOVERNOR_SCIENCE_MODIFIER,
 	SCIENCE_TRIANGLE_OFFSET,
+	SCIENCE_DISCONTENT_MODIFIER,
 	COMPETITIVE_EQUIVALENT_RATING,
 	COMPETITIVE_SCIENCE_STIPEND,
 	KNOWLEDGE_TIERS,
@@ -473,11 +474,10 @@ export type ScienceBreakdown = {
 	// SIGNED remainder vs the actual rate: the non-leader court (spouses,
 	// successors, courtiers, council — all opinion-scaled),
 	// Philosophy-via-Forums, connected-foreign-trade science, and every
-	// interaction the save doesn't itemize. The main NEGATIVE components are
-	// the city percent modifiers we can't price — angry/furious family
-	// opinion and discontent — so a science-heavy realm with unhappy
-	// families reads as a visibly negative remainder. Deliberately not
-	// clamped so that shows.
+	// interaction the save doesn't itemize. The main remaining NEGATIVE
+	// component is angry/furious family opinion (a city percent modifier the
+	// save doesn't let us price per family) — discontent IS priced, in the
+	// Modifiers section. Deliberately not clamped so over-counting shows.
 	other: number;
 	// The player's actual science/turn at game end.
 	total: number;
@@ -943,6 +943,27 @@ export function scienceBreakdown(
 		}
 	}
 
+	// Discontent: −5% science per NEGATIVE happiness level in the city
+	// (getHappinessLevelYieldModifier: -(level) × the negative modifier;
+	// positive levels pay nothing for science), estimated against the same
+	// city base. The big legitimate NEGATIVE modifier — with it priced, a
+	// negative Other genuinely means over-counting.
+	for (const city of cityContext.cities) {
+		const level = city.happiness_level;
+		if (level == null || level >= 0) continue;
+		const pct = -level * SCIENCE_DISCONTENT_MODIFIER;
+		const m = cityPct.get(city.city_name) ?? new Map<string, Acc>();
+		bump(
+			m,
+			"Discontent",
+			0,
+			pct,
+			{ category: "yields", value: "YIELD_DISCONTENT" },
+			0,
+		);
+		cityPct.set(city.city_name, m);
+	}
+
 	// Percent modifiers, estimated per city against that city's base (flat
 	// tiles + staff + the law and city-effect yields above).
 	const modifiers = new Map<string, Acc>();
@@ -1218,7 +1239,7 @@ export type KnowledgeFlipMarker = {
 // The game's bucketing (InfoHelpers.getBestPercentValue): the tier with the
 // smallest threshold ≥ pct wins; no threshold (Erudite) is the catch-all.
 function knowledgeTier(pct: number): string {
-	let best: string | null = null;
+	let best = KNOWLEDGE_TIERS[KNOWLEDGE_TIERS.length - 1].type;
 	let min = Infinity;
 	for (const t of KNOWLEDGE_TIERS) {
 		const p = t.percent ?? Infinity;
@@ -1227,17 +1248,24 @@ function knowledgeTier(pct: number): string {
 			best = t.type;
 		}
 	}
-	return best ?? KNOWLEDGE_TIERS[KNOWLEDGE_TIERS.length - 1].type;
+	return best;
 }
 
+// A new tier must hold this many consecutive turns to count as a shift.
+// Sitting exactly on a threshold flip-flops the raw classification every
+// turn (and the blob's ÷10 rounding adds its own jitter) — a burst of
+// C→N / N→C chips at one boundary says nothing a single shift doesn't.
+const KNOWLEDGE_MIN_RUN = 3;
+
 /**
- * Turns where the player's knowledge standing vs the opponent flipped tier —
+ * Turns where the player's knowledge standing vs the opponent shifted tier —
  * Primitive/Naive/Competent/Learned/Erudite, the exact classification the
  * game computes in Player.calculateKnowledgeOf: the player's cumulative
  * science as an integer percent of the opponent's, bucketed by
- * knowledge.xml's thresholds. (The blob's cumulatives are the save's ×10
- * totals ÷10 with rounding, so a flip landing exactly on a threshold can be
- * off by a turn.) No marker for the initial classification — only changes.
+ * knowledge.xml's thresholds. Runs shorter than {@link KNOWLEDGE_MIN_RUN}
+ * are folded into their predecessor (boundary churn, not a real shift); the
+ * final run always stands, so the last chip agrees with the end state. No
+ * marker for the initial classification — only changes.
  */
 export function knowledgeFlipMarkers(
 	mine: YieldDataPoint[],
@@ -1246,18 +1274,36 @@ export function knowledgeFlipMarkers(
 	const other = new Map<number, number>();
 	for (const d of theirs)
 		if (d.cumulative != null) other.set(d.turn, d.cumulative);
-	const flips: KnowledgeFlipMarker[] = [];
-	let current: string | null = null;
+	const perTurn: { turn: number; tier: string; pct: number }[] = [];
 	for (const d of mine) {
 		const ours = d.cumulative;
 		const opp = other.get(d.turn);
 		if (ours == null || opp == null || opp <= 0) continue;
 		const pct = Math.trunc((ours * 100) / opp);
-		const tier = knowledgeTier(pct);
-		if (current != null && tier !== current) {
-			flips.push({ turn: d.turn, from: current, to: tier, pct });
-		}
-		current = tier;
+		perTurn.push({ turn: d.turn, tier: knowledgeTier(pct), pct });
 	}
-	return flips;
+	// Group into runs, then fold sub-minimum runs into their predecessor.
+	type Run = { tier: string; first: (typeof perTurn)[number]; length: number };
+	const runs: Run[] = [];
+	for (const p of perTurn) {
+		const last = runs[runs.length - 1];
+		if (last && last.tier === p.tier) last.length++;
+		else runs.push({ tier: p.tier, first: p, length: 1 });
+	}
+	const kept: Run[] = [];
+	for (let i = 0; i < runs.length; i++) {
+		const isLast = i === runs.length - 1;
+		if (!isLast && runs[i].length < KNOWLEDGE_MIN_RUN && kept.length > 0) {
+			continue;
+		}
+		const prev = kept[kept.length - 1];
+		if (prev && prev.tier === runs[i].tier) continue;
+		kept.push(runs[i]);
+	}
+	return kept.slice(1).map((r, i) => ({
+		turn: r.first.turn,
+		from: kept[i].tier,
+		to: r.tier,
+		pct: r.first.pct,
+	}));
 }

--- a/src/lib/game-detail/science-techs.ts
+++ b/src/lib/game-detail/science-techs.ts
@@ -1142,47 +1142,45 @@ export function scienceSpikes(
 
 // ─── Leader changes ──────────────────────────────────────────────────
 
+// How a reign ended, for the marker's headline verb.
+export type ReignEnd = "died" | "abdicated" | "deposed";
+
 export type LeaderChangeMarker = {
 	turn: number;
 	// The outgoing leader — null when a leaderless realm crowned someone.
+	// `age` and `reignYears` use the game's turn-as-year convention (the
+	// same one the Leaders tab's reign windows use); `age` is at the reign's
+	// end. Ratings freeze at death, so a dead ruler's stored Wisdom IS their
+	// Wisdom when the reign ended; a LIVING character's is their end-of-game
+	// value.
 	prev: {
-		name: string;
-		wisdom: number | null;
-		// "died (plague)", "abdicated" — how the reign ended, when known.
-		end: string;
+		character: CharacterInfo;
+		end: ReignEnd;
+		age: number;
+		reignYears: number;
 	} | null;
 	// The incoming leader — null when the last leader died unsucceeded.
-	next: { name: string; wisdom: number | null } | null;
+	next: { character: CharacterInfo } | null;
 };
 
-// Character ratings freeze at death, so a dead leader's stored Wisdom IS
-// their Wisdom when the reign ended. A LIVING successor's rating is their
-// end-of-game value — a floor/ceiling on what they had at accession, which
-// the save doesn't record.
-function wisdomOf(c: CharacterInfo): number | null {
-	return c.wisdom ?? null;
-}
-
-function reignEnd(c: CharacterInfo, successionTurn: number | null): string {
+function reignEndOf(
+	c: CharacterInfo,
+	successionTurn: number | null,
+): { end: ReignEnd; endTurn: number | null } {
 	if (
 		c.abdicated_turn != null &&
 		(c.death_turn == null || c.abdicated_turn < c.death_turn) &&
 		(successionTurn == null || c.abdicated_turn <= successionTurn)
 	) {
-		return "abdicated";
+		return { end: "abdicated", endTurn: c.abdicated_turn };
 	}
-	if (c.death_turn != null) {
-		const reason = c.death_reason
-			? ` (${formatEnum(c.death_reason, "DEATH_").toLowerCase()})`
-			: "";
-		return `died${reason}`;
-	}
-	return "deposed";
+	if (c.death_turn != null) return { end: "died", endTurn: c.death_turn };
+	return { end: "deposed", endTurn: successionTurn };
 }
 
 /**
  * A player's leader transitions: every succession (with the outgoing and
- * incoming rulers' Wisdom — the court's only science rating), plus a final
+ * incoming rulers — Wisdom is the court's only science rating), plus a final
  * marker when the last leader died with no successor. The first accession
  * (game start) is not a change and isn't marked.
  */
@@ -1195,18 +1193,26 @@ export function leaderChangeMarkers(
 			(c) => c.player_xml_id === playerId && c.became_leader_turn != null,
 		)
 		.sort((a, b) => a.became_leader_turn! - b.became_leader_turn!);
+	const outgoing = (
+		c: CharacterInfo,
+		successionTurn: number | null,
+	): NonNullable<LeaderChangeMarker["prev"]> => {
+		const { end, endTurn } = reignEndOf(c, successionTurn);
+		const at = endTurn ?? successionTurn ?? c.became_leader_turn!;
+		return {
+			character: c,
+			end,
+			age: Math.max(0, at - c.birth_turn),
+			reignYears: Math.max(0, at - c.became_leader_turn!),
+		};
+	};
 	const markers: LeaderChangeMarker[] = [];
 	for (let i = 1; i < reigns.length; i++) {
-		const prev = reigns[i - 1];
 		const next = reigns[i];
 		markers.push({
 			turn: next.became_leader_turn!,
-			prev: {
-				name: prev.first_name ?? "Unknown",
-				wisdom: wisdomOf(prev),
-				end: reignEnd(prev, next.became_leader_turn),
-			},
-			next: { name: next.first_name ?? "Unknown", wisdom: wisdomOf(next) },
+			prev: outgoing(reigns[i - 1], next.became_leader_turn),
+			next: { character: next },
 		});
 	}
 	// The fall of the line: last leader died, nobody took the throne.
@@ -1214,11 +1220,7 @@ export function leaderChangeMarkers(
 	if (last != null && last.death_turn != null) {
 		markers.push({
 			turn: last.death_turn,
-			prev: {
-				name: last.first_name ?? "Unknown",
-				wisdom: wisdomOf(last),
-				end: reignEnd(last, null),
-			},
+			prev: outgoing(last, null),
 			next: null,
 		});
 	}

--- a/src/lib/game-detail/science-techs.ts
+++ b/src/lib/game-detail/science-techs.ts
@@ -34,7 +34,7 @@ import type { PlayerTech } from "$lib/types/PlayerTech";
 import type { YieldDataPoint } from "$lib/types/YieldDataPoint";
 import type { CityInfo } from "$lib/types/CityInfo";
 import type { StoryEvent } from "$lib/types/StoryEvent";
-import type { FamilyInfo } from "$lib/parser/types";
+import type { CharacterInfo, FamilyInfo } from "$lib/parser/types";
 import { SPECIALISTS, SPECIALIST_CLASSES } from "$lib/generated/specialists";
 import { IMPROVEMENT_NAMES } from "$lib/generated/improvement-names";
 import {
@@ -48,9 +48,15 @@ import {
 	LAW_UNLOCK_COST,
 	SHRINE_TYPE,
 	WISDOM_COURT_SCIENCE_RATE,
+	WISDOM_GOVERNOR_SCIENCE_MODIFIER,
 	SCIENCE_TRIANGLE_OFFSET,
 	COMPETITIVE_EQUIVALENT_RATING,
 	COMPETITIVE_SCIENCE_STIPEND,
+	KNOWLEDGE_TIERS,
+	FAMILY_CLASS_SCIENCE_PER_SPECIALIST,
+	NATION_CITY_SCIENCE,
+	THEOLOGY_SCIENCE_PER_RELIGION,
+	PROJECT_SCIENCE,
 } from "$lib/generated/science-yields";
 import { formatEnum } from "$lib/utils/formatting";
 
@@ -442,10 +448,17 @@ export type ScienceBreakdown = {
 	// × city count per Player.getYieldUpkeepNet). Exact rates from the
 	// law/effect XML.
 	laws: { items: BreakdownItem[]; total: number };
+	// Flat per-city effect sources (2.14.0+ blobs, empty before): the Sages
+	// family (+1/specialist in their cities), Babylonia's nation bonus
+	// (+1/city), Dualism (+1 × religions present, in each city holding a
+	// Dualism religion), and science city projects (Archives, Convoys). All
+	// are EffectCity base yields, so they feed the modifier estimates below.
+	cityEffects: { items: BreakdownItem[]; total: number };
 	// Percent modifiers — the percentages are exact game data (Library +10%,
-	// Musaeum +50%); their POINTS are computed against each city's
-	// reconstructed base (which, matching City.cs calculateBaseYield →
-	// :4682, includes the law yields above).
+	// Musaeum +50%, a governor's Wisdom curve); their POINTS are computed
+	// against each city's reconstructed base (which, matching City.cs
+	// calculateBaseYield → :4682, includes the law and city-effect yields
+	// above).
 	modifiers: { items: BreakdownItem[]; total: number };
 	// Player-level (not per-city) science from the ruling court, plus the
 	// Competitive Mode stipend that compensates for it. Only the LEADER is
@@ -457,11 +470,14 @@ export type ScienceBreakdown = {
 	// themselves — calculateCharacterOpinionRate returns null for them), so
 	// their contribution is exact. The rest stay in `other` below.
 	court: { items: BreakdownItem[]; total: number };
-	// SIGNED remainder vs the actual rate: governors, the non-leader court
-	// (spouses, successors, courtiers, council — all opinion-scaled),
-	// Philosophy-via-Forums, religion, connected-foreign-trade science, and
-	// every interaction the save doesn't itemize. A negative value means the
-	// itemized floor over-counted; it's deliberately not clamped so that shows.
+	// SIGNED remainder vs the actual rate: the non-leader court (spouses,
+	// successors, courtiers, council — all opinion-scaled),
+	// Philosophy-via-Forums, connected-foreign-trade science, and every
+	// interaction the save doesn't itemize. The main NEGATIVE components are
+	// the city percent modifiers we can't price — angry/furious family
+	// opinion and discontent — so a science-heavy realm with unhappy
+	// families reads as a visibly negative remainder. Deliberately not
+	// clamped so that shows.
 	other: number;
 	// The player's actual science/turn at game end.
 	total: number;
@@ -525,6 +541,31 @@ function triangleOffset(n: number, offset: number): number {
 	return Math.sign(n) * (triangle(value) - offset);
 }
 
+/** `Utils.triangleBoost` (Utils.cs:124) — the governor rating curve. */
+function triangleBoost(n: number): number {
+	if (n === 0) return 0;
+	return Math.sign(n) * triangle(Math.abs(n) + 1);
+}
+
+/**
+ * A governor's percent science modifier on their city —
+ * `InfoHelpers.boostRating` over rating.xml's aiYieldGovernorModifier. Same
+ * Competitive Mode linearization as the court curve, but WITHOUT the
+ * triangle offset (boostRating uses the plain triangleBoost). Signed: a
+ * negative-Wisdom governor genuinely costs the city science.
+ */
+function governorSciencePct(wisdom: number, competitive: boolean): number {
+	if (!competitive) {
+		return WISDOM_GOVERNOR_SCIENCE_MODIFIER * triangleBoost(wisdom);
+	}
+	const equivalent = Math.max(1, COMPETITIVE_EQUIVALENT_RATING);
+	// C# integer division truncates toward zero.
+	return Math.trunc(
+		(WISDOM_GOVERNOR_SCIENCE_MODIFIER * wisdom * triangleBoost(equivalent)) /
+			equivalent,
+	);
+}
+
 /**
  * `InfoHelpers.modifyRating` (InfoHelpers.cs:1205) — bend a flat rate by a
  * character's rating.
@@ -576,12 +617,27 @@ function leaderCourtScience(wisdom: number, competitive: boolean): number {
 	);
 }
 
+// Per-city context for the city-effect and governor rows: the player's own
+// CityInfo rows plus game-level lookups. The 2.14.0 city fields (religions,
+// project_counts, governor_xml_id) are optional on older blobs — absent
+// fields simply produce no rows, and those sources stay in `other`.
+export interface CityEffectContext {
+	cities: CityInfo[];
+	// The player's nation (Babylonia's bonus keys on it).
+	nation: string | null;
+	// religion → theologies it established, from game_religions (2.14.0+).
+	theologiesByReligion: ReadonlyMap<string, readonly string[]>;
+	// Governor character xml_id → their Wisdom rating (null = unknown).
+	governorWisdom: (xmlId: number) => number | null;
+}
+
 /**
  * Decompose a player's end-of-game science rate into itemized sources.
  * `improvements` are the player's own tiles; `activeLaws` their laws still
  * active at game end; `capital` their capital's name + culture level (null
  * when unresolvable); `cityCount` scales the per-city law upkeep;
- * `finalRate` is the last non-null YIELD_SCIENCE rate.
+ * `finalRate` is the last non-null YIELD_SCIENCE rate; `cityContext` the
+ * per-city data for the city-effect and governor rows.
  *
  * `leaderWisdom` is the reigning leader's RATING_WISDOM — null when there is
  * no reigning leader (an eliminated realm, whose last leader died without a
@@ -600,6 +656,7 @@ export function scienceBreakdown(
 	finalRate: number,
 	leaderWisdom: number | null,
 	competitive: boolean | null,
+	cityContext: CityEffectContext,
 	specialistName: (zType: string) => string,
 	improvementLabel: (zType: string) => string,
 ): ScienceBreakdown {
@@ -628,9 +685,11 @@ export function scienceBreakdown(
 	const specialistsRural = new Map<string, Acc>();
 	const specialistsUrban = new Map<string, Acc>();
 	const buildings = new Map<string, Acc>();
-	// Per-city flat base, per-city urban-specialist counts, and per-city
-	// percent items, for the law and modifier passes below.
+	// Per-city flat base, per-city specialist counts (all / urban-only), and
+	// per-city percent items, for the law, city-effect, and modifier passes
+	// below.
 	const cityFlat = new Map<string, number>();
+	const citySpecialists = new Map<string, number>();
 	const cityUrban = new Map<string, number>();
 	const cityPct = new Map<string, Map<string, Acc>>();
 	for (const i of improvements) {
@@ -676,6 +735,12 @@ export function scienceBreakdown(
 				i.city_name,
 				(cityFlat.get(i.city_name) ?? 0) + tile + staff,
 			);
+			if (i.specialist != null) {
+				citySpecialists.set(
+					i.city_name,
+					(citySpecialists.get(i.city_name) ?? 0) + 1,
+				);
+			}
 			if (i.specialist != null && SPECIALISTS[i.specialist]?.kind === "urban") {
 				cityUrban.set(i.city_name, (cityUrban.get(i.city_name) ?? 0) + 1);
 			}
@@ -752,8 +817,134 @@ export function scienceBreakdown(
 		}
 	}
 
+	// Flat city-effect sources (all EffectCity base yields, so each feeds
+	// cityFlat for the modifier estimates below). Rows are built directly —
+	// their counts mean different things (specialists for Sages, cities for
+	// Babylonia/Dualism, completions for projects).
+	const cityEffects = new Map<string, Acc>();
+	const addEffect = (
+		label: string,
+		city: string,
+		science: number,
+		countDelta: number,
+		icon?: BreakdownIcon,
+	) => {
+		const acc = cityEffects.get(label) ?? {
+			count: 0,
+			science: 0,
+			pct: 0,
+			icon,
+			order: 0,
+		};
+		acc.count += countDelta;
+		acc.science += science;
+		cityEffects.set(label, acc);
+		cityFlat.set(city, (cityFlat.get(city) ?? 0) + science);
+	};
+	// Project zTypes tier like improvements ("PROJECT_ARCHIVE_2"), and
+	// formatEnum drops the trailing digit — re-add it as the game's roman
+	// numeral ("Archive II").
+	const ROMAN = ["", "I", "II", "III", "IV", "V"];
+	const projectLabel = (zType: string): string => {
+		const base = formatEnum(zType, "PROJECT_");
+		const tier = /_(\d)$/.exec(zType);
+		return tier ? `${base} ${ROMAN[Number(tier[1])] ?? tier[1]}` : base;
+	};
+	const nationScience =
+		cityContext.nation != null
+			? (NATION_CITY_SCIENCE[cityContext.nation] ?? 0)
+			: 0;
+	for (const city of cityContext.cities) {
+		// Sages: +1 science per placed specialist in the family's cities
+		// (effectCity aiYieldRateSpecialist — any specialist, unlike
+		// Constitution's urban-only rate).
+		const familyRate =
+			city.family_class != null
+				? (FAMILY_CLASS_SCIENCE_PER_SPECIALIST[city.family_class] ?? 0)
+				: 0;
+		const specialists = citySpecialists.get(city.city_name) ?? 0;
+		if (familyRate > 0 && specialists > 0 && city.family_class != null) {
+			addEffect(
+				`${formatEnum(city.family_class, "FAMILYCLASS_")} cities`,
+				city.city_name,
+				familyRate * specialists,
+				specialists,
+				{
+					category: "crests",
+					value: `ARCHETYPE_${city.family_class.slice("FAMILYCLASS_".length)}`,
+				},
+			);
+		}
+		// Babylonia: flat science in every city, from the nation's player
+		// effect.
+		if (nationScience > 0 && cityContext.nation != null) {
+			addEffect(
+				formatEnum(cityContext.nation, "NATION_"),
+				city.city_name,
+				nationScience,
+				1,
+			);
+		}
+		// Theologies (Dualism): a city holding a religion that established the
+		// theology earns its rate × ALL religions present
+		// (City.cs ×getReligionCount, effect once per holding religion).
+		const religions = city.religions ?? [];
+		for (const [theology, rate] of Object.entries(
+			THEOLOGY_SCIENCE_PER_RELIGION,
+		)) {
+			const holders = religions.filter((r) =>
+				cityContext.theologiesByReligion.get(r)?.includes(theology),
+			).length;
+			if (holders > 0 && religions.length > 0) {
+				addEffect(
+					formatEnum(theology, "THEOLOGY_"),
+					city.city_name,
+					holders * rate * religions.length,
+					1,
+				);
+			}
+		}
+		// Science city projects (Archives, Convoys). bSingle effects pay once
+		// regardless of the completion count.
+		for (const pc of city.project_counts ?? []) {
+			const info = PROJECT_SCIENCE[pc.project];
+			if (!info || pc.count <= 0) continue;
+			const effective = info.single ? 1 : pc.count;
+			addEffect(
+				projectLabel(pc.project),
+				city.city_name,
+				effective * info.science,
+				effective,
+			);
+		}
+	}
+
+	// Governors: a percent city-science modifier off the governor's Wisdom
+	// (City.cs getYieldModifierForGovernor), estimated per city like the
+	// building modifiers. Gated on a known Competitive flag — the two curves
+	// diverge sharply at high Wisdom, same rationale as the court section.
+	if (competitive != null) {
+		for (const city of cityContext.cities) {
+			if (city.governor_xml_id == null) continue;
+			const wisdom = cityContext.governorWisdom(city.governor_xml_id);
+			if (wisdom == null) continue;
+			const pct = governorSciencePct(wisdom, competitive);
+			if (pct === 0) continue;
+			const m = cityPct.get(city.city_name) ?? new Map<string, Acc>();
+			bump(
+				m,
+				"Governors",
+				0,
+				pct,
+				{ category: "icons", value: "RATING_WISDOM" },
+				0,
+			);
+			cityPct.set(city.city_name, m);
+		}
+	}
+
 	// Percent modifiers, estimated per city against that city's base (flat
-	// tiles + staff + the law yields above).
+	// tiles + staff + the law and city-effect yields above).
 	const modifiers = new Map<string, Acc>();
 	for (const [city, mods] of cityPct) {
 		const base = cityFlat.get(city) ?? 0;
@@ -828,12 +1019,14 @@ export function scienceBreakdown(
 	const urbanItems = toItems(specialistsUrban, false);
 	const buildingItems = toItems(buildings, false);
 	const lawItems = toItems(laws, false);
+	const cityEffectItems = toItems(cityEffects, false);
 	const modifierItems = toItems(modifiers, true);
 	const courtItems = toItems(court, false);
 	const ruralTotal = sum(ruralItems);
 	const urbanTotal = sum(urbanItems);
 	const buildingsTotal = sum(buildingItems);
 	const lawsTotal = sum(lawItems);
+	const cityEffectsTotal = sum(cityEffectItems);
 	const modifiersTotal = sum(modifierItems);
 	const courtTotal = sum(courtItems);
 	return {
@@ -841,6 +1034,7 @@ export function scienceBreakdown(
 		specialistsUrban: { items: urbanItems, total: urbanTotal },
 		buildings: { items: buildingItems, total: buildingsTotal },
 		laws: { items: lawItems, total: lawsTotal },
+		cityEffects: { items: cityEffectItems, total: cityEffectsTotal },
 		modifiers: { items: modifierItems, total: modifiersTotal },
 		court: { items: courtItems, total: courtTotal },
 		// Signed on purpose — a negative remainder is the signal that the
@@ -851,6 +1045,7 @@ export function scienceBreakdown(
 				urbanTotal -
 				buildingsTotal -
 				lawsTotal -
+				cityEffectsTotal -
 				modifiersTotal -
 				courtTotal,
 		),
@@ -922,4 +1117,147 @@ export function scienceSpikes(
 		});
 	}
 	return spikes;
+}
+
+// ─── Leader changes ──────────────────────────────────────────────────
+
+export type LeaderChangeMarker = {
+	turn: number;
+	// The outgoing leader — null when a leaderless realm crowned someone.
+	prev: {
+		name: string;
+		wisdom: number | null;
+		// "died (plague)", "abdicated" — how the reign ended, when known.
+		end: string;
+	} | null;
+	// The incoming leader — null when the last leader died unsucceeded.
+	next: { name: string; wisdom: number | null } | null;
+};
+
+// Character ratings freeze at death, so a dead leader's stored Wisdom IS
+// their Wisdom when the reign ended. A LIVING successor's rating is their
+// end-of-game value — a floor/ceiling on what they had at accession, which
+// the save doesn't record.
+function wisdomOf(c: CharacterInfo): number | null {
+	return c.wisdom ?? null;
+}
+
+function reignEnd(c: CharacterInfo, successionTurn: number | null): string {
+	if (
+		c.abdicated_turn != null &&
+		(c.death_turn == null || c.abdicated_turn < c.death_turn) &&
+		(successionTurn == null || c.abdicated_turn <= successionTurn)
+	) {
+		return "abdicated";
+	}
+	if (c.death_turn != null) {
+		const reason = c.death_reason
+			? ` (${formatEnum(c.death_reason, "DEATH_").toLowerCase()})`
+			: "";
+		return `died${reason}`;
+	}
+	return "deposed";
+}
+
+/**
+ * A player's leader transitions: every succession (with the outgoing and
+ * incoming rulers' Wisdom — the court's only science rating), plus a final
+ * marker when the last leader died with no successor. The first accession
+ * (game start) is not a change and isn't marked.
+ */
+export function leaderChangeMarkers(
+	playerId: number,
+	characters: CharacterInfo[],
+): LeaderChangeMarker[] {
+	const reigns = characters
+		.filter(
+			(c) => c.player_xml_id === playerId && c.became_leader_turn != null,
+		)
+		.sort((a, b) => a.became_leader_turn! - b.became_leader_turn!);
+	const markers: LeaderChangeMarker[] = [];
+	for (let i = 1; i < reigns.length; i++) {
+		const prev = reigns[i - 1];
+		const next = reigns[i];
+		markers.push({
+			turn: next.became_leader_turn!,
+			prev: {
+				name: prev.first_name ?? "Unknown",
+				wisdom: wisdomOf(prev),
+				end: reignEnd(prev, next.became_leader_turn),
+			},
+			next: { name: next.first_name ?? "Unknown", wisdom: wisdomOf(next) },
+		});
+	}
+	// The fall of the line: last leader died, nobody took the throne.
+	const last = reigns[reigns.length - 1];
+	if (last != null && last.death_turn != null) {
+		markers.push({
+			turn: last.death_turn,
+			prev: {
+				name: last.first_name ?? "Unknown",
+				wisdom: wisdomOf(last),
+				end: reignEnd(last, null),
+			},
+			next: null,
+		});
+	}
+	return markers;
+}
+
+// ─── Knowledge standing (Player.calculateKnowledgeOf) ────────────────
+
+export type KnowledgeFlipMarker = {
+	turn: number;
+	from: string; // KNOWLEDGE_* the player was
+	to: string; // KNOWLEDGE_* they became
+	// The player's science total as a percent of the opponent's that turn —
+	// the exact quantity the game buckets.
+	pct: number;
+};
+
+// The game's bucketing (InfoHelpers.getBestPercentValue): the tier with the
+// smallest threshold ≥ pct wins; no threshold (Erudite) is the catch-all.
+function knowledgeTier(pct: number): string {
+	let best: string | null = null;
+	let min = Infinity;
+	for (const t of KNOWLEDGE_TIERS) {
+		const p = t.percent ?? Infinity;
+		if (p >= pct && p <= min) {
+			min = p;
+			best = t.type;
+		}
+	}
+	return best ?? KNOWLEDGE_TIERS[KNOWLEDGE_TIERS.length - 1].type;
+}
+
+/**
+ * Turns where the player's knowledge standing vs the opponent flipped tier —
+ * Primitive/Naive/Competent/Learned/Erudite, the exact classification the
+ * game computes in Player.calculateKnowledgeOf: the player's cumulative
+ * science as an integer percent of the opponent's, bucketed by
+ * knowledge.xml's thresholds. (The blob's cumulatives are the save's ×10
+ * totals ÷10 with rounding, so a flip landing exactly on a threshold can be
+ * off by a turn.) No marker for the initial classification — only changes.
+ */
+export function knowledgeFlipMarkers(
+	mine: YieldDataPoint[],
+	theirs: YieldDataPoint[],
+): KnowledgeFlipMarker[] {
+	const other = new Map<number, number>();
+	for (const d of theirs)
+		if (d.cumulative != null) other.set(d.turn, d.cumulative);
+	const flips: KnowledgeFlipMarker[] = [];
+	let current: string | null = null;
+	for (const d of mine) {
+		const ours = d.cumulative;
+		const opp = other.get(d.turn);
+		if (ours == null || opp == null || opp <= 0) continue;
+		const pct = Math.trunc((ours * 100) / opp);
+		const tier = knowledgeTier(pct);
+		if (current != null && tier !== current) {
+			flips.push({ turn: d.turn, from: current, to: tier, pct });
+		}
+		current = tier;
+	}
+	return flips;
 }

--- a/src/lib/generated/science-yields.ts
+++ b/src/lib/generated/science-yields.ts
@@ -508,3 +508,59 @@ export const COMPETITIVE_EQUIVALENT_RATING = 5;
 // YIELD_SCIENCE, per turn: the flat stipend that compensates for the
 // lowered character yields above.
 export const COMPETITIVE_SCIENCE_STIPEND = 4;
+
+// ─── Governor / city-effect science (City.cs yield derivation) ──────
+
+// Percent city science per boosted point of the governor's Wisdom
+// (rating.xml <aiYieldGovernorModifier>). RAW percent: multiply by
+// Utils.triangleBoost(wisdom) — or the Competitive linearization
+// around COMPETITIVE_EQUIVALENT_RATING — to get the city's %.
+export const WISDOM_GOVERNOR_SCIENCE_MODIFIER = 2;
+
+// Family class → flat science per placed specialist in its cities
+// (effectCity <aiYieldRateSpecialist>, any specialist — Sages).
+export const FAMILY_CLASS_SCIENCE_PER_SPECIALIST: Readonly<
+	Record<string, number>
+> = { FAMILYCLASS_SAGES: 1 };
+
+// Nation → flat science per city from its player effect (Babylonia).
+export const NATION_CITY_SCIENCE: Readonly<Record<string, number>> = {
+	NATION_BABYLONIA: 1,
+};
+
+// Theology → science per religion present, in each city where a
+// religion holding the theology is present (City.cs ×getReligionCount).
+export const THEOLOGY_SCIENCE_PER_RELIGION: Readonly<Record<string, number>> = {
+	THEOLOGY_DUALISM: 1,
+};
+
+// City project → flat science: `single` effects (bSingle — Archives)
+// pay once regardless of count; the rest multiply (Convoys).
+export const PROJECT_SCIENCE: Readonly<
+	Record<string, { readonly science: number; readonly single: boolean }>
+> = {
+	PROJECT_ARCHIVE_1: { science: 1, single: true },
+	PROJECT_ARCHIVE_2: { science: 2, single: true },
+	PROJECT_ARCHIVE_3: { science: 4, single: true },
+	PROJECT_ARCHIVE_4: { science: 8, single: true },
+	PROJECT_CONVOY: { science: 1, single: false },
+	PROJECT_GOVERNOR: { science: 2, single: true },
+};
+
+// ─── Knowledge tiers (Player.calculateKnowledgeOf) ──────────────────
+
+// knowledge.xml in file order. A player's knowledge OF another is
+// bucketed by percent = theirScienceTotal × 100 / ourScienceTotal
+// (integer division): the tier with the smallest percent ≥ that value
+// wins (InfoHelpers.getBestPercentValue); `percent: null` (Erudite) is
+// the catch-all — InfoPercentBase defaults to int.MaxValue.
+export const KNOWLEDGE_TIERS: readonly {
+	readonly type: string;
+	readonly percent: number | null;
+}[] = [
+	{ type: "KNOWLEDGE_PRIMITIVE", percent: 67 },
+	{ type: "KNOWLEDGE_NAIVE", percent: 83 },
+	{ type: "KNOWLEDGE_COMPETENT", percent: 120 },
+	{ type: "KNOWLEDGE_LEARNED", percent: 150 },
+	{ type: "KNOWLEDGE_ERUDITE", percent: null },
+];

--- a/src/lib/generated/science-yields.ts
+++ b/src/lib/generated/science-yields.ts
@@ -517,6 +517,11 @@ export const COMPETITIVE_SCIENCE_STIPEND = 4;
 // around COMPETITIVE_EQUIVALENT_RATING — to get the city's %.
 export const WISDOM_GOVERNOR_SCIENCE_MODIFIER = 2;
 
+// Percent city science PER DISCONTENT LEVEL (yield.xml
+// iNegativeHappinessModifier ×|level| — getHappinessLevelYieldModifier).
+// Negative: an unhappy city genuinely earns less.
+export const SCIENCE_DISCONTENT_MODIFIER = -5;
+
 // Family class → flat science per placed specialist in its cities
 // (effectCity <aiYieldRateSpecialist>, any specialist — Sages).
 export const FAMILY_CLASS_SCIENCE_PER_SPECIALIST: Readonly<

--- a/src/lib/parser/derive/city-statistics.ts
+++ b/src/lib/parser/derive/city-statistics.ts
@@ -5,7 +5,7 @@
 // city_culture; team_id falls back to player.xmlId per the Rust COALESCE.
 
 import type { Character } from "../parsers/characters.js";
-import type { City, CityCulture } from "../parsers/cities.js";
+import type { City, CityCulture, CityReligion } from "../parsers/cities.js";
 import type { Family } from "../parsers/families.js";
 import type { Player } from "../parsers/players.js";
 import type { CityInfo, CityStatistics } from "../types.js";
@@ -14,6 +14,7 @@ import { playerByXmlId, strCmp } from "./_helpers.js";
 export function deriveCityStatistics(
 	cities: City[],
 	cityCulture: CityCulture[],
+	cityReligions: CityReligion[],
 	families: Family[],
 	characters: Character[],
 	players: Player[],
@@ -35,6 +36,14 @@ export function deriveCityStatistics(
 	const cultureByKey = new Map<string, CityCulture>();
 	for (const cc of cityCulture) {
 		cultureByKey.set(cultureKey(cc.cityXmlId, cc.teamId), cc);
+	}
+
+	// Religion presence per city (the same parse the map tiles consume).
+	const religionsByCity = new Map<number, string[]>();
+	for (const cr of cityReligions) {
+		const list = religionsByCity.get(cr.cityXmlId) ?? [];
+		list.push(cr.religion);
+		religionsByCity.set(cr.cityXmlId, list);
 	}
 
 	const out: CityInfo[] = cities.map((c) => {
@@ -85,6 +94,9 @@ export function deriveCityStatistics(
 			is_capital: c.isCapital,
 			citizens: c.citizens,
 			governor_name: governor?.firstName ?? null,
+			governor_xml_id: c.governorXmlId,
+			religions: religionsByCity.get(c.xmlId) ?? [],
+			project_counts: c.projectCounts,
 			culture_level: culture?.cultureLevel ?? null,
 			growth_count: c.growthCount,
 			unit_production_count: c.unitProductionCount,

--- a/src/lib/parser/derive/city-statistics.ts
+++ b/src/lib/parser/derive/city-statistics.ts
@@ -97,6 +97,14 @@ export function deriveCityStatistics(
 			governor_xml_id: c.governorXmlId,
 			religions: religionsByCity.get(c.xmlId) ?? [],
 			project_counts: c.projectCounts,
+			// The owner team's happiness level (same team resolution as
+			// culture above); negative = discontent. Null for unowned cities,
+			// 0 when neutral.
+			happiness_level:
+				teamForCulture !== null
+					? (c.teamHappinessLevels.find((t) => t.teamId === teamForCulture)
+							?.level ?? 0)
+					: null,
 			culture_level: culture?.cultureLevel ?? null,
 			growth_count: c.growthCount,
 			unit_production_count: c.unitProductionCount,

--- a/src/lib/parser/derive/game-religions.ts
+++ b/src/lib/parser/derive/game-religions.ts
@@ -22,6 +22,7 @@ export function deriveGameReligions(
 				? (playerMap.get(r.founderPlayerXmlId)?.nation ?? null)
 				: null,
 		founder_player_xml_id: r.founderPlayerXmlId,
+		theologies: r.theologies,
 	}));
 
 	// `NULLS LAST` on founded_turn — null entries sort after everything else.

--- a/src/lib/parser/parsers/cities.ts
+++ b/src/lib/parser/parsers/cities.ts
@@ -51,6 +51,11 @@ export interface City {
 	// city projects like Archives and Forums that carry city effects.
 	// (Religion presence is parsed separately — parseCityReligions.)
 	projectCounts: { project: string; count: number }[];
+	// Per-team happiness level (<T.X>N, signed — negative levels are
+	// discontent and modify the city's yields). Current saves write
+	// <TeamHappinessLevel>; older ones <TeamDiscontentLevel> with the sign
+	// flipped (City.cs:1748 loads it negated), normalized here.
+	teamHappinessLevels: { teamId: number; level: number }[];
 }
 
 export interface CityProductionItem {
@@ -169,6 +174,13 @@ export function parseCities(root: Record<string, unknown>): City[] {
 		const projectCounts = [...parseNameKeyedIntMap(node.ProjectCount)].map(
 			([project, count]) => ({ project, count }),
 		);
+		const teamHappinessLevels = isElement(node.TeamHappinessLevel)
+			? [...parsePrefixedKeyedIntMap(node.TeamHappinessLevel, "T.")].map(
+					([teamId, level]) => ({ teamId, level }),
+				)
+			: [...parsePrefixedKeyedIntMap(node.TeamDiscontentLevel, "T.")].map(
+					([teamId, level]) => ({ teamId, level: -level }),
+				);
 
 		cities.push({
 			xmlId,
@@ -193,6 +205,7 @@ export function parseCities(root: Record<string, unknown>): City[] {
 			unitProductionCount,
 			buyTileCount: optInt(node.BuyTileCount) ?? 0,
 			projectCounts,
+			teamHappinessLevels,
 		});
 	}
 

--- a/src/lib/parser/parsers/cities.ts
+++ b/src/lib/parser/parsers/cities.ts
@@ -47,6 +47,10 @@ export interface City {
 	growthCount: number;
 	unitProductionCount: number;
 	buyTileCount: number;
+	// Per-city project completions from <ProjectCount> (PROJECT_X → count) —
+	// city projects like Archives and Forums that carry city effects.
+	// (Religion presence is parsed separately — parseCityReligions.)
+	projectCounts: { project: string; count: number }[];
 }
 
 export interface CityProductionItem {
@@ -162,6 +166,10 @@ export function parseCities(root: Record<string, unknown>): City[] {
 			}
 		}
 
+		const projectCounts = [...parseNameKeyedIntMap(node.ProjectCount)].map(
+			([project, count]) => ({ project, count }),
+		);
+
 		cities.push({
 			xmlId,
 			cityName,
@@ -184,6 +192,7 @@ export function parseCities(root: Record<string, unknown>): City[] {
 			growthCount: optInt(node.GrowthCount) ?? 0,
 			unitProductionCount,
 			buyTileCount: optInt(node.BuyTileCount) ?? 0,
+			projectCounts,
 		});
 	}
 

--- a/src/lib/parser/parsers/index.ts
+++ b/src/lib/parser/parsers/index.ts
@@ -181,6 +181,7 @@ export function extractAllGameData(
 	const cityStatistics = deriveCityStatistics(
 		cities,
 		cityCulture,
+		cityReligions,
 		families,
 		characters,
 		players,

--- a/src/lib/parser/parsers/religions.ts
+++ b/src/lib/parser/parsers/religions.ts
@@ -8,7 +8,11 @@
 // integer text content. The parser unions the keys across all four to form
 // the row set.
 
-import { isElement, parseNameKeyedIntMap } from "../parse-xml.js";
+import {
+	getElementChildren,
+	isElement,
+	parseNameKeyedIntMap,
+} from "../parse-xml.js";
 
 export interface Religion {
 	religionName: string;
@@ -16,6 +20,10 @@ export interface Religion {
 	founderPlayerXmlId: number | null;
 	headCharacterXmlId: number | null;
 	holyCityXmlId: number | null;
+	// Theologies the religion has established, from the <Game> element's
+	// <ReligionTheology> presence list of dotted composite tags
+	// (<RELIGION_X.THEOLOGY_Y />).
+	theologies: string[];
 }
 
 export function parseReligions(root: Record<string, unknown>): Religion[] {
@@ -27,11 +35,24 @@ export function parseReligions(root: Record<string, unknown>): Religion[] {
 	const heads = parseNameKeyedIntMap(gameNode.ReligionHeadID);
 	const holyCity = parseNameKeyedIntMap(gameNode.ReligionHolyCity);
 
+	const theologies = new Map<string, string[]>();
+	if (isElement(gameNode.ReligionTheology)) {
+		for (const [tag] of getElementChildren(gameNode.ReligionTheology)) {
+			const dot = tag.indexOf(".");
+			if (dot < 0) continue;
+			const religion = tag.slice(0, dot);
+			const list = theologies.get(religion) ?? [];
+			list.push(tag.slice(dot + 1));
+			theologies.set(religion, list);
+		}
+	}
+
 	const names = new Set<string>([
 		...founded.keys(),
 		...founder.keys(),
 		...heads.keys(),
 		...holyCity.keys(),
+		...theologies.keys(),
 	]);
 
 	const religions: Religion[] = [];
@@ -42,6 +63,7 @@ export function parseReligions(root: Record<string, unknown>): Religion[] {
 			founderPlayerXmlId: founder.get(religionName) ?? null,
 			headCharacterXmlId: heads.get(religionName) ?? null,
 			holyCityXmlId: holyCity.get(religionName) ?? null,
+			theologies: theologies.get(religionName) ?? [],
 		});
 	}
 

--- a/src/lib/parser/types.ts
+++ b/src/lib/parser/types.ts
@@ -380,4 +380,4 @@ export interface FullGameData {
  * fixes, MINOR for additive fields, MAJOR for breaking schema changes.
  * Initial value `2.0.0` mirrors `FullGameData.version: 2`.
  */
-export const PARSER_VERSION = "2.12.0";
+export const PARSER_VERSION = "2.14.0";

--- a/src/lib/types/CityInfo.ts
+++ b/src/lib/types/CityInfo.ts
@@ -50,6 +50,15 @@ religions?: Array<string>,
  */
 project_counts?: Array<{ project: string, count: number }>,
 /**
+ * The owner team's happiness level in this city, signed — negative levels
+ * are discontent, each a negative yield modifier
+ * (getHappinessLevelYieldModifier). 0 = neutral, null = unowned city.
+ * Normalized from either save tag (TeamHappinessLevel, or the legacy
+ * TeamDiscontentLevel negated). Optional: absent on blobs before
+ * PARSER_VERSION 2.14.0.
+ */
+happiness_level?: number | null,
+/**
  * Culture level as string enum (CULTURE_WEAK, CULTURE_DEVELOPING, CULTURE_STRONG, CULTURE_ESTABLISHED, CULTURE_LEGENDARY)
  */
 culture_level: string | null, growth_count: number, unit_production_count: number, specialist_count: number, buy_tile_count: number, hurry_civics_count: number, hurry_money_count: number, hurry_training_count: number, hurry_population_count: number, };

--- a/src/lib/types/CityInfo.ts
+++ b/src/lib/types/CityInfo.ts
@@ -31,7 +31,24 @@ player_families?: Array<{ player_xml_id: number, family: string | null, family_c
  * cross-game milestones (cities_founded, fifth_city_turn, ...) attribute
  * to the founder rather than the current owner.
  */
-first_owner_player_xml_id: number | null, founded_turn: number, is_capital: boolean, citizens: number, governor_name: string | null, 
+first_owner_player_xml_id: number | null, founded_turn: number, is_capital: boolean, citizens: number, governor_name: string | null,
+/**
+ * xml_id of the governing character, matching CharacterInfo.xml_id — the
+ * science breakdown reads the governor's Wisdom through it (name matching
+ * is ambiguous). Optional: absent on blobs before PARSER_VERSION 2.14.0.
+ */
+governor_xml_id?: number | null,
+/**
+ * Religions present in the city (the save's <Religion> presence list).
+ * Optional: absent on blobs before PARSER_VERSION 2.14.0.
+ */
+religions?: Array<string>,
+/**
+ * Per-city project completions (<ProjectCount>): Archives, Forums, Treasury
+ * and other repeat-effect city projects. Optional: absent on blobs before
+ * PARSER_VERSION 2.14.0.
+ */
+project_counts?: Array<{ project: string, count: number }>,
 /**
  * Culture level as string enum (CULTURE_WEAK, CULTURE_DEVELOPING, CULTURE_STRONG, CULTURE_ESTABLISHED, CULTURE_LEGENDARY)
  */

--- a/src/lib/types/GameReligion.ts
+++ b/src/lib/types/GameReligion.ts
@@ -9,4 +9,10 @@ export type GameReligion = { religion_name: string, founded_turn: number | null,
  * founders in mirror matches, where founder_nation collides. Optional:
  * absent on blobs parsed before PARSER_VERSION 2.6.0.
  */
-founder_player_xml_id?: number | null, };
+founder_player_xml_id?: number | null,
+/**
+ * Theologies the religion established (THEOLOGY_X enums, from the save's
+ * ReligionTheology list). Optional: absent on blobs before PARSER_VERSION
+ * 2.14.0.
+ */
+theologies?: Array<string>, };

--- a/src/lib/utils/formatting.ts
+++ b/src/lib/utils/formatting.ts
@@ -490,3 +490,30 @@ export function formatArchetype(archetype: string): string {
 export function archetypeSpriteKey(archetype: string): string {
 	return archetype.replace(ARCHETYPE_SUFFIX, "");
 }
+
+/**
+ * A ruler's display name: the NAME_* first name plus the regnal numeral when
+ * they share a name with an earlier ruler (suffix > 1). The first of a name
+ * carries no numeral, matching Old World. The numeral is appended after
+ * formatEnum so its trailing-digit strip can't eat it (and it's Roman
+ * letters anyway).
+ */
+export function rulerDisplayName(
+	firstName: string | null,
+	suffix: number,
+): string {
+	const name = formatEnum(firstName ?? "", "NAME_") || "Unknown";
+	return suffix > 1 ? `${name} ${toRomanNumeral(suffix)}` : name;
+}
+
+/**
+ * Display label for a character's death_reason: the save writes localization
+ * keys like TEXT_TRAIT_SEVERELY_ILL_M, so strip the TEXT_/TRAIT_ prefix and
+ * the gendered _F/_M suffix before formatting ("Severely Ill").
+ */
+export function deathReasonLabel(reason: string): string {
+	return formatEnum(
+		reason.replace(/^TEXT_(TRAIT_)?/, "").replace(/_(F|M)$/, ""),
+		"",
+	);
+}


### PR DESCRIPTION
## What

Extends the Techs tab's **Science Sources** breakdown and the science graph's annotation rail — every number anchored on the game's own formulas (Reference/XML + game source, cited at each site).

**New breakdown sections/rows:**

- **Nation, family & religion** — the flat per-city EffectCity sources the save now lets us price:
  - **Sages cities**: +1 science per placed specialist in the family's cities (`EFFECTCITY_FAMILYCLASS_SAGES aiYieldRateSpecialist` — any specialist, unlike Constitution's urban-only rate).
  - **Babylonia**: +1/city from the nation's player effect.
  - **Dualism**: in each city holding a religion that established the theology, its rate × ALL religions present, once per holding religion (`City.cs resetReligionCityEffect` × `getReligionCount()`).
  - **Science city projects**: Archive I–IV (+1/+2/+4/+8, `bSingle` so they pay once) and Convoys (repeatable).
- **Governors** (in Modifiers): percent city science off the governor's Wisdom — `boostRating` over `aiYieldGovernorModifier` (+2%/boosted point, plain `triangleBoost`, no offset), with the Competitive Mode linearization, estimated per city against the same reconstructed base as the Library rows. Gated on a known Competitive flag, same rationale as the court section.
- **Discontent** (in Modifiers, negative): −5% science per negative happiness level per city (`yield.xml iNegativeHappinessModifier` × |level|, `getHappinessLevelYieldModifier`). This was the big unpriced negative — on the test game below it moves the signed Other remainder from **−49.9 to +12.3**, making it a genuine floor again.

Since these are all EffectCity **base** yields, they also feed the per-city bases the percent-modifier estimates multiply, matching `City.cs calculateBaseYield`.

**New rail rows (two-player games):**

- **Leader changes** (Wisdom icon): who died/abdicated and both rulers' Wisdom — exact for the outgoing ruler, since ratings freeze at death.
- **Knowledge shifts** (text chips, "N→C"): the game's Primitive/Naive/Competent/Learned/Erudite classification from `Player.calculateKnowledgeOf` — cumulative science as an integer percent of the opponent's, bucketed by knowledge.xml's thresholds (67/83/120/150, Erudite the catch-all per `InfoPercentBase`'s int.MaxValue default). Debounced: a tier must hold 3 consecutive turns (threshold-hovering flip-flops the raw classification every turn); the final run always stands.

## Screenshots

**Science Sources** with the new sections — Sages, Babylonia, Archives, Governors, Discontent:

![sections](https://raw.githubusercontent.com/alcaras/per-ankh/76234c63f1daf04c7077f768b5903128e4de4fc2/science-sources-sages.png)

**Dualism** on a two-religion theology game (each city holding both counts twice):

![dualism](https://raw.githubusercontent.com/alcaras/per-ankh/76234c63f1daf04c7077f768b5903128e4de4fc2/science-sources-dualism.png)

**The rail** — leader changes (Wisdom icons) and knowledge shift chips (`C→N` … `N→C`):

![rail](https://raw.githubusercontent.com/alcaras/per-ankh/76234c63f1daf04c7077f768b5903128e4de4fc2/science-rail.png)

## Parser 2.14.0

Four additive fields: `city_statistics.cities[]` gains `religions` (reusing the presence list `parseCityReligions` already reads for the map), `project_counts`, `governor_xml_id`, and `happiness_level` (signed; current saves write `TeamHappinessLevel`, older ones `TeamDiscontentLevel` which the game loads negated — `City.cs:1748` — normalized in the parser); `game_religions[]` gains `theologies` (the `<ReligionTheology>` dotted presence tags). Older blobs lack the fields and the new rows are simply omitted.

**Version note:** this PR numbers the bump 2.14.0 and deliberately skips 2.13.0, which is reserved by the open projects PR (#172). If this lands first, #172 should renumber to 2.15.0 on rebase (a lower-than-current version would break its re-imports); if #172 lands first, this rebases cleanly on top.

**Deploy order:** Worker before frontend (as always for a parser bump). Existing games pick the new rows up on re-upload — reindex can't backfill parser-derived fields.

## Testing

- Verified against re-imported 2.14.0 games: section totals reconcile exactly to the final science rate; Dualism's establishment turns match +15–20 jumps in the rate series; the Halab-style multi-religion city prices out exactly (holders × religions present); Discontent turns the previously-negative Other positive on both test games.
- `npm run lint` / `svelte-check` clean; `cloud/` unit suite green except the 4 pre-existing `canonical-map-options` failures on `main`.
- The bake's new tables are generic (whole familyClass/nation/theology/project sweeps), so a future mod or patch that adds another science-carrying entry appears without code changes.