### PR TITLE
feat: Economy rail — city markers wear their family crest (depends on #169)

### DIFF
--- a/src/lib/SpriteMap.svelte
+++ b/src/lib/SpriteMap.svelte
@@ -11,6 +11,7 @@
 		NATION_ALIASES_URL,
 	} from "$lib/generated/atlas-manifest";
 	import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
+	import { familyCrestKey } from "$lib/game-detail/helpers";
 	import MapTooltip from "$lib/MapTooltip.svelte";
 	import Checkbox from "$lib/ui/Checkbox.svelte";
 
@@ -302,10 +303,8 @@
 	});
 
 	// city_name → resolved crest sprite key (or null when no crest is
-	// renderable). Resolution prefers a per-family crest when we ship the
-	// art; otherwise falls back to the family-class archetype crest, which
-	// always exists for non-null family_class values. Existence is checked
-	// against the SPRITE_MANIFEST baked from static/sprites/crests/CREST_FAMILY_*.png.
+	// renderable), via the shared familyCrestKey rule (per-family crest when
+	// we ship the art, else the family-class archetype crest).
 	//
 	// The family is resolved for whoever owns the city at the represented turn:
 	// a city's family only changes when another nation conquers it, so
@@ -321,16 +320,10 @@
 				ownerAtTurn != null
 					? c.player_families?.find((f) => f.player_xml_id === ownerAtTurn)
 					: undefined;
-			const family = pf?.family ?? c.family;
-			const familyClass = pf?.family_class ?? c.family_class;
-			let key: string | null = null;
-			if (family && SPRITE_MANIFEST[`crests/CREST_FAMILY_${family}`] != null) {
-				key = family;
-			} else if (familyClass) {
-				// FAMILYCLASS_CHAMPIONS → ARCHETYPE_CHAMPIONS
-				key = familyClass.replace(/^FAMILYCLASS_/, "ARCHETYPE_");
-			}
-			map.set(c.city_name, key);
+			map.set(
+				c.city_name,
+				familyCrestKey(pf?.family ?? c.family, pf?.family_class ?? c.family_class),
+			);
 		}
 		return map;
 	});

--- a/src/lib/SpriteMap.svelte
+++ b/src/lib/SpriteMap.svelte
@@ -11,7 +11,7 @@
 		NATION_ALIASES_URL,
 	} from "$lib/generated/atlas-manifest";
 	import { SPRITE_MANIFEST } from "$lib/generated/sprite-manifest";
-	import { familyCrestKey } from "$lib/game-detail/helpers";
+	import { familyCrestKey, familyForOwner } from "$lib/game-detail/helpers";
 	import MapTooltip from "$lib/MapTooltip.svelte";
 	import Checkbox from "$lib/ui/Checkbox.svelte";
 
@@ -306,24 +306,19 @@
 	// renderable), via the shared familyCrestKey rule (per-family crest when
 	// we ship the art, else the family-class archetype crest).
 	//
-	// The family is resolved for whoever owns the city at the represented turn:
-	// a city's family only changes when another nation conquers it, so
-	// player_families holds each past owner's family and a captured city shows
-	// its founder's family for turns before the capture. Recomputed when the
-	// cities prop or the per-turn tiles change.
+	// The family is resolved (via familyForOwner) for whoever owns the city at
+	// the represented turn, so a captured city shows its founder's family for
+	// turns before the capture. Recomputed when the cities prop or the
+	// per-turn tiles change.
 	const cityFamilyCrestByName = $derived.by(() => {
 		// eslint-disable-next-line svelte/prefer-svelte-reactivity -- locally-scoped Map, not reactive state
 		const map = new Map<string, string | null>();
 		for (const c of cities) {
-			const ownerAtTurn = cityCenterOwnerByTurn.get(c.city_name);
-			const pf =
-				ownerAtTurn != null
-					? c.player_families?.find((f) => f.player_xml_id === ownerAtTurn)
-					: undefined;
-			map.set(
-				c.city_name,
-				familyCrestKey(pf?.family ?? c.family, pf?.family_class ?? c.family_class),
+			const { family, familyClass } = familyForOwner(
+				c,
+				cityCenterOwnerByTurn.get(c.city_name),
 			);
+			map.set(c.city_name, familyCrestKey(family, familyClass));
 		}
 		return map;
 	});

--- a/src/lib/game-detail/EconomyTab.svelte
+++ b/src/lib/game-detail/EconomyTab.svelte
@@ -60,6 +60,7 @@
 		ownedByPlayer,
 		type TableState,
 		familyCrestKey,
+		familyForOwner,
 		filledLineStyle,
 		getSpritePath,
 		improvementDisplayName,
@@ -396,29 +397,22 @@
 				// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local, not reactive state
 				const familySeen = new Map<string, number>();
 				const cityMarkers: RailMarker[] = founded.map((c, i) => {
-					const pf = c.player_families?.find(
-						(f) => f.player_xml_id === player.playerId,
-					);
-					const family = pf?.family ?? c.family;
-					const familyClass = pf?.family_class ?? c.family_class;
+					const { family, familyClass } = familyForOwner(c, player.playerId);
 					const crest = familyCrestKey(family, familyClass);
-					const familyLabel = familyClass
-						? formatEnum(familyClass, "FAMILYCLASS_")
-						: null;
-					const nthOfFamily = familyClass
-						? (familySeen.get(familyClass) ?? 0) + 1
-						: null;
-					if (familyClass) familySeen.set(familyClass, nthOfFamily!);
+					const lines = [`Founded turn ${c.founded_turn}`];
+					if (familyClass) {
+						const nthOfFamily = (familySeen.get(familyClass) ?? 0) + 1;
+						familySeen.set(familyClass, nthOfFamily);
+						lines.push(
+							`${formatEnum(familyClass, "FAMILYCLASS_")} city #${nthOfFamily}`,
+						);
+					}
+					lines.push(`Overall city #${i + 1}`);
 					const crestUrl = crest ? getSpritePath("crests", crest) : null;
 					const title =
 						(crestUrl
 							? `<img src="${crestUrl}" alt="" style="display:inline;width:14px;height:14px;vertical-align:-2px;margin-right:3px"/>`
 							: "") + formatEnum(c.city_name, "CITYNAME_");
-					const lines = [
-						`Founded on turn ${c.founded_turn}`,
-						...(familyLabel ? [`${familyLabel} city #${nthOfFamily}`] : []),
-						`Overall city #${i + 1}`,
-					];
 					return {
 						turn: c.founded_turn,
 						iconCategory: "crests" as const,

--- a/src/lib/game-detail/EconomyTab.svelte
+++ b/src/lib/game-detail/EconomyTab.svelte
@@ -59,6 +59,7 @@
 		type DetailPlayer,
 		ownedByPlayer,
 		type TableState,
+		familyCrestKey,
 		filledLineStyle,
 		getSpritePath,
 		improvementDisplayName,
@@ -385,19 +386,47 @@
 	const railGroups = $derived.by<RailGroup[]>(() =>
 		orderedPlayers
 			.map((player) => {
-				const cityMarkers: RailMarker[] = cityStatistics.cities
+				// Each city marker wears its family crest (the family during the
+				// FOUNDER's tenure — a captured city's current family is the
+				// conqueror's), and the tooltip counts the founding ordinals:
+				// this player's Nth city of that family, and Nth city overall.
+				const founded = cityStatistics.cities
 					.filter((c) => c.first_owner_player_xml_id === player.playerId)
-					.sort((a, b) => a.founded_turn - b.founded_turn)
-					.map((c) => ({
+					.sort((a, b) => a.founded_turn - b.founded_turn);
+				// eslint-disable-next-line svelte/prefer-svelte-reactivity -- local, not reactive state
+				const familySeen = new Map<string, number>();
+				const cityMarkers: RailMarker[] = founded.map((c, i) => {
+					const pf = c.player_families?.find(
+						(f) => f.player_xml_id === player.playerId,
+					);
+					const family = pf?.family ?? c.family;
+					const familyClass = pf?.family_class ?? c.family_class;
+					const crest = familyCrestKey(family, familyClass);
+					const familyLabel = familyClass
+						? formatEnum(familyClass, "FAMILYCLASS_")
+						: null;
+					const nthOfFamily = familyClass
+						? (familySeen.get(familyClass) ?? 0) + 1
+						: null;
+					if (familyClass) familySeen.set(familyClass, nthOfFamily!);
+					const crestUrl = crest ? getSpritePath("crests", crest) : null;
+					const title =
+						(crestUrl
+							? `<img src="${crestUrl}" alt="" style="display:inline;width:14px;height:14px;vertical-align:-2px;margin-right:3px"/>`
+							: "") + formatEnum(c.city_name, "CITYNAME_");
+					const lines = [
+						`Founded on turn ${c.founded_turn}`,
+						...(familyLabel ? [`${familyLabel} city #${nthOfFamily}`] : []),
+						`Overall city #${i + 1}`,
+					];
+					return {
 						turn: c.founded_turn,
-						iconCategory: "icons" as const,
-						iconValue: "CITY_FOUNDED",
+						iconCategory: "crests" as const,
+						iconValue: crest,
 						color: player.color,
-						tooltipHtml: tooltip(
-							formatEnum(c.city_name, "CITYNAME_"),
-							`Founded turn ${c.founded_turn}`,
-						),
-					}));
+						tooltipHtml: tooltip(title, lines.join("<br/>")),
+					};
+				});
 				const wonderMarkers: RailMarker[] = playerWonders
 					.filter((w) => w.player_id === player.playerId)
 					.sort((a, b) => a.completed_turn - b.completed_turn)

--- a/src/lib/game-detail/EventRail.svelte
+++ b/src/lib/game-detail/EventRail.svelte
@@ -64,12 +64,14 @@
 		onHighlight?: (h: { turn: number; color: string } | null) => void;
 	} = $props();
 
-	// Per-marker render sizes (bare icons, no tile). The nation crest reads as
-	// the row label at 24; event icons sit at 14 so every marker kind reads at
-	// the same weight. Unmapped categories fall back to the default.
+	// Per-marker render sizes (bare icons, no tile). Event icons sit at 14 so
+	// every marker kind reads at the same weight; unmapped categories fall
+	// back to the default. The nation crest labelling each band is not a
+	// marker and gets its own larger size (crest markers — the Economy rail's
+	// family crests — stay at the default).
 	const RAIL_ICON_SIZE_DEFAULT = 16;
+	const RAIL_GUTTER_CREST_SIZE = 24;
 	const RAIL_ICON_SIZE: Partial<Record<SpriteCategory, number>> = {
-		crests: 24,
 		"traits-trimmed": 14,
 		laws: 14,
 		units: 14,
@@ -210,7 +212,7 @@
 					<SpriteIcon
 						category="crests"
 						value={group.player.nation}
-						size={RAIL_ICON_SIZE.crests ?? RAIL_ICON_SIZE_DEFAULT}
+						size={RAIL_GUTTER_CREST_SIZE}
 						alt={group.player.label}
 					/>
 				{:else}

--- a/src/lib/game-detail/helpers.ts
+++ b/src/lib/game-detail/helpers.ts
@@ -588,10 +588,10 @@ export function familyCrestKey(
 	family: string | null | undefined,
 	familyClass: string | null | undefined,
 ): string | null {
-	// Family values already carry the FAMILY_ prefix (FAMILY_ANTIGONUS), and
-	// the crest art ships as CREST_FAMILY_ANTIGONUS — so the value is used
-	// as-is, no re-prefixing.
-	if (family && SPRITE_MANIFEST[`crests/CREST_${family}`] != null) {
+	// Family values already carry the FAMILY_ prefix (FAMILY_ANTIGONUS) and the
+	// art ships as CREST_FAMILY_ANTIGONUS, but the CREST_ prefix is
+	// getSpritePath's to add — so the value goes through as-is.
+	if (family && getSpritePath("crests", family)) {
 		return family;
 	}
 	if (familyClass) {
@@ -599,6 +599,28 @@ export function familyCrestKey(
 		return familyClass.replace(/^FAMILYCLASS_/, "ARCHETYPE_");
 	}
 	return null;
+}
+
+/**
+ * The family a city was held under by a given owner: its `player_families`
+ * entry, else the city's current family. A city's family only changes on
+ * conquest, so each past owner's entry is the family during their tenure —
+ * a captured city resolves to the founder's family for the founder and the
+ * conqueror's for the conqueror. Falls back to the current family when the
+ * owner is unknown, or for pre-2.10.0 blobs, which ship no `player_families`.
+ */
+export function familyForOwner(
+	city: CityInfo,
+	playerXmlId: number | null | undefined,
+): { family: string | null; familyClass: string | null } {
+	const pf =
+		playerXmlId != null
+			? city.player_families?.find((f) => f.player_xml_id === playerXmlId)
+			: undefined;
+	return {
+		family: pf?.family ?? city.family,
+		familyClass: pf?.family_class ?? city.family_class,
+	};
 }
 
 // ─── Unit Classification ────────────────────────────────────────────

--- a/src/lib/game-detail/helpers.ts
+++ b/src/lib/game-detail/helpers.ts
@@ -272,12 +272,7 @@ export const CITY_COLUMNS: CityColumn[] = [
 		iconCategory: "crests",
 		// Per-family crest art ships for only a few families; fall back to the
 		// always-available archetype crest derived from family_class.
-		iconValue: (c) =>
-			c.family && getSpritePath("crests", c.family)
-				? c.family
-				: c.family_class
-					? c.family_class.replace("FAMILYCLASS_", "ARCHETYPE_")
-					: null,
+		iconValue: (c) => familyCrestKey(c.family, c.family_class),
 	},
 	{
 		key: "founded_turn",
@@ -580,6 +575,30 @@ export function getSpritePath(
 		return SPRITE_MANIFEST[`units/${name}`] ?? null;
 	}
 	return SPRITE_MANIFEST[`${category}/${enumValue}`] ?? null;
+}
+
+/**
+ * Crest sprite key (for the `crests` category) of a family: the per-family
+ * crest when we ship the art, else the family-class archetype crest —
+ * which always exists for non-null family_class values. Null when neither
+ * resolves, so callers can degrade (the map omits the crest, the rail
+ * renders its colored dot).
+ */
+export function familyCrestKey(
+	family: string | null | undefined,
+	familyClass: string | null | undefined,
+): string | null {
+	// Family values already carry the FAMILY_ prefix (FAMILY_ANTIGONUS), and
+	// the crest art ships as CREST_FAMILY_ANTIGONUS — so the value is used
+	// as-is, no re-prefixing.
+	if (family && SPRITE_MANIFEST[`crests/CREST_${family}`] != null) {
+		return family;
+	}
+	if (familyClass) {
+		// FAMILYCLASS_CHAMPIONS → ARCHETYPE_CHAMPIONS
+		return familyClass.replace(/^FAMILYCLASS_/, "ARCHETYPE_");
+	}
+	return null;
 }
 
 // ─── Unit Classification ────────────────────────────────────────────


### PR DESCRIPTION
> **Depends on #169** (the Economy tab) — this branch stacks on it, so the diff includes the economy-stack commits until #169 merges. Only the last two commits are this PR.

## What

The Economy rail's cities-founded markers drop the generic CITY_FOUNDED icon for **the city's family crest**, and the tooltip gains the founding ordinals:

![city crest markers](https://raw.githubusercontent.com/alcaras/per-ankh/791c6081aac603ca8cb3e01d4fb3e3a534f30a03/city-crest-markers.png)

- The family is the one during the **founder's** tenure (`player_families`), so a captured city keeps its founder's crest rather than the conqueror's — same rule the map's turn slider uses.
- Tooltip: crest inline in the title, then `Founded on turn 20` / `Landowners city #2` / `Overall city #4` — both ordinals counted per player in founding order.
- Crest resolution prefers the per-family crest when we ship the art, else the always-available `FAMILYCLASS_X → ARCHETYPE_X` fallback.

## Comes with a real bug fix

Extracting that resolution rule surfaced that the repo had **three** copies of it, and the map's copy was broken: blob family values already carry the `FAMILY_` prefix (`FAMILY_ANTIGONUS`) and the art ships as `CREST_FAMILY_ANTIGONUS`, but SpriteMap's existence check looked up `CREST_FAMILY_${family}` → `CREST_FAMILY_FAMILY_…`, which never exists — so per-family crests **never rendered on the map tooltip** and silently fell back to the archetype crest. The first commit extracts one shared `familyCrestKey` into `game-detail/helpers` (fixing the lookup) and points SpriteMap, the Cities table's Family column, and the new rail markers at it.

## Mechanics

- `EventRail`'s crest sizing splits in two: the nation crest labelling each band keeps its 24px (now its own constant); crest *markers* render at the 16px marker default so family crests sit at marker weight.
- UI-only — no parser, worker, or schema changes; pre-2.10.0 blobs (no `player_families`) fall back to the city's current family, and a city with no resolvable crest renders the existing colored dot.

## Testing

- `npm run lint` / `svelte-check` clean on the branch.
- Verified live: distinct crests per marker on both players' rows, ordinals hand-checked against the founding order, capture case exercised via `player_families`, and the map tooltip unaffected visually for archetype-crest families (the per-family crest fix only changes families whose art we actually ship — the Greek-DLC set).