### PR TITLE
fix(video): date live content by when it aired, not when its VOD went up

### DIFF
--- a/cloud/src/channels.ts
+++ b/cloud/src/channels.ts
@@ -25,6 +25,7 @@ import {
 	supportedPlatforms,
 } from "./video/registry";
 import {
+	byPublishedDesc,
 	ChannelResolutionError,
 	type Video,
 	type VideoEnv,
@@ -207,8 +208,8 @@ export async function handleUserVideos(
 
 	const videos = perChannel
 		.flat()
-		// Newest first across all platforms; ISO timestamps sort lexically.
-		.sort((a, b) => (a.published_at < b.published_at ? 1 : -1))
+		// Newest first across all platforms.
+		.sort(byPublishedDesc)
 		.slice(0, MAX_MERGED_VIDEOS);
 
 	return jsonResponse({ videos }, 200, cors);
@@ -243,15 +244,12 @@ export interface CreatorVideo extends Video {
 
 // Merge per-channel lists (each already attributed to its creator) into the
 // home feed: newest-first across all creators, capped. Pure — the DB query and
-// per-channel fetch live in buildCreatorFeed. ISO timestamps sort lexically.
+// per-channel fetch live in buildCreatorFeed.
 export function mergeCreatorFeed(
 	perChannel: CreatorVideo[][],
 	cap = MAX_CREATOR_FEED_VIDEOS,
 ): CreatorVideo[] {
-	return perChannel
-		.flat()
-		.sort((a, b) => (a.published_at < b.published_at ? 1 : -1))
-		.slice(0, cap);
+	return perChannel.flat().sort(byPublishedDesc).slice(0, cap);
 }
 
 // Assemble the feed: every linked channel joined to its owner, each channel's

--- a/cloud/src/video/cache.test.ts
+++ b/cloud/src/video/cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { getVideosCached } from "./cache";
+import { UncacheableVideos, type Video, type VideoEnv } from "./types";
+
+const video = (id: string, published_at: string): Video => ({
+	id,
+	title: id,
+	url: `https://www.youtube.com/watch?v=${id}`,
+	thumbnail_url: null,
+	published_at,
+	platform: "youtube",
+});
+
+const AIRED = [video("BROADCAST01", "2026-07-31T01:04:43Z")];
+const VOD_DATED = [video("BROADCAST01", "2026-07-31T15:27:03Z")];
+
+// The cache only ever get()s and put()s one key, so a Map stands in for KV.
+// `puts` records writes, which is what these tests are actually about.
+function fakeEnv(): {
+	env: VideoEnv;
+	store: Map<string, string>;
+	puts: string[];
+} {
+	const store = new Map<string, string>();
+	const puts: string[] = [];
+	const env = {
+		SESSIONS_KV: {
+			get: (k: string) => Promise.resolve(store.get(k) ?? null),
+			put: (k: string, v: string) => {
+				puts.push(k);
+				store.set(k, v);
+				return Promise.resolve();
+			},
+		},
+	} as unknown as VideoEnv;
+	return { env, store, puts };
+}
+
+// Collects the background refresh the stale path hands to waitUntil, so a test
+// can await it instead of racing it.
+function fakeCtx(): { ctx: ExecutionContext; settled: () => Promise<unknown> } {
+	const pending: Promise<unknown>[] = [];
+	const ctx = {
+		waitUntil: (p: Promise<unknown>) => {
+			pending.push(p);
+		},
+	} as unknown as ExecutionContext;
+	return { ctx, settled: () => Promise.all(pending) };
+}
+
+// Age the single cached entry past the 1h soft TTL. Reads the key back out of
+// the store rather than rebuilding it, so this doesn't pin CACHE_VERSION.
+function makeStale(store: Map<string, string>): void {
+	const [key] = [...store.keys()];
+	const entry = JSON.parse(store.get(key) as string) as { fetched_at: number };
+	entry.fetched_at = Date.now() - 2 * 60 * 60 * 1000;
+	store.set(key, JSON.stringify(entry));
+}
+
+describe("getVideosCached", () => {
+	it("caches a clean fetch", async () => {
+		const { env, puts } = fakeEnv();
+		const videos = await getVideosCached(env, "youtube", "UC1", () =>
+			Promise.resolve(AIRED),
+		);
+		expect(videos).toEqual(AIRED);
+		expect(puts).toHaveLength(1);
+	});
+
+	it("serves a degraded fetch without caching it", async () => {
+		const { env, puts } = fakeEnv();
+		const videos = await getVideosCached(env, "youtube", "UC1", () =>
+			Promise.reject(new UncacheableVideos(VOD_DATED)),
+		);
+		// Cold miss: better to show the VOD dates than an empty feed — but they
+		// must not be persisted, or they'd be served for the whole TTL.
+		expect(videos).toEqual(VOD_DATED);
+		expect(puts).toHaveLength(0);
+	});
+
+	it("keeps a stale entry's good dates when the refresh degrades", async () => {
+		const { env, store, puts } = fakeEnv();
+		await getVideosCached(env, "youtube", "UC1", () => Promise.resolve(AIRED));
+		makeStale(store);
+		puts.length = 0;
+
+		const { ctx, settled } = fakeCtx();
+		const served = await getVideosCached(
+			env,
+			"youtube",
+			"UC1",
+			() => Promise.reject(new UncacheableVideos(VOD_DATED)),
+			ctx,
+		);
+		await settled();
+
+		expect(served).toEqual(AIRED);
+		expect(puts).toHaveLength(0);
+		const [key] = [...store.keys()];
+		expect(
+			(JSON.parse(store.get(key) as string) as { videos: Video[] }).videos,
+		).toEqual(AIRED);
+	});
+
+	it("still swallows a hard fetch failure on a cold miss", async () => {
+		const { env, puts } = fakeEnv();
+		const videos = await getVideosCached(env, "youtube", "UC1", () =>
+			Promise.reject(new Error("youtube feed responded 503")),
+		);
+		expect(videos).toEqual([]);
+		expect(puts).toHaveLength(0);
+	});
+});

--- a/cloud/src/video/cache.ts
+++ b/cloud/src/video/cache.ts
@@ -22,7 +22,10 @@ import type { Video, VideoEnv, VideoProvider } from "./types";
 // v4: playlist fetches now dedupe repeated video ids (a curator re-adding a
 //     video); orphan the v3 entries so a warmed playlist doesn't keep serving a
 //     duplicate-containing list that crashes the Videos tab's keyed {#each}.
-const CACHE_VERSION = 4;
+// v5: live content is dated by when the broadcast aired rather than when its
+//     VOD was published; orphan the v4 entries so a warmed feed doesn't keep
+//     serving dates that are hours-to-a-day too recent.
+const CACHE_VERSION = 5;
 // Serve a cached entry without refetching under this age.
 const SOFT_TTL_MS = 60 * 60 * 1000; // 1h
 // KV hard expiry — a safety net far past the soft TTL.

--- a/cloud/src/video/cache.ts
+++ b/cloud/src/video/cache.ts
@@ -9,10 +9,16 @@
 // repopulates it, so a profile view never blocks on YouTube once warm; a cold
 // miss fetches synchronously. Transient upstream errors never overwrite a good
 // entry (fetchRecent throws rather than returning []) — worst case we serve
-// slightly-stale videos.
+// slightly-stale videos. A fetch that succeeded but degraded says so with
+// UncacheableVideos, and is served without being written (see refresh).
 
 import { logError } from "../log";
-import type { Video, VideoEnv, VideoProvider } from "./types";
+import {
+	UncacheableVideos,
+	type Video,
+	type VideoEnv,
+	type VideoProvider,
+} from "./types";
 
 // Bump when the CachedVideos shape changes — old keys orphan and expire.
 // v2: playlist entries gained per-video uploader fields (PlaylistVideo).
@@ -74,7 +80,19 @@ async function refresh<T extends Video>(
 	cacheId: string,
 	fetchFn: () => Promise<T[]>,
 ): Promise<T[]> {
-	const videos = await fetchFn();
+	let videos: T[];
+	try {
+		videos = await fetchFn();
+	} catch (e) {
+		// Degraded but serve-able: hand it back without writing, so the
+		// degradation lasts this one response rather than the whole TTL. On the
+		// stale path the caller has already served the prior (good) entry and
+		// discards this; leaving it unwritten is what keeps that entry. The cast
+		// is sound for the same reason the read cast below is — the payload is
+		// exactly what fetchFn produced.
+		if (e instanceof UncacheableVideos) return e.videos as T[];
+		throw e;
+	}
 	await writeCache(env, platform, cacheId, videos);
 	return videos;
 }

--- a/cloud/src/video/types.ts
+++ b/cloud/src/video/types.ts
@@ -44,6 +44,14 @@ export interface PlaylistVideo extends Video {
 	uploader_name: string | null;
 }
 
+// Newest first, for any list of normalized videos. ISO timestamps sort
+// lexically, and an entry missing a date ("") falls to the end. Every fetch and
+// merge path sorts through this, so the "newest first" contract they each
+// document has one definition.
+export function byPublishedDesc(a: Video, b: Video): number {
+	return a.published_at < b.published_at ? 1 : -1;
+}
+
 // A resolved channel: the platform, the (canonicalized) URL we show the
 // user, and the native id the fetch path needs.
 export interface ChannelIdentity {
@@ -54,7 +62,9 @@ export interface ChannelIdentity {
 
 // Bindings a provider may need: KV for the recent-videos cache, and any
 // per-provider API credential. YOUTUBE_API_KEY is optional — a `/channel/UC…`
-// URL resolves without it; only handle/username resolution calls the Data API.
+// URL resolves without it, and the fetch path falls back to the feed's own
+// dates. With it, handle/username resolution and the broadcast-date pass on
+// recent videos both call the Data API (see youtube.ts).
 export interface VideoEnv {
 	SESSIONS_KV: KVNamespace;
 	YOUTUBE_API_KEY?: string;
@@ -74,6 +84,21 @@ export class ChannelResolutionError extends Error {
 	}
 }
 
+// Thrown by a fetch path that produced usable videos it does not want
+// persisted: the list is serve-able but degraded, so caching it would hold the
+// degradation for the whole TTL. Today's one source is a failed broadcast-date
+// enrichment (see fetchBroadcastStarts in youtube.ts), which leaves live
+// content dated by its VOD publish instant — the very bug the enrichment
+// exists to fix. The cache layer serves `videos` and skips the write, so a
+// warm entry keeps its prior good dates and a cold miss simply retries next
+// request.
+export class UncacheableVideos extends Error {
+	constructor(readonly videos: Video[]) {
+		super("video fetch degraded — serve, do not cache");
+		this.name = "UncacheableVideos";
+	}
+}
+
 export interface VideoProvider {
 	readonly platform: VideoPlatform;
 
@@ -90,6 +115,9 @@ export interface VideoProvider {
 	// Fetch the channel's recent videos from the platform (uncached — the
 	// cache layer wraps this). Returns [] for a channel with no uploads;
 	// THROWS on a transient upstream failure so the cache layer can keep
-	// serving a prior good result instead of caching an error as "empty".
+	// serving a prior good result instead of caching an error as "empty", and
+	// throws UncacheableVideos when it has videos worth serving but not
+	// storing. A caller outside the cache layer must handle the latter — it
+	// carries a perfectly good list (see scripts/admin/commands/channels.ts).
 	fetchRecent(channelId: string, env: VideoEnv): Promise<Video[]>;
 }

--- a/cloud/src/video/types.ts
+++ b/cloud/src/video/types.ts
@@ -25,7 +25,10 @@ export interface Video {
 	url: string;
 	// Best available thumbnail, or null if the feed omitted one.
 	thumbnail_url: string | null;
-	// ISO 8601 publish instant.
+	// ISO 8601. When the video went up — except for live content, where it is
+	// when the broadcast aired rather than when its VOD was later published (see
+	// the broadcast-dates note in youtube.ts). Feeds report the latter, and it
+	// runs hours late, so the two are worth keeping straight.
 	published_at: string;
 	platform: VideoPlatform;
 }

--- a/cloud/src/video/youtube.test.ts
+++ b/cloud/src/video/youtube.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+	applyBroadcastStarts,
 	decodeXmlEntities,
 	parsePlaylistItemsPage,
+	parseVideosListPage,
 	parseYouTubeChannelUrl,
 	parseYouTubeFeed,
 	parseYouTubePlaylistFeed,
 	parseYouTubePlaylistUrl,
 } from "./youtube";
+import type { Video } from "./types";
 
 // A syntactically valid channel id: UC + 22 url-safe chars.
 const CHANNEL_ID = "UCabcdefghijklmnopqrstuv";
@@ -306,5 +309,90 @@ describe("parsePlaylistItemsPage", () => {
 			videos: [],
 			nextPageToken: null,
 		});
+	});
+});
+
+describe("parseVideosListPage", () => {
+	// Shapes taken from a real videos.list?part=liveStreamingDetails response:
+	// an archived broadcast, an ordinary upload (no liveStreamingDetails at all),
+	// and a broadcast that was scheduled but never aired.
+	const page = {
+		items: [
+			{
+				id: "e5eFJgzYz3Q",
+				liveStreamingDetails: {
+					actualStartTime: "2026-07-31T01:04:43Z",
+					actualEndTime: "2026-07-31T02:56:37Z",
+				},
+			},
+			{ id: "VID0000001" },
+			{
+				id: "VID0000002",
+				liveStreamingDetails: { scheduledStartTime: "2026-08-09T00:00:00Z" },
+			},
+		],
+	};
+
+	it("maps an archived broadcast to the instant it started", () => {
+		expect(parseVideosListPage(page).get("e5eFJgzYz3Q")).toBe(
+			"2026-07-31T01:04:43Z",
+		);
+	});
+
+	it("omits ordinary uploads and never-aired broadcasts", () => {
+		const starts = parseVideosListPage(page);
+		expect(starts.has("VID0000001")).toBe(false);
+		expect(starts.has("VID0000002")).toBe(false);
+		expect(starts.size).toBe(1);
+	});
+
+	it("tolerates a malformed/empty response", () => {
+		expect(parseVideosListPage(null).size).toBe(0);
+		expect(parseVideosListPage({}).size).toBe(0);
+	});
+});
+
+describe("applyBroadcastStarts", () => {
+	const video = (id: string, published_at: string): Video => ({
+		id,
+		title: id,
+		url: `https://www.youtube.com/watch?v=${id}`,
+		thumbnail_url: null,
+		published_at,
+		platform: "youtube",
+	});
+
+	it("re-dates a broadcast to its air time and leaves uploads alone", () => {
+		const out = applyBroadcastStarts(
+			[
+				video("BROADCAST01", "2026-07-31T15:27:03Z"),
+				video("UPLOAD00001", "2026-07-30T09:00:00Z"),
+			],
+			new Map([["BROADCAST01", "2026-07-31T01:04:43Z"]]),
+		);
+		expect(out.map((v) => v.published_at)).toEqual([
+			"2026-07-31T01:04:43Z",
+			"2026-07-30T09:00:00Z",
+		]);
+	});
+
+	// Regression for the reported bug: this cast aired on Jul 30 (21:04 ET) but
+	// its VOD was published 14h later on Jul 31, so the feed dated it Jul 31 and
+	// the home page rendered it as ~18h newer than it was.
+	it("moves a cast back to the day it actually aired", () => {
+		const [corrected] = applyBroadcastStarts(
+			[video("e5eFJgzYz3Q", "2026-07-31T15:27:03Z")],
+			new Map([["e5eFJgzYz3Q", "2026-07-31T01:04:43Z"]]),
+		);
+		const skewHours =
+			(Date.parse("2026-07-31T15:27:03Z") -
+				Date.parse(corrected.published_at)) /
+			3_600_000;
+		expect(skewHours).toBeCloseTo(14.4, 1);
+	});
+
+	it("returns dates untouched when nothing is a broadcast", () => {
+		const videos = [video("UPLOAD00001", "2026-07-30T09:00:00Z")];
+		expect(applyBroadcastStarts(videos, new Map())).toEqual(videos);
 	});
 });

--- a/cloud/src/video/youtube.ts
+++ b/cloud/src/video/youtube.ts
@@ -12,7 +12,9 @@
 
 import { logError, logWarn } from "../log";
 import {
+	byPublishedDesc,
 	ChannelResolutionError,
+	UncacheableVideos,
 	type ChannelIdentity,
 	type PlaylistVideo,
 	type Video,
@@ -307,13 +309,6 @@ export function parseYouTubePlaylistFeed(xml: string): PlaylistVideo[] {
 	return videos;
 }
 
-// Newest first. ISO timestamps sort lexically, and an entry missing a date
-// ("") falls to the end. Shared by all three fetch paths so the "newest first"
-// contract the Videos tab documents has one definition.
-function byPublishedDesc(a: Video, b: Video): number {
-	return a.published_at < b.published_at ? 1 : -1;
-}
-
 // ─── Broadcast dates ─────────────────────────────────────────────────
 //
 // A tournament cast is streamed live, and for live content the feed's
@@ -367,19 +362,22 @@ export function applyBroadcastStarts<T extends Video>(
 }
 
 // Broadcast start instants for `ids`, via videos.list, batched at
-// VIDEOS_LIST_BATCH.
+// VIDEOS_LIST_BATCH. `degraded` is true when any batch failed, so its videos
+// still carry the feed's VOD dates.
 //
 // NEVER throws, unlike the feed fetches around it. Enrichment improves a date we
 // already have; it is not a precondition for having one. A quota-exhausted or
 // failing videos.list therefore degrades that batch to its feed <published> —
 // exactly the pre-enrichment behavior — rather than discarding a feed we already
 // fetched successfully. Each batch is independent, so one bad page doesn't cost
-// the others.
+// the others. What the caller must not do is let a degraded result be cached;
+// that is what `degraded` is for.
 async function fetchBroadcastStarts(
 	ids: string[],
 	apiKey: string,
-): Promise<Map<string, string>> {
+): Promise<{ starts: Map<string, string>; degraded: boolean }> {
 	const starts = new Map<string, string>();
+	let degraded = false;
 	for (let i = 0; i < ids.length; i += VIDEOS_LIST_BATCH) {
 		const url = new URL("https://www.googleapis.com/youtube/v3/videos");
 		url.searchParams.set("part", "liveStreamingDetails");
@@ -389,10 +387,11 @@ async function fetchBroadcastStarts(
 			const res = await fetch(url);
 			if (!res.ok) {
 				const detail = await res.text().catch(() => "");
-				logWarn("youtube_videos_list_failed", {
+				logError("youtube_videos_list_failed", null, {
 					yt_status: res.status,
 					yt_detail: detail.slice(0, 500),
 				});
+				degraded = true;
 				continue;
 			}
 			for (const [id, start] of parseVideosListPage(await res.json())) {
@@ -400,24 +399,31 @@ async function fetchBroadcastStarts(
 			}
 		} catch (e) {
 			logError("youtube_videos_list_failed", e);
+			degraded = true;
 		}
 	}
-	return starts;
+	return { starts, degraded };
 }
 
 // Correct the feed's dates for live content, where a key allows it. Without one
 // every date stands as the feed gave it — the channel path stays usable with no
-// credentials (see the module header). Callers must re-sort afterwards: moving a
-// broadcast back to its air time can push it past a video published after it.
+// credentials (see the module header), and that is not a degraded result but
+// the documented keyless behavior, so `degraded` stays false.
+//
+// Callers must re-sort afterwards — moving a broadcast back to its air time can
+// push it past a video published after it — and must throw UncacheableVideos
+// with the finished list when `degraded`, once the rest of their pipeline has
+// run.
 async function withBroadcastStarts<T extends Video>(
 	videos: T[],
 	apiKey: string | undefined,
-): Promise<T[]> {
-	if (!apiKey || videos.length === 0) return videos;
+): Promise<{ videos: T[]; degraded: boolean }> {
+	if (!apiKey || videos.length === 0) return { videos, degraded: false };
 	// Distinct ids only — a playlist may list one video twice (see dedupeById),
 	// and a repeat would otherwise burn a slot in the 50-id batch.
 	const ids = [...new Set(videos.map((v) => v.id))];
-	return applyBroadcastStarts(videos, await fetchBroadcastStarts(ids, apiKey));
+	const { starts, degraded } = await fetchBroadcastStarts(ids, apiKey);
+	return { videos: applyBroadcastStarts(videos, starts), degraded };
 }
 
 async function fetchYouTubeRecent(
@@ -434,14 +440,20 @@ async function fetchYouTubeRecent(
 		throw new Error(`youtube feed responded ${res.status}`);
 	}
 	const xml = await res.text();
-	// Cap on the feed's own order before enriching, so this costs one videos.list
-	// call rather than one per feed page; then re-sort, because re-dating a
-	// broadcast to when it aired can move it past a video published after it.
-	const recent = await withBroadcastStarts(
+	// The cap runs on the feed's own order, so the feed's dates still decide
+	// which entries we keep: enrichment only ever moves a broadcast earlier, so
+	// one of the ~3 entries past the cap can be newer than a kept broadcast and
+	// go unsurfaced anyway. Then re-sort — that same shift can move a broadcast
+	// past a video published after it.
+	const { videos, degraded } = await withBroadcastStarts(
 		parseYouTubeFeed(xml).slice(0, MAX_VIDEOS),
 		env.YOUTUBE_API_KEY,
 	);
-	return recent.sort(byPublishedDesc);
+	const recent = videos.sort(byPublishedDesc);
+	// Enrichment failed: these are the feed's VOD dates, i.e. the bug. Serve
+	// them, but keep them out of the cache.
+	if (degraded) throw new UncacheableVideos(recent);
+	return recent;
 }
 
 // A YouTube playlist can list the same video in more than one slot — a curator
@@ -484,8 +496,7 @@ export async function fetchYouTubePlaylistVideos(
 	// chronological (a curated or append-ordered playlist won't be) — so sort
 	// newest-first before capping, both to honor the "newest first" contract the
 	// Videos tab documents and so the cap keeps the newest entries, not whichever
-	// happen to sit first. Mirrors the home feed's ordering (mergeCreatorFeed);
-	// ISO timestamps sort lexically and entries missing a date fall to the end.
+	// happen to sit first. Mirrors the home feed's ordering (mergeCreatorFeed).
 	return dedupeById(parseYouTubePlaylistFeed(xml).sort(byPublishedDesc)).slice(
 		0,
 		MAX_VIDEOS,
@@ -556,8 +567,9 @@ export function parsePlaylistItemsPage(data: unknown): {
 // Data API key and spends quota (1 unit/page, plus one per 50 videos for the
 // broadcast-start pass). Uncached (getVideosCached wraps it). Returns [] for a
 // missing/private playlist (404); THROWS on a transient upstream failure so the
-// cache keeps serving a prior good result. Sorted newest-first and capped like
-// the RSS path, for the same reasons.
+// cache keeps serving a prior good result, and throws UncacheableVideos when
+// only the broadcast-start pass failed. Sorted newest-first and capped like the
+// RSS path, for the same reasons.
 export async function fetchYouTubePlaylistVideosViaApi(
 	playlistId: string,
 	apiKey: string,
@@ -602,11 +614,15 @@ export async function fetchYouTubePlaylistVideosViaApi(
 	// Enrich before sorting so the order reflects when casts aired, not when
 	// their VODs went public — two casts from one evening can otherwise land in
 	// the order their VODs were published the next day.
-	const enriched = await withBroadcastStarts(all, apiKey);
-	return dedupeById(enriched.sort(byPublishedDesc)).slice(
+	const { videos, degraded } = await withBroadcastStarts(all, apiKey);
+	const listed = dedupeById(videos.sort(byPublishedDesc)).slice(
 		0,
 		MAX_PLAYLIST_VIDEOS,
 	);
+	// Enrichment failed: these are the feed's VOD dates, i.e. the bug. Serve
+	// them, but keep them out of the cache.
+	if (degraded) throw new UncacheableVideos(listed);
+	return listed;
 }
 
 export const youtubeProvider: VideoProvider = {

--- a/cloud/src/video/youtube.ts
+++ b/cloud/src/video/youtube.ts
@@ -4,8 +4,11 @@
 // native id directly (no API call), while an @handle or legacy /user/ name is
 // resolved to its UC… id via one YouTube Data API call (1 quota unit). Recent
 // videos are then pulled from the free, unauthenticated per-channel Atom feed
-// (`/feeds/videos.xml?channel_id=UC…`) — so the recurring hot path needs no
-// key and costs no quota; only the one-time resolve does.
+// (`/feeds/videos.xml?channel_id=UC…`).
+//
+// The feed alone misdates live content, so a keyed build spends one more quota
+// unit per refresh correcting it (see fetchBroadcastStarts). The hot path still
+// works without a key — it just falls back to the feed's own dates.
 
 import { logError, logWarn } from "../log";
 import {
@@ -36,6 +39,11 @@ const MAX_VIDEOS = 12;
 const MAX_PLAYLIST_VIDEOS = 500;
 // playlistItems.list returns at most 50 items per page.
 const PLAYLIST_PAGE_SIZE = 50;
+// videos.list accepts up to 50 ids per call and costs one quota unit per call
+// regardless of how many are asked for, so broadcast-start enrichment is a
+// single request per channel refresh (MAX_VIDEOS is 12) and ceil(n / 50) for a
+// full playlist.
+const VIDEOS_LIST_BATCH = 50;
 
 type ParsedYouTube =
 	| { kind: "id"; channelId: string }
@@ -299,9 +307,122 @@ export function parseYouTubePlaylistFeed(xml: string): PlaylistVideo[] {
 	return videos;
 }
 
+// Newest first. ISO timestamps sort lexically, and an entry missing a date
+// ("") falls to the end. Shared by all three fetch paths so the "newest first"
+// contract the Videos tab documents has one definition.
+function byPublishedDesc(a: Video, b: Video): number {
+	return a.published_at < b.published_at ? 1 : -1;
+}
+
+// ─── Broadcast dates ─────────────────────────────────────────────────
+//
+// A tournament cast is streamed live, and for live content the feed's
+// <published> is when the *VOD* was published — which lands hours after the
+// broadcast ended, routinely in the next calendar day. Observed on six casts
+// from one channel: +4h to +15h, and 5 of 6 crossed a day boundary. Because the
+// VOD instant is later than the air time, dating a cast by it renders the cast
+// as more recent than it is ("20 hours ago" for a stream that aired 38 hours
+// earlier), which is both wrong and contradicts what YouTube itself shows
+// ("Streamed live on Jul 30").
+//
+// The Atom feed carries nothing about the broadcast — <published> and <updated>
+// are its only timestamps, and <updated> tracks view-count churn, so it is
+// further from the air time, not closer. videos.list is the only supported
+// source, hence the one extra quota unit.
+
+// The videos.list response (only the fields we read).
+interface VideosListResponse {
+	items?: {
+		id?: string;
+		liveStreamingDetails?: { actualStartTime?: string };
+	}[];
+}
+
+// Map video id → the instant its broadcast actually started, for those ids that
+// are live broadcasts. An ordinary upload carries no liveStreamingDetails at
+// all, so it is simply absent from the map — that absence is the discriminator,
+// not a sentinel. A broadcast scheduled but never aired has liveStreamingDetails
+// without actualStartTime, and is likewise absent. Pure — exported for unit
+// tests.
+export function parseVideosListPage(data: unknown): Map<string, string> {
+	const page = (data ?? {}) as VideosListResponse;
+	const starts = new Map<string, string>();
+	for (const item of page.items ?? []) {
+		const start = item.liveStreamingDetails?.actualStartTime;
+		if (item.id && start) starts.set(item.id, start);
+	}
+	return starts;
+}
+
+// Re-date live broadcasts to when they aired. A video with no entry in `starts`
+// keeps its feed date. Pure — exported for unit tests.
+export function applyBroadcastStarts<T extends Video>(
+	videos: T[],
+	starts: Map<string, string>,
+): T[] {
+	return videos.map((v) => {
+		const start = starts.get(v.id);
+		return start ? { ...v, published_at: start } : v;
+	});
+}
+
+// Broadcast start instants for `ids`, via videos.list, batched at
+// VIDEOS_LIST_BATCH.
+//
+// NEVER throws, unlike the feed fetches around it. Enrichment improves a date we
+// already have; it is not a precondition for having one. A quota-exhausted or
+// failing videos.list therefore degrades that batch to its feed <published> —
+// exactly the pre-enrichment behavior — rather than discarding a feed we already
+// fetched successfully. Each batch is independent, so one bad page doesn't cost
+// the others.
+async function fetchBroadcastStarts(
+	ids: string[],
+	apiKey: string,
+): Promise<Map<string, string>> {
+	const starts = new Map<string, string>();
+	for (let i = 0; i < ids.length; i += VIDEOS_LIST_BATCH) {
+		const url = new URL("https://www.googleapis.com/youtube/v3/videos");
+		url.searchParams.set("part", "liveStreamingDetails");
+		url.searchParams.set("id", ids.slice(i, i + VIDEOS_LIST_BATCH).join(","));
+		url.searchParams.set("key", apiKey);
+		try {
+			const res = await fetch(url);
+			if (!res.ok) {
+				const detail = await res.text().catch(() => "");
+				logWarn("youtube_videos_list_failed", {
+					yt_status: res.status,
+					yt_detail: detail.slice(0, 500),
+				});
+				continue;
+			}
+			for (const [id, start] of parseVideosListPage(await res.json())) {
+				starts.set(id, start);
+			}
+		} catch (e) {
+			logError("youtube_videos_list_failed", e);
+		}
+	}
+	return starts;
+}
+
+// Correct the feed's dates for live content, where a key allows it. Without one
+// every date stands as the feed gave it — the channel path stays usable with no
+// credentials (see the module header). Callers must re-sort afterwards: moving a
+// broadcast back to its air time can push it past a video published after it.
+async function withBroadcastStarts<T extends Video>(
+	videos: T[],
+	apiKey: string | undefined,
+): Promise<T[]> {
+	if (!apiKey || videos.length === 0) return videos;
+	// Distinct ids only — a playlist may list one video twice (see dedupeById),
+	// and a repeat would otherwise burn a slot in the 50-id batch.
+	const ids = [...new Set(videos.map((v) => v.id))];
+	return applyBroadcastStarts(videos, await fetchBroadcastStarts(ids, apiKey));
+}
+
 async function fetchYouTubeRecent(
 	channelId: string,
-	_env: VideoEnv,
+	env: VideoEnv,
 ): Promise<Video[]> {
 	const res = await fetch(
 		`https://www.youtube.com/feeds/videos.xml?channel_id=${encodeURIComponent(channelId)}`,
@@ -313,7 +434,14 @@ async function fetchYouTubeRecent(
 		throw new Error(`youtube feed responded ${res.status}`);
 	}
 	const xml = await res.text();
-	return parseYouTubeFeed(xml).slice(0, MAX_VIDEOS);
+	// Cap on the feed's own order before enriching, so this costs one videos.list
+	// call rather than one per feed page; then re-sort, because re-dating a
+	// broadcast to when it aired can move it past a video published after it.
+	const recent = await withBroadcastStarts(
+		parseYouTubeFeed(xml).slice(0, MAX_VIDEOS),
+		env.YOUTUBE_API_KEY,
+	);
+	return recent.sort(byPublishedDesc);
 }
 
 // A YouTube playlist can list the same video in more than one slot — a curator
@@ -337,6 +465,10 @@ function dedupeById<T extends { id: string }>(videos: T[]): T[] {
 // Returns [] for a missing/private playlist (404); THROWS on a transient
 // upstream failure so the cache keeps serving a prior good result. Exported for
 // the tournament videos read.
+//
+// Live content keeps the feed's VOD date here: correcting it needs videos.list,
+// and this path only runs when there is no key to call it with — a keyed
+// deployment takes fetchYouTubePlaylistVideosViaApi instead.
 export async function fetchYouTubePlaylistVideos(
 	playlistId: string,
 ): Promise<PlaylistVideo[]> {
@@ -354,11 +486,10 @@ export async function fetchYouTubePlaylistVideos(
 	// Videos tab documents and so the cap keeps the newest entries, not whichever
 	// happen to sit first. Mirrors the home feed's ordering (mergeCreatorFeed);
 	// ISO timestamps sort lexically and entries missing a date fall to the end.
-	return dedupeById(
-		parseYouTubePlaylistFeed(xml).sort((a, b) =>
-			a.published_at < b.published_at ? 1 : -1,
-		),
-	).slice(0, MAX_VIDEOS);
+	return dedupeById(parseYouTubePlaylistFeed(xml).sort(byPublishedDesc)).slice(
+		0,
+		MAX_VIDEOS,
+	);
 }
 
 // One item as returned by playlistItems.list (only the fields we read).
@@ -422,10 +553,11 @@ export function parsePlaylistItemsPage(data: unknown): {
 // the full-playlist source behind the tournament Videos tab's search. Unlike the
 // free Atom feed (fetchYouTubePlaylistVideos), which only ever returns the ~15
 // most recent entries, this pages through the whole playlist, so it needs the
-// Data API key and spends quota (1 unit/page). Uncached (getVideosCached wraps
-// it). Returns [] for a missing/private playlist (404); THROWS on a transient
-// upstream failure so the cache keeps serving a prior good result. Sorted
-// newest-first and capped like the RSS path, for the same reasons.
+// Data API key and spends quota (1 unit/page, plus one per 50 videos for the
+// broadcast-start pass). Uncached (getVideosCached wraps it). Returns [] for a
+// missing/private playlist (404); THROWS on a transient upstream failure so the
+// cache keeps serving a prior good result. Sorted newest-first and capped like
+// the RSS path, for the same reasons.
 export async function fetchYouTubePlaylistVideosViaApi(
 	playlistId: string,
 	apiKey: string,
@@ -467,9 +599,14 @@ export async function fetchYouTubePlaylistVideosViaApi(
 			cap: MAX_PLAYLIST_VIDEOS,
 		});
 	}
-	return dedupeById(
-		all.sort((a, b) => (a.published_at < b.published_at ? 1 : -1)),
-	).slice(0, MAX_PLAYLIST_VIDEOS);
+	// Enrich before sorting so the order reflects when casts aired, not when
+	// their VODs went public — two casts from one evening can otherwise land in
+	// the order their VODs were published the next day.
+	const enriched = await withBroadcastStarts(all, apiKey);
+	return dedupeById(enriched.sort(byPublishedDesc)).slice(
+		0,
+		MAX_PLAYLIST_VIDEOS,
+	);
 }
 
 export const youtubeProvider: VideoProvider = {

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -179,14 +179,16 @@ ALLOWED_ORIGINS = "https://per-ankh.app,http://localhost:1420"
 DISCORD_CLIENT_ID = "1500901451034263604"
 # DISCORD_CLIENT_SECRET is set out-of-band:
 #   npx wrangler secret put DISCORD_CLIENT_SECRET
-# YOUTUBE_API_KEY (also a secret, set out-of-band) is used only to resolve an
-# @handle / legacy /user/ channel URL to its channel id when a user links a
-# YouTube channel (cloud/src/video/youtube.ts). Fetching recent videos uses the
-# unauthenticated RSS feed and needs no key. It's optional — no preflight
-# requires it (unlike DISCORD_CLIENT_SECRET) — but wrangler secrets are
-# per-environment, so set it in BOTH or handle/username resolution silently
-# fails in whichever env lacks it (that env can then only accept a
-# …/channel/UC… URL):
+# YOUTUBE_API_KEY (also a secret, set out-of-band) has two uses, both in
+# cloud/src/video/youtube.ts: resolving an @handle / legacy /user/ channel URL
+# to its channel id when a user links a YouTube channel, and correcting the
+# dates on live content, which the RSS feed reports as when the VOD went up
+# rather than when the broadcast aired (1 quota unit per channel refresh,
+# behind the 1h video cache). It's optional — no preflight requires it (unlike
+# DISCORD_CLIENT_SECRET) — but wrangler secrets are per-environment, so set it
+# in BOTH or, in whichever env lacks it, handle/username resolution silently
+# fails (that env can then only accept a …/channel/UC… URL) and casts show
+# their VOD dates:
 #   npx wrangler secret put YOUTUBE_API_KEY
 #   npx wrangler secret put YOUTUBE_API_KEY --env staging
 # Session cookie name. A var (not a code const) so staging can use a distinct

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -314,8 +314,8 @@ Recent videos merged across the user's linked channels (newest first) — feeds 
 
 - **Auth:** Public — channels and their videos are user-published; no PII, same for every viewer.
 - **Path:** `user_id` (21-char).
-- **Response 200:** `{ videos: { id, title, url, thumbnail_url: string|null, published_at, platform }[] }` (empty when the user has no linked channels).
-- **Notes:** Per-channel KV cache, stale-while-revalidate (serves cached instantly, refreshes in the background past a 1h soft TTL). YouTube videos come from the unauthenticated channel RSS feed.
+- **Response 200:** `{ videos: { id, title, url, thumbnail_url: string|null, published_at, platform }[] }` (empty when the user has no linked channels). For live content `published_at` is when the broadcast aired, not when its VOD was later published — see the note below.
+- **Notes:** Per-channel KV cache, stale-while-revalidate (serves cached instantly, refreshes in the background past a 1h soft TTL). YouTube videos come from the unauthenticated channel RSS feed. That feed dates live content by its VOD publish instant, which runs hours (routinely a calendar day) after the broadcast, so when `YOUTUBE_API_KEY` is configured each refresh spends one further quota unit on `videos.list` to re-date broadcasts to `liveStreamingDetails.actualStartTime` and re-sorts. Without the key the feed's own dates stand. A refresh whose `videos.list` call fails is served but not cached, so the feed dates never persist past that one response.
 
 ### `GET /v1/users/:user_id/tournaments`
 One player's whole tournament record — played + upcoming matches, and cast appearances — for the profile "Tournaments" tab.
@@ -331,7 +331,7 @@ Cross-creator home feed — the newest uploads across all users' linked channels
 
 - **Auth:** Public — channels and their videos are user-published; no PII, same for every viewer.
 - **Response 200:** `{ videos: { id, title, url, thumbnail_url: string|null, published_at, platform, user_id, display_name, avatar_url }[] }` (each video carries its creator; empty only when no channel has recent uploads).
-- **Notes:** Cached as one pre-assembled KV entry, stale-while-revalidate (mirrors the per-channel cache): fresh served as-is, stale served instantly while a background task re-assembles it, cold miss built synchronously and cached so the first request already returns the feed. The cold build's per-channel fetches run in parallel over mostly-warm caches (~one RSS fetch at worst). Capped at 8 (two rows of four). Underlying per-channel data is the same SWR RSS cache as `GET /v1/users/:user_id/videos`.
+- **Notes:** Cached as one pre-assembled KV entry, stale-while-revalidate (mirrors the per-channel cache): fresh served as-is, stale served instantly while a background task re-assembles it, cold miss built synchronously and cached so the first request already returns the feed. The cold build's per-channel fetches run in parallel over mostly-warm caches (at worst one RSS fetch per channel, plus one `videos.list` call where a key is configured). Capped at 8 (two rows of four). Underlying per-channel data is the same SWR cache as `GET /v1/users/:user_id/videos`, including its broadcast-date correction — so a cast is placed and labelled by when it aired.
 
 ---
 
@@ -425,9 +425,9 @@ Single match detail.
 - **Errors:** `404 MATCH_NOT_FOUND` (missing, or the match's round isn't in this tournament), `404 TOURNAMENT_NOT_FOUND`, `429 RATE_LIMIT_TOURNAMENT_VIEW`.
 
 ### `GET /v1/tournaments/:id/videos`
-Uploads from the tournament's admin-set YouTube playlist (`youtube_playlist_url`) — feeds the Videos tab, whose search filters the returned list client-side. KV-cached (stale-while-revalidate), same as the profile videos read. When `YOUTUBE_API_KEY` is configured the whole playlist is enumerated via the Data API (`playlistItems.list`, paged, capped at 500) so search can reach every video; without the key it falls back to the free RSS feed's ~15 most-recent entries.
+Uploads from the tournament's admin-set YouTube playlist (`youtube_playlist_url`) — feeds the Videos tab, whose search filters the returned list client-side. KV-cached (stale-while-revalidate), same as the profile videos read. When `YOUTUBE_API_KEY` is configured the whole playlist is enumerated via the Data API (`playlistItems.list`, paged, capped at 500) so search can reach every video, and broadcasts are re-dated to when they aired (`videos.list`, one further unit per 50 videos — same correction as the profile videos read); without the key it falls back to the free RSS feed's ~15 most-recent entries, dated as the feed gave them.
 
-- **Response 200:** `{ videos: [{ id, title, url, thumbnail_url, published_at, platform, …uploader }] }`, newest first. Each video carries uploader attribution: a linked Per-Ankh uploader adds `{ user_id, display_name, avatar_url }` (Discord identity, like the creator feed); an unlinked YouTube uploader adds `{ uploader_name, uploader_url }`; a feed without an author adds neither. Empty when no playlist is configured or the stored value no longer parses.
+- **Response 200:** `{ videos: [{ id, title, url, thumbnail_url, published_at, platform, …uploader }] }`, newest first (on the keyed path, by air time for live content). Each video carries uploader attribution: a linked Per-Ankh uploader adds `{ user_id, display_name, avatar_url }` (Discord identity, like the creator feed); an unlinked YouTube uploader adds `{ uploader_name, uploader_url }`; a feed without an author adds neither. Empty when no playlist is configured or the stored value no longer parses.
 - **Errors:** `404 TOURNAMENT_NOT_FOUND`, `429 RATE_LIMIT_TOURNAMENT_VIEW`.
 
 ---

--- a/scripts/admin/commands/channels.ts
+++ b/scripts/admin/commands/channels.ts
@@ -43,7 +43,11 @@ import { d1Exec, d1Query, sqlStr } from "../wrangler";
 // object (mirrors the tournament-seed import in ./tournament.ts). Types are
 // erased at runtime, so they import cleanly by name.
 import videoRegistry from "../../../cloud/src/video/registry";
-import type { VideoEnv } from "../../../cloud/src/video/types";
+import type {
+	Video,
+	VideoEnv,
+	VideoProvider,
+} from "../../../cloud/src/video/types";
 const { providerForUrl, supportedPlatforms } = videoRegistry;
 
 // scripts/admin/commands/channels.ts → repo root is three levels up.
@@ -60,13 +64,36 @@ const MAX_URL_LEN = 500;
 
 // The Worker reads YOUTUBE_API_KEY from a wrangler secret; the CLI resolves the
 // same way the local Worker does — process env first, else cloud/.dev.vars.
-// Only @handle / /user/ resolution needs it; …/channel/UC… works without.
+// @handle / /user/ resolution needs it (…/channel/UC… works without), as does
+// the broadcast-date pass on the recent-videos fetch.
 function youtubeApiKey(): string | undefined {
 	return (
 		process.env.YOUTUBE_API_KEY ||
 		readDotVars(DEV_VARS_PATH).YOUTUBE_API_KEY ||
 		undefined
 	);
+}
+
+// fetchRecent throws UncacheableVideos when it fetched a feed but couldn't
+// correct its broadcast dates — usable videos the Worker declines to persist
+// (cloud/src/video/types.ts). For a one-off sanity check the dates don't
+// matter, so unwrap it rather than reporting a live feed as unreachable.
+// Matched by name because cloud/ is CJS: its runtime named exports don't cross
+// into this ESM script (see the registry import above), so `instanceof` has no
+// class to test against here.
+async function fetchRecentForCheck(
+	provider: VideoProvider,
+	channelId: string,
+	env: VideoEnv,
+): Promise<Video[]> {
+	try {
+		return await provider.fetchRecent(channelId, env);
+	} catch (e) {
+		if (e instanceof Error && e.name === "UncacheableVideos") {
+			return (e as Error & { videos: Video[] }).videos;
+		}
+		throw e;
+	}
 }
 
 interface UserRow {
@@ -155,10 +182,15 @@ export async function runAddChannel(
 
 	// Confirm the stored id points at a live feed: a mistyped …/channel/UC… id
 	// stores fine but yields an empty Videos tab, so surface the recent-video
-	// count (RSS, no key) as a sanity check. Non-fatal — the row is written.
+	// count (the RSS feed, plus a broadcast-date lookup when a key is present)
+	// as a sanity check. Non-fatal — the row is written.
 	let recent = "unavailable";
 	try {
-		const videos = await provider.fetchRecent(identity.channel_id, env);
+		const videos = await fetchRecentForCheck(
+			provider,
+			identity.channel_id,
+			env,
+		);
 		const latest = videos[0];
 		recent = latest
 			? `${videos.length} (latest: "${trunc(latest.title, 48)}", ${formatDate(latest.published_at)})`


### PR DESCRIPTION
Reported in Discord by Konstant: the "X hours ago" pills on the home creator feed are wrong. Confirmed on a freshly-opened tab, and confirmed to affect archived streams but not a currently-live one.

## The bug

Nearly every video in the creator feed is a tournament cast, and casts are streamed live. For live content, the channel Atom feed's `<published>` is when the **VOD** was published — which lands hours after the broadcast ended, routinely in the next calendar day. `videoFromEntry` reads that tag straight into `Video.published_at`, so the feed dated every cast by its VOD publish instant. Because that instant is *later* than the air time, casts rendered as more recent than they are.

Six casts from one channel, sampled 2026-08-01. `startTimestamp` is from the watch page's `liveBroadcastDetails`; `<published>` is the Atom feed's value, identical to the watch page's `publishDate`/`uploadDate`:

| video | aired (`startTimestamp`) | `<published>` (what we used) | skew | YouTube's own label |
|---|---|---|---|---|
| `e5eFJgzYz3Q` fiddlers25 v nobody, Part 5 | 2026-07-31T01:04:43Z | 2026-07-31T15:27:03Z | +14.4h | Streamed live on **Jul 30** |
| `CLauyN3KQys` fiddlers25 v nobody, Part 4 | 2026-07-29T01:04:34Z | 2026-07-29T16:09:39Z | +15.1h | Streamed live on **Jul 28** |
| `LE9A41q8GCk` Sabertooth v Nicknight, Part 3 | 2026-07-27T02:01:09Z | 2026-07-27T15:52:18Z | +13.9h | Streamed live on **Jul 26** |
| `8SJOXJod6rA` alcaras v HazardBringsAxe, Part 2 | 2026-07-26T18:00:09Z | 2026-07-27T08:00:24Z | +14.0h | Streamed live on **Jul 26** |
| `ilZDbW_0p1o` alcaras v HazardBringsAxe | 2026-07-25T18:01:04Z | 2026-07-25T22:13:47Z | +4.2h | Streamed live on **Jul 25** |
| `nqMGQ-svQGk` fiddlers25 v nobody | 2026-07-17T00:18:21Z | 2026-07-17T15:29:35Z | +15.2h | Streamed live on **Jul 16** |

All six report `isLiveContent: true`. Skew +4h to +15h, five of six crossing a day boundary.

This reproduces the report exactly: at ~2026-08-01T11:27Z the feed showed Part 5 as "20 hours ago" — precisely `now − 2026-07-31T15:27:03Z` — while the stream aired ~38 hours earlier, which YouTube presents as Jul 30. It also explains why a currently-live stream looked right: a stream that hasn't ended has no VOD publish instant to skew away from its start.

**Not caching**, which was the first hypothesis. The KV SWR layer and the `s-maxage=60` on `/v1/creator-videos` affect *which* videos appear, not their timestamps; the rendered label matched `<published>` to the minute. **Not the last release** either — `git log c0ef8b4..HEAD` over the home page, `VideoCard`, `formatting.ts`, `channels.ts`, and `video/` is empty.

## Why videos.list

The Atom feed carries nothing about the broadcast. `<published>` and `<updated>` are its only two timestamps, and `<updated>` tracks view-count churn — it moved ~35 minutes before I fetched it because `media:statistics` ticked — so it sits *further* from the air time, not closer. oEmbed returns no timestamps at all. The watch page does carry `liveBroadcastDetails`, but that's an undocumented blob inside ~1.2 MB of HTML, one fetch per video. `videos.list` is the only supported source.

## The changes

**`parseVideosListPage` / `applyBroadcastStarts`** — pure, unit-tested. Maps video id → `liveStreamingDetails.actualStartTime`, then re-dates. An ordinary upload carries no `liveStreamingDetails` at all, so its absence from the map is the discriminator rather than a sentinel value; a broadcast scheduled but never aired has the object without `actualStartTime` and is likewise absent.

**`fetchBroadcastStarts`** — batched at 50 ids (`videos.list` costs 1 unit per call regardless of id count). Never throws, unlike the feed fetches around it: enrichment improves a date we already have rather than being a precondition for having one, so a quota-exhausted or failing call degrades that batch to its feed `<published>` instead of discarding a feed already fetched successfully. Batches are independent, so one bad page doesn't cost the others. It reports whether any batch failed, which is what the cache decision below turns on.

**A degraded result is served but never cached.** Falling back to the feed's `<published>` is the pre-change behavior, but *caching* that fallback isn't: `getVideosCached` would write the VOD dates to KV and serve them for up to the 1h soft / 24h hard TTL, which is the bug this branch exists to fix, re-frozen for an hour. It also runs against the module's own convention — every other fetch path throws on a transient upstream failure precisely so a prior good entry survives. So both keyed paths now finish their pipeline (sort, dedupe, cap) and then throw `UncacheableVideos` carrying the finished list; `refresh()` serves that payload and skips the write. A warm entry keeps its prior good dates; a cold miss serves the feed dates once and retries on the next request.

`fetchRecent`'s signature is unchanged, so the throw is the whole contract. The one caller outside the cache layer — `./per-ankh admin add-channel`, whose post-write sanity check calls `fetchRecent` directly — unwraps it and uses the payload, since a one-off "does this channel id point at a live feed?" doesn't care about the dates. It matches on `name` rather than `instanceof` because `cloud/` is CJS and its runtime named exports don't cross into that ESM script (same reason the registry is imported through default interop there).

**`withBroadcastStarts`** — no key ⇒ returns the input untouched, and that is the documented keyless behavior rather than a degraded result, so it doesn't suppress caching. Dedupes ids so a video a curator listed twice doesn't burn a slot in the 50-id batch.

**Wired into both keyed paths** — `fetchYouTubeRecent` (home feed + profile Videos tab) and `fetchYouTubePlaylistVideosViaApi` (tournament Videos tab). The keyless RSS playlist path is deliberately unchanged: it only runs when there is no key to call `videos.list` with, so there is nothing to wire.

**Enrichment runs before the sort in both paths.** Ordering was affected too, not just labels — re-dating a cast can move it past a video published after it, and two casts from one evening would otherwise sort by when their VODs went public the next day.

**`byPublishedDesc` extracted to `video/types.ts`.** The comparator existed in four inline copies — two in `youtube.ts`, two in `channels.ts` (`handleUserVideos` and `mergeCreatorFeed`, which is where the "newest first" contract is actually promised to callers) — and this branch adds a fifth call site. One definition, five users.

**`CACHE_VERSION` 4 → 5** so warmed entries holding VOD dates orphan, rather than serving wrong dates for up to the 24h hard TTL.

**Docs.** Four places described the recent-videos path as needing no key — `cloud/wrangler.toml`, two endpoints in `docs/api-reference.md`, the admin CLI, and the `VideoEnv` doc comment. `docs/api-reference.md` also now states what `published_at` means for live content on all three video endpoints, and that a failed correction is served but not cached.

**Logging.** A non-OK `videos.list` logs at error, like the file's other two upstream failures, rather than putting the same event name on two levels.

## Cost

One extra quota unit per channel refresh (`MAX_VIDEOS` is 12, so one call), amortized behind the existing 1h SWR TTL — 24/day per linked channel, against a 10k/day default. The playlist path adds `ceil(n / 50)`, so up to 10 units on top of its existing 10.

The structural cost: the channel hot path was advertised as key-free, and this makes a keyed build spend quota on it. It degrades to the feed date without a key rather than becoming a hard dependency, and the module header and `wrangler.toml` are rewritten to say so.

## Known limitation

On the channel path the cap to `MAX_VIDEOS` runs on the feed's own order, so the feed's dates still decide *which* entries we keep — enrichment only ever moves a broadcast earlier, so one of the ~3 entries past the cap can end up newer than a kept broadcast and go unsurfaced anyway. Labels and ordering within the kept set are correct. Noted in the code rather than fixed; moving the slice after the sort would cost nothing in quota if we decide the membership edge case matters.

## Verification

Rebased on current `main` (the D1/R2 instrumentation work; no overlap with `cloud/src/video/`).

- `cloud/` `tsc --noEmit` — clean
- `cloud/` `npm test` — 578 passing, 10 of them new (6 for the date correction, 4 for the cache-skip)
- `npm run check` (svelte-check) — 1290 files, 0 errors
- `npm run lint` and `prettier --check` — clean
- `scripts/` isn't covered by any configured typecheck, so `scripts/admin/commands/channels.ts` was checked with `tsc` directly — clean

The 4 `canonical-map-options` failures are pre-existing and unrelated (#115/#141) — confirmed by running that file on a stashed clean tree, where it fails identically.

**Not verified:** the `videos.list` call itself is only exercised against real YouTube with a key. The tests cover the pure parse/apply functions and the cache's serve-don't-write branch, not the network path — worth a staging check before prod.

## Not in scope

`formatRelativeToNow` reads `Date.now()` directly rather than the repo's existing reactive clock (`nowMs()`, `src/lib/stores/now.svelte.ts`), so none of its four callers re-render as time passes and a page left open shows a frozen badge. That was the first hypothesis here and Konstant ruled it out by reproducing on a fresh tab. Now filed as #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MoWizF9ZomtCiKd51nabx
