### PR TITLE
feat(tournament): sesh export lists a match that outlived its sitting as owing its next part

### DIFF
--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -184,6 +184,28 @@ export function partPlayed(part: TournamentMatchPart, now = nowMs()): boolean {
 // Reads the shared reactive clock (nowMs), like its sibling helpers here, so a
 // $derived that lists these (the Cast view, the popover's caster post) drops a
 // sitting as its time passes instead of waiting for the next data refetch.
+// A pending match whose every sitting is timed and has aged out (started
+// more than LIVE_WINDOW_MS ago) did not finish in its last session — a
+// finished match gets its save uploaded and reported promptly, so a still-
+// open one is between sittings and owes the schedule its next part. Returns
+// that next part's number, or null when the match doesn't owe one: no
+// sittings yet (a different "to be scheduled" case), an explicitly open
+// part (the TO already added the blank sitting by hand), or a sitting
+// still ahead or plausibly live. Reads the shared reactive clock like its
+// sibling helpers, so a match starts owing as its last sitting ages out.
+export function owesNextSitting(m: TournamentMatch): number | null {
+	if (m.status !== "pending" || m.slot_b_id == null) return null;
+	const parts = matchParts(m);
+	if (parts.length === 0) return null;
+	const cutoff = nowMs() - LIVE_WINDOW_MS;
+	for (const p of parts) {
+		if (p.scheduled_at == null) return null;
+		const t = Date.parse(p.scheduled_at);
+		if (Number.isNaN(t) || t > cutoff) return null;
+	}
+	return parts.length + 1;
+}
+
 export function upcomingScheduledParts(
 	matches: TournamentMatch[],
 	graceMs = 0,

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -213,9 +213,8 @@ export function owesNextSitting(m: TournamentMatch): number | null {
 	if (parts.length === 0) return null;
 	const cutoff = nowMs() - LIVE_WINDOW_MS;
 	for (const p of parts) {
-		if (p.scheduled_at == null) return null;
-		const t = Date.parse(p.scheduled_at);
-		if (Number.isNaN(t) || t > cutoff) return null;
+		const t = partInstant(p);
+		if (t == null || t > cutoff) return null;
 	}
 	return parts.length + 1;
 }

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -198,23 +198,21 @@ export function upcomingScheduledParts(
 	});
 }
 
-// A pending match whose every sitting is timed and has aged out (started
-// more than LIVE_WINDOW_MS ago) did not finish in its last session — a
-// finished match gets its save uploaded and reported promptly, so a still-
-// open one is between sittings and owes the schedule its next part. Returns
-// that next part's number, or null when the match doesn't owe one: no
-// sittings yet (a different "to be scheduled" case), an explicitly open
-// part (the TO already added the blank sitting by hand), or a sitting
-// still ahead or plausibly live. Reads the shared reactive clock like its
-// sibling helpers, so a match starts owing as its last sitting ages out.
+// A pending match whose every sitting has aged out (partPlayed, which owns
+// that boundary) did not finish in its last session — a finished match gets
+// its save uploaded and reported promptly, so a still-open one is between
+// sittings and owes the schedule its next part. Returns that next part's
+// number, or null when the match doesn't owe one: no sittings yet (a
+// different "to be scheduled" case), an explicitly open part (the TO already
+// added the blank sitting by hand), or a sitting still ahead or plausibly
+// live. Classifies every part against one `now` off the shared reactive
+// clock, as liveAndUpcoming does, so a match starts owing as its last sitting
+// ages out.
 export function owesNextSitting(m: TournamentMatch): number | null {
 	if (m.status !== "pending" || m.slot_b_id == null) return null;
 	const parts = matchParts(m);
 	if (parts.length === 0) return null;
-	const cutoff = nowMs() - LIVE_WINDOW_MS;
-	for (const p of parts) {
-		const t = partInstant(p);
-		if (t == null || t > cutoff) return null;
-	}
+	const now = nowMs();
+	if (!parts.every((p) => partPlayed(p, now))) return null;
 	return parts.length + 1;
 }

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -184,6 +184,20 @@ export function partPlayed(part: TournamentMatchPart, now = nowMs()): boolean {
 // Reads the shared reactive clock (nowMs), like its sibling helpers here, so a
 // $derived that lists these (the Cast view, the popover's caster post) drops a
 // sitting as its time passes instead of waiting for the next data refetch.
+export function upcomingScheduledParts(
+	matches: TournamentMatch[],
+	graceMs = 0,
+): NumberedPart[] {
+	const cutoff = nowMs() - graceMs;
+	const pending = matches.filter(
+		(m) => m.status === "pending" && m.slot_b_id != null,
+	);
+	return scheduledParts(pending).filter((np) => {
+		const t = partInstant(np.part);
+		return t != null && t >= cutoff;
+	});
+}
+
 // A pending match whose every sitting is timed and has aged out (started
 // more than LIVE_WINDOW_MS ago) did not finish in its last session — a
 // finished match gets its save uploaded and reported promptly, so a still-
@@ -204,18 +218,4 @@ export function owesNextSitting(m: TournamentMatch): number | null {
 		if (Number.isNaN(t) || t > cutoff) return null;
 	}
 	return parts.length + 1;
-}
-
-export function upcomingScheduledParts(
-	matches: TournamentMatch[],
-	graceMs = 0,
-): NumberedPart[] {
-	const cutoff = nowMs() - graceMs;
-	const pending = matches.filter(
-		(m) => m.status === "pending" && m.slot_b_id != null,
-	);
-	return scheduledParts(pending).filter((np) => {
-		const t = partInstant(np.part);
-		return t != null && t >= cutoff;
-	});
 }

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -208,7 +208,7 @@ export function upcomingScheduledParts(
 // live. Classifies every part against one `now` off the shared reactive
 // clock, as liveAndUpcoming does, so a match starts owing as its last sitting
 // ages out.
-export function owesNextSitting(m: TournamentMatch): number | null {
+export function owedPartNumber(m: TournamentMatch): number | null {
 	if (m.status !== "pending" || m.slot_b_id == null) return null;
 	const parts = matchParts(m);
 	if (parts.length === 0) return null;

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -44,6 +44,7 @@
 		matchParts,
 		matchDisplayStatus,
 		owesNextSitting,
+		partInstant,
 		upcomingScheduledParts,
 		CAST_GRACE_MS,
 		type NumberedPart,
@@ -151,9 +152,13 @@
 						: [];
 				}
 				const split = parts.length >= 2;
+				// An open part is one with no usable time — partInstant's answer, not
+				// a raw null check, so a part carrying an unparseable time lands here
+				// instead of falling through both this branch and owesNextSitting
+				// (which reads the same helper) and vanishing from the post.
 				const open = parts
 					.map((part, i) => ({ part, partNumber: i + 1 }))
-					.filter(({ part }) => part.scheduled_at == null)
+					.filter(({ part }) => partInstant(part) == null)
 					.map(({ partNumber }) => line(partNumber, split));
 				if (open.length > 0) return open;
 				const next = owesNextSitting(m);

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -43,7 +43,7 @@
 	import {
 		matchParts,
 		matchDisplayStatus,
-		owesNextSitting,
+		owedPartNumber,
 		partInstant,
 		upcomingScheduledParts,
 		CAST_GRACE_MS,
@@ -154,14 +154,14 @@
 				const split = parts.length >= 2;
 				// An open part is one with no usable time — partInstant's answer, not
 				// a raw null check, so a part carrying an unparseable time lands here
-				// instead of falling through both this branch and owesNextSitting
+				// instead of falling through both this branch and owedPartNumber
 				// (which reads the same helper) and vanishing from the post.
 				const open = parts
 					.map((part, i) => ({ part, partNumber: i + 1 }))
 					.filter(({ part }) => partInstant(part) == null)
 					.map(({ partNumber }) => line(partNumber, split));
 				if (open.length > 0) return open;
-				const next = owesNextSitting(m);
+				const next = owedPartNumber(m);
 				return next != null ? [line(next, true)] : [];
 			});
 

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -134,43 +134,30 @@
 			.filter((m) => m.status === "pending" && m.slot_b_id != null)
 			.sort((a, b) => (a.match_number ?? 0) - (b.match_number ?? 0))
 			.flatMap((m) => {
+				// Every line in this block is the same match with no time, so only
+				// the part tag varies — bind the match once rather than repeating it
+				// per branch.
+				const line = (partNumber: number, split: boolean) =>
+					seshMatchLine({
+						matchNumber: m.match_number,
+						versus: vs(m),
+						partNumber,
+						split,
+					});
 				const parts = matchParts(m);
 				if (parts.length === 0) {
 					return matchDisplayStatus(m) === "unscheduled"
-						? [
-								seshMatchLine({
-									matchNumber: m.match_number,
-									versus: vs(m),
-									partNumber: 1,
-									split: false,
-								}),
-							]
+						? [line(1, false)]
 						: [];
 				}
 				const split = parts.length >= 2;
 				const open = parts
 					.map((part, i) => ({ part, partNumber: i + 1 }))
 					.filter(({ part }) => part.scheduled_at == null)
-					.map(({ partNumber }) =>
-						seshMatchLine({
-							matchNumber: m.match_number,
-							versus: vs(m),
-							partNumber,
-							split,
-						}),
-					);
+					.map(({ partNumber }) => line(partNumber, split));
 				if (open.length > 0) return open;
 				const next = owesNextSitting(m);
-				return next != null
-					? [
-							seshMatchLine({
-								matchNumber: m.match_number,
-								versus: vs(m),
-								partNumber: next,
-								split: true,
-							}),
-						]
-					: [];
+				return next != null ? [line(next, true)] : [];
 			});
 
 		const blocks = [

--- a/src/routes/tournaments/[slug]/matches/+page.svelte
+++ b/src/routes/tournaments/[slug]/matches/+page.svelte
@@ -43,6 +43,7 @@
 	import {
 		matchParts,
 		matchDisplayStatus,
+		owesNextSitting,
 		upcomingScheduledParts,
 		CAST_GRACE_MS,
 		type NumberedPart,
@@ -120,11 +121,15 @@
 				(scheduled.length ? scheduled.join("\n") : "(none — all covered)")
 			);
 		}
-		// "To be scheduled" = matches still owing a time: never scheduled at all,
-		// or carrying a part without one yet (a split match heading into "Part 2,
-		// time TBD" — see #91). A match that has fully started (in progress,
-		// awaiting result, no open part) doesn't belong here. The part tag mirrors
-		// the "Upcoming" lines: shown only when the match is actually split.
+		// "To be scheduled" = matches still owing a time: never scheduled at
+		// all; carrying a part without one yet (a split match heading into
+		// "Part 2, time TBD" — see #91); or still pending after every sitting
+		// aged out — the game didn't finish in its last session (a finished
+		// match gets reported promptly), so it owes a next sitting without the
+		// TO having to add a blank part by hand. A match with a sitting still
+		// ahead or plausibly live doesn't belong here. The part tag mirrors the
+		// "Upcoming" lines: shown for any split match, including the synthetic
+		// next part (it is by definition part 2+).
 		const unscheduled = data.matches
 			.filter((m) => m.status === "pending" && m.slot_b_id != null)
 			.sort((a, b) => (a.match_number ?? 0) - (b.match_number ?? 0))
@@ -143,7 +148,7 @@
 						: [];
 				}
 				const split = parts.length >= 2;
-				return parts
+				const open = parts
 					.map((part, i) => ({ part, partNumber: i + 1 }))
 					.filter(({ part }) => part.scheduled_at == null)
 					.map(({ partNumber }) =>
@@ -154,6 +159,18 @@
 							split,
 						}),
 					);
+				if (open.length > 0) return open;
+				const next = owesNextSitting(m);
+				return next != null
+					? [
+							seshMatchLine({
+								matchNumber: m.match_number,
+								versus: vs(m),
+								partNumber: next,
+								split: true,
+							}),
+						]
+					: [];
 			});
 
 		const blocks = [


### PR DESCRIPTION
Mini PR for a TO workflow gap in the sesh export.

## The gap

A pending match whose only scheduled sitting has passed **vanishes from the "Copy upcoming (sesh)" post entirely**: it isn't upcoming (nothing ahead), and it isn't "To be scheduled" (no part missing a time). In practice TOs were adding a blank part by hand after every unfinished session, just to keep the match visible in the schedule post.

But a pending match is by definition unfinished — when a session actually ends the game, the save gets uploaded and the match reported promptly. So a match whose every sitting is timed and aged out (started more than `LIVE_WINDOW_MS = 4h` ago) is simply *between sessions*, and it owes the schedule its next sitting.

## The change

`owesNextSitting` (new helper in `parts.ts`, reactive via the shared clock like its siblings) returns the part number such a match owes, or null when it doesn't: no sittings yet (the existing never-scheduled case), an explicitly open part (the TO already added one), or a sitting still ahead / plausibly live. The sesh export's To-be-scheduled block now lists the owed part as a synthetic split line.

Verified on a local fixture, clipboard contents via the real Copy button:

- sitting **8h ago**, match still pending →
  ```
  To be scheduled

  Match 012 (Part 2) - @A v @B
  ```
- same sitting moved to **1h ago** (inside the live window) → match stays out of both blocks, exactly as before.

No behavior change for never-scheduled matches, hand-added open parts, or matches with a future sitting. `lint` / `svelte-check` / prettier clean.
