### PR TITLE
fix(tournament): match card leads with the next session; played sessions collapse

### DIFF
--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -44,6 +44,7 @@
 		matchSlotUserId,
 	} from "$lib/tournament/match-occupant";
 	import { upcomingScheduledParts } from "$lib/tournament/parts";
+	import { nowMs } from "$lib/stores/now.svelte";
 	import { seshMatchLine, seshVersus } from "$lib/tournament/sesh";
 	import { mapScriptLabel } from "$lib/tournament/map-scripts";
 	import {
@@ -379,6 +380,41 @@
 	// castingParts keeps each part's original 1-based number so a split match
 	// labels "Part N" consistently in both panels, and drops parts with no
 	// broadcast info so the casting panel only lists sittings that have some.
+	// Schedule rows, upcoming-first. A long split match accumulates played
+	// sittings that bury the one a viewer actually needs — the NEXT one —
+	// below the popover's fold (the report that prompted this was a match on
+	// sitting seven, whose only future time sat off-screen). Sittings that
+	// have started render behind a collapsed "N played sittings" toggle when
+	// there are two or more of them; with nothing still ahead, the most
+	// recent played sitting stays inline so the panel never opens empty.
+	// Reads the shared clock, so a sitting moves into the played group as
+	// its time passes.
+	const numberedSittings = $derived(
+		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
+	);
+	const startedSittings = $derived(
+		numberedSittings.filter(({ part }) => {
+			if (part.scheduled_at == null) return false;
+			const t = Date.parse(part.scheduled_at);
+			return !Number.isNaN(t) && t <= nowMs();
+		}),
+	);
+	const aheadSittings = $derived(
+		numberedSittings.filter((np) => !startedSittings.includes(np)),
+	);
+	const collapsedSittings = $derived(
+		startedSittings.length >= 2
+			? aheadSittings.length > 0
+				? startedSittings
+				: startedSittings.slice(0, -1)
+			: [],
+	);
+	const scheduleRows = $derived([
+		...startedSittings.filter((np) => !collapsedSittings.includes(np)),
+		...aheadSittings,
+	]);
+	let showPlayed = $state(false);
+
 	const castingParts = $derived(
 		match.parts
 			.map((part, i) => ({ part, partNumber: i + 1 }))
@@ -1068,16 +1104,28 @@
 			class="flex flex-col gap-2 rounded-lg p-3"
 			style="background-color: rgb(var(--color-surface-raised));"
 		>
-			{#each match.parts as part, i (part.id)}
+			{#if collapsedSittings.length > 0}
+				<button
+					type="button"
+					class="flex items-center gap-1 self-start text-[10px] font-bold uppercase tracking-wider text-muted transition-colors hover:text-tan"
+					onclick={() => (showPlayed = !showPlayed)}
+					aria-expanded={showPlayed}
+				>
+					<span aria-hidden="true">{showPlayed ? "▾" : "▸"}</span>
+					{collapsedSittings.length} played
+					{collapsedSittings.length === 1 ? "sitting" : "sittings"}
+				</button>
+			{/if}
+			{#each showPlayed ? [...collapsedSittings, ...scheduleRows] : scheduleRows as { part, partNumber }, i (part.id)}
 				<div
-					class="flex items-center gap-2 {i > 0
+					class="flex items-center gap-2 {i > 0 || collapsedSittings.length > 0
 						? 'border-t border-border-subtle pt-2'
 						: ''}"
 				>
 					{#if match.parts.length > 1}
 						<span
 							class="shrink-0 text-[10px] font-bold uppercase tracking-wider text-muted"
-							>Part {i + 1}</span
+							>Part {partNumber}</span
 						>
 					{/if}
 					{#if part.scheduled_at}

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -419,12 +419,18 @@
 	// Read view splits the old combined parts block into two stacked panels: the
 	// schedule (per-part times) and casting (per-part casters + stream links).
 	// castingParts keeps each part's original 1-based number so a split match
-	// labels "Part N" consistently in both panels, and drops parts with no
-	// broadcast info so the casting panel only lists sittings that have some.
+	// labels "Part N" consistently in both panels. Played sessions appear only
+	// when they have broadcast info to archive; a session still ahead (or
+	// live) appears regardless — an upcoming sitting with nobody signed up is
+	// exactly the one the panel should be advertising, and hiding it made a
+	// split match's next session vanish from the card entirely.
 	const castingParts = $derived(
-		match.parts
-			.map((part, i) => ({ part, partNumber: i + 1 }))
-			.filter(({ part }) => part.casters.length > 0 || part.streams.length > 0),
+		numberedSessions.filter(
+			(np) =>
+				np.part.casters.length > 0 ||
+				np.part.streams.length > 0 ||
+				(match.status === "pending" && !playedSessions.includes(np)),
+		),
 	);
 	const hasSecondaryActions = $derived(
 		canSchedule ||
@@ -1186,6 +1192,11 @@
 					{/if}
 					<!-- Caster on the left, its stream link(s) to the right. -->
 					<div class="flex items-start gap-3">
+						{#if part.casters.length === 0}
+							<!-- An upcoming session with nobody signed up — the reason it's
+							     listed at all is to advertise the seat. -->
+							<span class="text-xs italic text-muted">Needs a caster</span>
+						{/if}
 						{#if part.casters.length > 0}
 							<!-- Streamer first (with avatar), co-casters appended. Each name
 							     is its own link, so the co-casters are rendered one at a time

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -381,37 +381,37 @@
 	// labels "Part N" consistently in both panels, and drops parts with no
 	// broadcast info so the casting panel only lists sittings that have some.
 	// Schedule rows, upcoming-first. A long split match accumulates played
-	// sittings that bury the one a viewer actually needs — the NEXT one —
+	// sessions that bury the one a viewer actually needs — the NEXT one —
 	// below the popover's fold (the report that prompted this was a match on
-	// sitting seven, whose only future time sat off-screen). Sittings that
-	// have started render behind a collapsed "N played sittings" toggle when
+	// session seven, whose only future time sat off-screen). Sessions that
+	// have started render behind a collapsed "N played sessions" toggle when
 	// there are two or more of them; with nothing still ahead, the most
-	// recent played sitting stays inline so the panel never opens empty.
-	// Reads the shared clock, so a sitting moves into the played group as
+	// recent played session stays inline so the panel never opens empty.
+	// Reads the shared clock, so a session moves into the played group as
 	// its time passes.
-	const numberedSittings = $derived(
+	const numberedSessions = $derived(
 		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
 	);
-	const startedSittings = $derived(
-		numberedSittings.filter(({ part }) => {
+	const startedSessions = $derived(
+		numberedSessions.filter(({ part }) => {
 			if (part.scheduled_at == null) return false;
 			const t = Date.parse(part.scheduled_at);
 			return !Number.isNaN(t) && t <= nowMs();
 		}),
 	);
-	const aheadSittings = $derived(
-		numberedSittings.filter((np) => !startedSittings.includes(np)),
+	const aheadSessions = $derived(
+		numberedSessions.filter((np) => !startedSessions.includes(np)),
 	);
-	const collapsedSittings = $derived(
-		startedSittings.length >= 2
-			? aheadSittings.length > 0
-				? startedSittings
-				: startedSittings.slice(0, -1)
+	const collapsedSessions = $derived(
+		startedSessions.length >= 2
+			? aheadSessions.length > 0
+				? startedSessions
+				: startedSessions.slice(0, -1)
 			: [],
 	);
 	const scheduleRows = $derived([
-		...startedSittings.filter((np) => !collapsedSittings.includes(np)),
-		...aheadSittings,
+		...startedSessions.filter((np) => !collapsedSessions.includes(np)),
+		...aheadSessions,
 	]);
 	let showPlayed = $state(false);
 
@@ -1104,7 +1104,7 @@
 			class="flex flex-col gap-2 rounded-lg p-3"
 			style="background-color: rgb(var(--color-surface-raised));"
 		>
-			{#if collapsedSittings.length > 0}
+			{#if collapsedSessions.length > 0}
 				<button
 					type="button"
 					class="flex items-center gap-1 self-start text-[10px] font-bold uppercase tracking-wider text-muted transition-colors hover:text-tan"
@@ -1112,13 +1112,13 @@
 					aria-expanded={showPlayed}
 				>
 					<span aria-hidden="true">{showPlayed ? "▾" : "▸"}</span>
-					{collapsedSittings.length} played
-					{collapsedSittings.length === 1 ? "sitting" : "sittings"}
+					{collapsedSessions.length} played
+					{collapsedSessions.length === 1 ? "session" : "sessions"}
 				</button>
 			{/if}
-			{#each showPlayed ? [...collapsedSittings, ...scheduleRows] : scheduleRows as { part, partNumber }, i (part.id)}
+			{#each showPlayed ? [...collapsedSessions, ...scheduleRows] : scheduleRows as { part, partNumber }, i (part.id)}
 				<div
-					class="flex items-center gap-2 {i > 0 || collapsedSittings.length > 0
+					class="flex items-center gap-2 {i > 0 || collapsedSessions.length > 0
 						? 'border-t border-border-subtle pt-2'
 						: ''}"
 				>

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -43,7 +43,10 @@
 		matchSlotSlug,
 		matchSlotUserId,
 	} from "$lib/tournament/match-occupant";
-	import { upcomingScheduledParts } from "$lib/tournament/parts";
+	import {
+		LIVE_WINDOW_MS,
+		upcomingScheduledParts,
+	} from "$lib/tournament/parts";
 	import { nowMs } from "$lib/stores/now.svelte";
 	import { seshMatchLine, seshVersus } from "$lib/tournament/sesh";
 	import { mapScriptLabel } from "$lib/tournament/map-scripts";
@@ -375,46 +378,49 @@
 	const canSchedule = $derived(
 		!isPlaceholder && match.status !== "bye" && (isAdmin || isParticipant),
 	);
+	// Schedule rows, played-last-and-collapsed. A long split match
+	// accumulates played sessions that bury the one a viewer actually needs
+	// — the NEXT one — below the popover's fold (the report that prompted
+	// this was a match on session seven, whose only future time sat
+	// off-screen). A session counts as played once it has aged out of
+	// LIVE_WINDOW_MS — the same boundary liveAndUpcoming uses, so a session
+	// being streamed right now stays inline, in order, with the upcoming
+	// ones. Played sessions render behind a collapsed "N played sessions"
+	// toggle when there are two or more; with nothing else to show, the
+	// most recent played session stays inline so the panel never opens
+	// empty. Reads the shared clock, so a session slides into the played
+	// group as it ages out.
+	const numberedSessions = $derived(
+		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
+	);
+	const playedSessions = $derived(
+		numberedSessions.filter(({ part }) => {
+			if (part.scheduled_at == null) return false;
+			const t = Date.parse(part.scheduled_at);
+			return !Number.isNaN(t) && t <= nowMs() - LIVE_WINDOW_MS;
+		}),
+	);
+	const aheadSessions = $derived(
+		numberedSessions.filter((np) => !playedSessions.includes(np)),
+	);
+	const collapsedSessions = $derived(
+		playedSessions.length >= 2
+			? aheadSessions.length > 0
+				? playedSessions
+				: playedSessions.slice(0, -1)
+			: [],
+	);
+	const scheduleRows = $derived([
+		...playedSessions.filter((np) => !collapsedSessions.includes(np)),
+		...aheadSessions,
+	]);
+	let showPlayed = $state(false);
+
 	// Read view splits the old combined parts block into two stacked panels: the
 	// schedule (per-part times) and casting (per-part casters + stream links).
 	// castingParts keeps each part's original 1-based number so a split match
 	// labels "Part N" consistently in both panels, and drops parts with no
 	// broadcast info so the casting panel only lists sittings that have some.
-	// Schedule rows, upcoming-first. A long split match accumulates played
-	// sessions that bury the one a viewer actually needs — the NEXT one —
-	// below the popover's fold (the report that prompted this was a match on
-	// session seven, whose only future time sat off-screen). Sessions that
-	// have started render behind a collapsed "N played sessions" toggle when
-	// there are two or more of them; with nothing still ahead, the most
-	// recent played session stays inline so the panel never opens empty.
-	// Reads the shared clock, so a session moves into the played group as
-	// its time passes.
-	const numberedSessions = $derived(
-		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
-	);
-	const startedSessions = $derived(
-		numberedSessions.filter(({ part }) => {
-			if (part.scheduled_at == null) return false;
-			const t = Date.parse(part.scheduled_at);
-			return !Number.isNaN(t) && t <= nowMs();
-		}),
-	);
-	const aheadSessions = $derived(
-		numberedSessions.filter((np) => !startedSessions.includes(np)),
-	);
-	const collapsedSessions = $derived(
-		startedSessions.length >= 2
-			? aheadSessions.length > 0
-				? startedSessions
-				: startedSessions.slice(0, -1)
-			: [],
-	);
-	const scheduleRows = $derived([
-		...startedSessions.filter((np) => !collapsedSessions.includes(np)),
-		...aheadSessions,
-	]);
-	let showPlayed = $state(false);
-
 	const castingParts = $derived(
 		match.parts
 			.map((part, i) => ({ part, partNumber: i + 1 }))

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -17,10 +17,15 @@ export function matchParts(m: TournamentMatch): TournamentMatchPart[] {
 
 // A match's status for display, refining the raw match status with parts info:
 //   completed    — reported or forfeit.
-//   in_progress  — pending, but a scheduled part's time has already passed, so
-//                  play has started (single session underway, or split across
-//                  sittings) and a result is pending.
-//   scheduled    — pending with an upcoming (still-future) part and none started.
+//   in_progress  — pending with a session plausibly being played right now
+//                  (started within LIVE_WINDOW_MS), or every session played
+//                  and nothing further scheduled — a result (or the next
+//                  sitting) is owed.
+//   scheduled    — pending with an upcoming (still-future) session; a split
+//                  match between sessions reads by its NEXT sitting, not its
+//                  past ones — the bracket card's chip is often the only
+//                  signal a viewer gets, and "In progress" hid that a next
+//                  session was already on the calendar.
 //   unscheduled  — pending, no part scheduled at all.
 // Byes return null (auto-resolved, nothing to show).
 export type MatchDisplayStatus =
@@ -45,9 +50,23 @@ export function matchDisplayStatus(
 ): MatchDisplayStatus | null {
 	if (m.status === "complete" || m.status === "forfeit") return "completed";
 	if (m.status === "bye") return null;
-	if (hasStartedPart(m)) return "in_progress";
+	if (hasLivePart(m)) return "in_progress";
 	if (isMatchScheduled(m)) return "scheduled";
+	if (hasStartedPart(m)) return "in_progress";
 	return "unscheduled";
+}
+
+// True while a session is plausibly being played right now — started within
+// LIVE_WINDOW_MS, the same boundary liveAndUpcoming draws. Outranks a
+// future sitting in matchDisplayStatus: a match being streamed is "in
+// progress" even when its next session is already scheduled.
+export function hasLivePart(m: TournamentMatch): boolean {
+	const now = nowMs();
+	return matchParts(m).some((p) => {
+		if (p.scheduled_at == null) return false;
+		const t = Date.parse(p.scheduled_at);
+		return !Number.isNaN(t) && t <= now && t > now - LIVE_WINDOW_MS;
+	});
 }
 
 // True once any scheduled part's time has passed — the match is underway (or


### PR DESCRIPTION
Fixes the TO bug report: *"if a match has more than 6 parts they don't show on the card, just when clicking schedule — you can see this on the live site with the fiddlers/nobody match, they have a scheduled part 7 but it doesn't show on the card."*

## The actual bug — the card's status chip

`matchDisplayStatus` checked `hasStartedPart` before `isMatchScheduled`, so the moment any session's time passed, the match read **"In progress"** forever. The bracket card renders only that chip — so a split match's scheduled next session was invisible on the card, discoverable only inside the schedule editor. Exactly the report.

Classification now runs **live → scheduled → started → unscheduled**: a session started within `LIVE_WINDOW_MS` still reads "In progress" (a match being streamed outranks its next booking), an upcoming session reads "Scheduled", and a match with everything aged out and nothing booked reads "In progress" as before. One shared classifier, so the bracket cards, championship tree, and the matches table's filter buckets all correct together — and the table's sort comment already expected this case ("a split match mid-schedule sorts by its next sitting").

The reported match, before and after:

![before card](https://raw.githubusercontent.com/alcaras/per-ankh/14124d666010d64ec07af8c8b620ea378c38e011/before-card-inprogress.png)
![after card](https://raw.githubusercontent.com/alcaras/per-ankh/14124d666010d64ec07af8c8b620ea378c38e011/after-card-scheduled.png)

## Also fixed along the way: the card scroll fold

No data cap anywhere: all seven parts arrive and all seven render. But the match card scrolls (`max-h-[85vh]`), the schedule panel listed sittings in play order, and six played timestamps plus casting rows push the **only sitting that matters — the next one — below the fold**, where macOS's auto-hiding scrollbars make it read as missing. Measured on the live match: Part 7's row sat at y≈1092 in a 900px viewport.

## The fix — lead with what matters

The schedule panel now renders **upcoming sessions first**; sittings whose time has passed collapse behind a **"N played sessions"** toggle when there are two or more. With nothing still ahead, the most recent played session stays inline so the panel never opens empty. Single-session matches and 1-played/1-ahead splits render exactly as before — only the wall-of-stale-dates case changes. The partition reads the shared clock, so a session slides into the played group as its time passes.

Before (live site, the reported match — Part 7 is far below this fold):

![before](https://raw.githubusercontent.com/alcaras/per-ankh/5a90311e73bbc8d813145826b8da88d604d65316/before-live.png)

After (same seven parts on a local fixture — the next sitting is the first row):

![after](https://raw.githubusercontent.com/alcaras/per-ankh/5a90311e73bbc8d813145826b8da88d604d65316/after-collapsed.png)

Expanded:

![expanded](https://raw.githubusercontent.com/alcaras/per-ankh/5a90311e73bbc8d813145826b8da88d604d65316/after-expanded.png)

Deliberately untouched: the **Casting** panel below still lists every cast session — that content is archival (who cast what, stream links) rather than a schedule, and collapsing it is a separate design call.

`lint` / `svelte-check` / prettier clean.






