### PR TITLE
fix(tournament): collapse played sessions so the next one stays above the popover fold

### DIFF
--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -382,6 +382,9 @@
 			match.status !== "bye" &&
 			(isAdmin || (isParticipant && match.status === "pending")),
 	);
+	// Whether the collapsed played sessions are currently disclosed. Reset per
+	// match by the parent's {#key match.match_id} remount.
+	let showPlayed = $state(false);
 	// Schedule rows, played-last-and-collapsed. A long split match
 	// accumulates played sessions that push the one a viewer actually needs
 	// — the NEXT one — below the popover frame's max-h-[85vh] fold, where on
@@ -400,24 +403,23 @@
 	const numberedSessions = $derived(
 		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
 	);
-	const playedSessions = $derived(
-		numberedSessions.filter(({ part }) => partPlayed(part)),
-	);
-	const aheadSessions = $derived(
-		numberedSessions.filter((np) => !playedSessions.includes(np)),
-	);
-	const collapsedSessions = $derived(
-		playedSessions.length >= 2
-			? aheadSessions.length > 0
-				? playedSessions
-				: playedSessions.slice(0, -1)
-			: [],
-	);
-	const scheduleRows = $derived([
-		...playedSessions.filter((np) => !collapsedSessions.includes(np)),
-		...aheadSessions,
-	]);
-	let showPlayed = $state(false);
+	const schedule = $derived.by(() => {
+		const played = numberedSessions.filter(({ part }) => partPlayed(part));
+		const ahead = numberedSessions.filter(({ part }) => !partPlayed(part));
+		// A single count drives the whole partition: the hidden rows are the
+		// first `hidden` played ones, the rest render inline. Slicing by that
+		// count keeps played order intact without a membership test.
+		const hidden =
+			played.length < 2
+				? 0
+				: ahead.length > 0
+					? played.length
+					: played.length - 1;
+		return {
+			collapsedCount: hidden,
+			rows: [...(showPlayed ? played : played.slice(hidden)), ...ahead],
+		};
+	});
 
 	// Read view splits the old combined parts block into two stacked panels: the
 	// schedule (per-part times) and casting (per-part casters + stream links).
@@ -1113,7 +1115,7 @@
 			class="flex flex-col gap-2 rounded-lg p-3"
 			style="background-color: rgb(var(--color-surface-raised));"
 		>
-			{#if collapsedSessions.length > 0}
+			{#if schedule.collapsedCount > 0}
 				<button
 					type="button"
 					class="flex items-center gap-1 self-start text-[10px] font-bold uppercase tracking-wider text-muted transition-colors hover:text-tan"
@@ -1121,13 +1123,13 @@
 					aria-expanded={showPlayed}
 				>
 					<span aria-hidden="true">{showPlayed ? "▾" : "▸"}</span>
-					{collapsedSessions.length} played
-					{collapsedSessions.length === 1 ? "session" : "sessions"}
+					{schedule.collapsedCount} played
+					{schedule.collapsedCount === 1 ? "session" : "sessions"}
 				</button>
 			{/if}
-			{#each showPlayed ? [...collapsedSessions, ...scheduleRows] : scheduleRows as { part, partNumber }, i (part.id)}
+			{#each schedule.rows as { part, partNumber }, i (part.id)}
 				<div
-					class="flex items-center gap-2 {i > 0 || collapsedSessions.length > 0
+					class="flex items-center gap-2 {i > 0 || schedule.collapsedCount > 0
 						? 'border-t border-border-subtle pt-2'
 						: ''}"
 				>

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -382,30 +382,29 @@
 			match.status !== "bye" &&
 			(isAdmin || (isParticipant && match.status === "pending")),
 	);
-	// Whether the collapsed played sessions are currently disclosed. Reset per
+	// Whether the collapsed played parts are currently disclosed. Reset per
 	// match by the parent's {#key match.match_id} remount.
 	let showPlayed = $state(false);
-	// Schedule rows, played-last-and-collapsed. A long split match
-	// accumulates played sessions that push the one a viewer actually needs
-	// — the NEXT one — below the popover frame's max-h-[85vh] fold, where on
-	// a short laptop screen it clips around the sixth row and the overlay
-	// scrollbar gives no hint there's more (the report that prompted this was
-	// a match on session seven whose only future time sat off-screen).
-	// Collapsing keeps the panel short at any viewport height. A session
-	// counts as played once partPlayed says so — aged out of LIVE_WINDOW_MS,
-	// the same boundary the live/upcoming surfaces draw — so a session being
-	// streamed right now stays inline, in order, with the upcoming ones.
-	// Played sessions render behind a collapsed "N played sessions" toggle
-	// when there are two or more; with nothing else to show, the most recent
-	// played session stays inline so the panel never opens empty. partPlayed
-	// reads the shared clock, so a session slides into the played group as it
-	// ages out.
-	const numberedSessions = $derived(
+	// Schedule rows, played-last-and-collapsed. A long split match accumulates
+	// played parts that push the one a viewer actually needs — the NEXT one —
+	// below the popover frame's max-h-[85vh] fold, where on a short laptop
+	// screen it clips around the sixth row and the overlay scrollbar gives no
+	// hint there's more (the report that prompted this was a match on part
+	// seven whose only future time sat off-screen). Collapsing keeps the panel
+	// short at any viewport height. A part counts as played once partPlayed
+	// says so — aged out of LIVE_WINDOW_MS, the same boundary the live/upcoming
+	// surfaces draw — so a part being streamed right now stays inline, in
+	// order, with the upcoming ones. Played parts render behind a collapsed
+	// "N played parts" toggle when there are two or more; with nothing else to
+	// show, the most recent played part stays inline so the panel never opens
+	// empty. partPlayed reads the shared clock, so a part slides into the
+	// played group as it ages out.
+	const numberedParts = $derived(
 		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
 	);
 	const schedule = $derived.by(() => {
-		const played = numberedSessions.filter(({ part }) => partPlayed(part));
-		const ahead = numberedSessions.filter(({ part }) => !partPlayed(part));
+		const played = numberedParts.filter(({ part }) => partPlayed(part));
+		const ahead = numberedParts.filter(({ part }) => !partPlayed(part));
 		// A single count drives the whole partition: the hidden rows are the
 		// first `hidden` played ones, the rest render inline. Slicing by that
 		// count keeps played order intact without a membership test.
@@ -425,9 +424,9 @@
 	// schedule (per-part times) and casting (per-part casters + stream links).
 	// castingParts keeps each part's original 1-based number so a split match
 	// labels "Part N" consistently in both panels, and drops parts with no
-	// broadcast info so the casting panel only lists sessions that have some.
+	// broadcast info so the casting panel only lists sittings that have some.
 	const castingParts = $derived(
-		numberedSessions.filter(
+		numberedParts.filter(
 			({ part }) => part.casters.length > 0 || part.streams.length > 0,
 		),
 	);
@@ -1121,10 +1120,25 @@
 					class="flex items-center gap-1 self-start text-[10px] font-bold uppercase tracking-wider text-muted transition-colors hover:text-tan"
 					onclick={() => (showPlayed = !showPlayed)}
 					aria-expanded={showPlayed}
+					aria-label={`${showPlayed ? "Collapse" : "Expand"} played parts`}
 				>
-					<span aria-hidden="true">{showPlayed ? "▾" : "▸"}</span>
-					{schedule.collapsedCount} played
-					{schedule.collapsedCount === 1 ? "session" : "sessions"}
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						class="h-3 w-3 shrink-0 transition-transform"
+						class:rotate-90={showPlayed}
+						viewBox="0 0 20 20"
+						fill="currentColor"
+						aria-hidden="true"
+					>
+						<path
+							fill-rule="evenodd"
+							d="M7.21 14.77a.75.75 0 010-1.06L10.94 10 7.21 6.29a.75.75 0 111.06-1.06l4.25 4.25a.75.75 0 010 1.06l-4.25 4.25a.75.75 0 01-1.06-.02z"
+							clip-rule="evenodd"
+						/>
+					</svg>
+					{schedule.collapsedCount} played part{schedule.collapsedCount === 1
+						? ""
+						: "s"}
 				</button>
 			{/if}
 			{#each schedule.rows as { part, partNumber }, i (part.id)}

--- a/src/lib/tournament/MatchPopover.svelte
+++ b/src/lib/tournament/MatchPopover.svelte
@@ -45,7 +45,7 @@
 		matchSlotSlug,
 		matchSlotUserId,
 	} from "$lib/tournament/match-occupant";
-	import { upcomingScheduledParts } from "$lib/tournament/parts";
+	import { partPlayed, upcomingScheduledParts } from "$lib/tournament/parts";
 	import { seshMatchLine, seshVersus } from "$lib/tournament/sesh";
 	import { mapScriptLabel } from "$lib/tournament/map-scripts";
 	import {
@@ -382,15 +382,52 @@
 			match.status !== "bye" &&
 			(isAdmin || (isParticipant && match.status === "pending")),
 	);
+	// Schedule rows, played-last-and-collapsed. A long split match
+	// accumulates played sessions that push the one a viewer actually needs
+	// — the NEXT one — below the popover frame's max-h-[85vh] fold, where on
+	// a short laptop screen it clips around the sixth row and the overlay
+	// scrollbar gives no hint there's more (the report that prompted this was
+	// a match on session seven whose only future time sat off-screen).
+	// Collapsing keeps the panel short at any viewport height. A session
+	// counts as played once partPlayed says so — aged out of LIVE_WINDOW_MS,
+	// the same boundary the live/upcoming surfaces draw — so a session being
+	// streamed right now stays inline, in order, with the upcoming ones.
+	// Played sessions render behind a collapsed "N played sessions" toggle
+	// when there are two or more; with nothing else to show, the most recent
+	// played session stays inline so the panel never opens empty. partPlayed
+	// reads the shared clock, so a session slides into the played group as it
+	// ages out.
+	const numberedSessions = $derived(
+		match.parts.map((part, i) => ({ part, partNumber: i + 1 })),
+	);
+	const playedSessions = $derived(
+		numberedSessions.filter(({ part }) => partPlayed(part)),
+	);
+	const aheadSessions = $derived(
+		numberedSessions.filter((np) => !playedSessions.includes(np)),
+	);
+	const collapsedSessions = $derived(
+		playedSessions.length >= 2
+			? aheadSessions.length > 0
+				? playedSessions
+				: playedSessions.slice(0, -1)
+			: [],
+	);
+	const scheduleRows = $derived([
+		...playedSessions.filter((np) => !collapsedSessions.includes(np)),
+		...aheadSessions,
+	]);
+	let showPlayed = $state(false);
+
 	// Read view splits the old combined parts block into two stacked panels: the
 	// schedule (per-part times) and casting (per-part casters + stream links).
 	// castingParts keeps each part's original 1-based number so a split match
 	// labels "Part N" consistently in both panels, and drops parts with no
-	// broadcast info so the casting panel only lists sittings that have some.
+	// broadcast info so the casting panel only lists sessions that have some.
 	const castingParts = $derived(
-		match.parts
-			.map((part, i) => ({ part, partNumber: i + 1 }))
-			.filter(({ part }) => part.casters.length > 0 || part.streams.length > 0),
+		numberedSessions.filter(
+			({ part }) => part.casters.length > 0 || part.streams.length > 0,
+		),
 	);
 	const hasSecondaryActions = $derived(
 		canSchedule ||
@@ -1076,16 +1113,28 @@
 			class="flex flex-col gap-2 rounded-lg p-3"
 			style="background-color: rgb(var(--color-surface-raised));"
 		>
-			{#each match.parts as part, i (part.id)}
+			{#if collapsedSessions.length > 0}
+				<button
+					type="button"
+					class="flex items-center gap-1 self-start text-[10px] font-bold uppercase tracking-wider text-muted transition-colors hover:text-tan"
+					onclick={() => (showPlayed = !showPlayed)}
+					aria-expanded={showPlayed}
+				>
+					<span aria-hidden="true">{showPlayed ? "▾" : "▸"}</span>
+					{collapsedSessions.length} played
+					{collapsedSessions.length === 1 ? "session" : "sessions"}
+				</button>
+			{/if}
+			{#each showPlayed ? [...collapsedSessions, ...scheduleRows] : scheduleRows as { part, partNumber }, i (part.id)}
 				<div
-					class="flex items-center gap-2 {i > 0
+					class="flex items-center gap-2 {i > 0 || collapsedSessions.length > 0
 						? 'border-t border-border-subtle pt-2'
 						: ''}"
 				>
 					{#if match.parts.length > 1}
 						<span
 							class="shrink-0 text-[10px] font-bold uppercase tracking-wider text-muted"
-							>Part {i + 1}</span
+							>Part {partNumber}</span
 						>
 					{/if}
 					{#if part.scheduled_at}

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -154,6 +154,18 @@ export const CAST_GRACE_MS = 2 * 60 * 60 * 1000;
 // yet. Bounds how long a finished-but-unreported match can linger as "live".
 export const LIVE_WINDOW_MS = 4 * 60 * 60 * 1000;
 
+// True once a sitting has aged out of LIVE_WINDOW_MS — its broadcast window
+// has closed, so the session was plausibly played to completion. The
+// complement of the live/upcoming windows above, kept beside them so every
+// surface that groups a match's past sessions draws the same boundary.
+// Reactive: reads the shared clock (nowMs), so a session slides into the
+// played group as it ages out.
+export function partPlayed(part: TournamentMatchPart): boolean {
+	if (part.scheduled_at == null) return false;
+	const t = Date.parse(part.scheduled_at);
+	return !Number.isNaN(t) && t <= nowMs() - LIVE_WINDOW_MS;
+}
+
 // Upcoming scheduled parts of still-pending, non-bye matches, soonest first.
 // graceMs keeps a just-started sitting visible (e.g. the cast surfaces pass
 // CAST_GRACE_MS so a match that began 20 minutes ago is still claimable); 0

--- a/src/lib/tournament/parts.ts
+++ b/src/lib/tournament/parts.ts
@@ -15,6 +15,18 @@ export function matchParts(m: TournamentMatch): TournamentMatchPart[] {
 	return m.parts ?? [];
 }
 
+// A part's scheduled instant as epoch ms, or null when it has no usable time.
+// Unscheduled (scheduled_at null) and unparseable collapse to the same answer
+// because no caller distinguishes them — both mean "this part has no time to
+// compare against". The one place that turns the stored string into a number,
+// so the time-window helpers below don't each re-derive it. Note epoch 0 is a
+// valid instant: test the result with `!= null`, never for truthiness.
+export function partInstant(part: TournamentMatchPart): number | null {
+	if (part.scheduled_at == null) return null;
+	const t = Date.parse(part.scheduled_at);
+	return Number.isNaN(t) ? null : t;
+}
+
 // A match's status for display, refining the raw match status with parts info:
 //   completed    — reported or forfeit.
 //   in_progress  — pending, but a scheduled part's time has already passed, so
@@ -56,9 +68,8 @@ export function matchDisplayStatus(
 export function hasStartedPart(m: TournamentMatch): boolean {
 	const now = nowMs();
 	return matchParts(m).some((p) => {
-		if (p.scheduled_at == null) return false;
-		const t = Date.parse(p.scheduled_at);
-		return !Number.isNaN(t) && t <= now;
+		const t = partInstant(p);
+		return t != null && t <= now;
 	});
 }
 
@@ -73,9 +84,8 @@ export function nextScheduledAt(m: TournamentMatch): string | null {
 	let next: string | null = null;
 	let nextT = Infinity;
 	for (const p of matchParts(m)) {
-		if (p.scheduled_at == null) continue;
-		const t = Date.parse(p.scheduled_at);
-		if (Number.isNaN(t) || t < now) continue; // unparseable or already passed
+		const t = partInstant(p);
+		if (t == null || t < now) continue; // no usable time, or already passed
 		if (t < nextT) {
 			nextT = t;
 			next = p.scheduled_at;
@@ -155,15 +165,15 @@ export const CAST_GRACE_MS = 2 * 60 * 60 * 1000;
 export const LIVE_WINDOW_MS = 4 * 60 * 60 * 1000;
 
 // True once a sitting has aged out of LIVE_WINDOW_MS — its broadcast window
-// has closed, so the session was plausibly played to completion. The
-// complement of the live/upcoming windows above, kept beside them so every
-// surface that groups a match's past sessions draws the same boundary.
-// Reactive: reads the shared clock (nowMs), so a session slides into the
-// played group as it ages out.
-export function partPlayed(part: TournamentMatchPart): boolean {
-	if (part.scheduled_at == null) return false;
-	const t = Date.parse(part.scheduled_at);
-	return !Number.isNaN(t) && t <= nowMs() - LIVE_WINDOW_MS;
+// has closed, so the part was plausibly played to completion. The complement
+// of the live/upcoming windows above, kept beside them so every surface that
+// groups a match's past parts draws the same boundary. Defaults to the shared
+// reactive clock (nowMs), so a part slides into the played group as it ages
+// out; callers already threading a `now` (liveAndUpcoming) pass theirs in so
+// every part in one pass is classified against the same instant.
+export function partPlayed(part: TournamentMatchPart, now = nowMs()): boolean {
+	const t = partInstant(part);
+	return t != null && t <= now - LIVE_WINDOW_MS;
 }
 
 // Upcoming scheduled parts of still-pending, non-bye matches, soonest first.
@@ -183,7 +193,7 @@ export function upcomingScheduledParts(
 		(m) => m.status === "pending" && m.slot_b_id != null,
 	);
 	return scheduledParts(pending).filter((np) => {
-		const t = Date.parse(np.part.scheduled_at as string);
-		return !Number.isNaN(t) && t >= cutoff;
+		const t = partInstant(np.part);
+		return t != null && t >= cutoff;
 	});
 }

--- a/src/lib/tournament/schedule.ts
+++ b/src/lib/tournament/schedule.ts
@@ -1,5 +1,10 @@
 import type { TournamentMatch } from "$lib/api-cloud";
-import { scheduledParts, LIVE_WINDOW_MS, type NumberedPart } from "./parts";
+import {
+	scheduledParts,
+	partInstant,
+	partPlayed,
+	type NumberedPart,
+} from "./parts";
 
 export type ScheduleZone = "utc" | "local";
 
@@ -33,10 +38,11 @@ export interface LiveAndUpcoming {
 // `now` is passed in (callers thread the reactive nowMs()) so the result
 // recomputes as the clock advances. A sitting is:
 //   • upcoming — its start is still in the future.
-//   • live     — started within LIVE_WINDOW_MS (plausibly still broadcasting).
-//   • aged out — started longer ago than the window: the game has almost
-//                certainly finished (and its ephemeral `…/live` link died), so
-//                it belongs to neither list and drops off the schedule entirely.
+//   • live     — started within the live window (plausibly still broadcasting).
+//   • aged out — started longer ago than the window, i.e. partPlayed (which
+//                owns that boundary): the game has almost certainly finished
+//                (and its ephemeral `…/live` link died), so it belongs to
+//                neither list and drops off the schedule entirely.
 // Both lists inherit partitionSchedule's soonest-first order.
 export function liveAndUpcoming(
 	matches: TournamentMatch[],
@@ -45,10 +51,10 @@ export function liveAndUpcoming(
 	const live: NumberedPart[] = [];
 	const upcoming: NumberedPart[] = [];
 	for (const np of partitionSchedule(matches).scheduled) {
-		const t = Date.parse(np.part.scheduled_at ?? "");
-		if (Number.isNaN(t)) continue;
+		const t = partInstant(np.part);
+		if (t == null) continue;
 		if (t > now) upcoming.push(np);
-		else if (t > now - LIVE_WINDOW_MS) live.push(np);
+		else if (!partPlayed(np.part, now)) live.push(np);
 	}
 	return { live, upcoming };
 }


### PR DESCRIPTION
Fixes the "a match with more than 6 sessions doesn't show its next time on the card" report (previously mis-chased in #195 — this is the minimal redo).

## The bug

The match popover's schedule panel lists every session in order, and the shared popover frame clamps at `max-h-[85vh]` with `overflow-y-auto`. On a short laptop screen that fold lands right around the sixth row — and since macOS overlay scrollbars are invisible until you scroll, there is no hint that anything sits below it. A split match on session seven looked like it had no upcoming time at all; the only future session was exactly the row below the fold. The bug is viewport-dependent, which is why it reproduced on one machine and not another.

Before (1280×700 viewport, 7-session match — Part 7 clipped at the very bottom edge; a slightly shorter window hides it entirely):

![before](https://raw.githubusercontent.com/alcaras/per-ankh/fd8b0f9d59cfed51a3275c7c17413c34c70d1b95/before-fold-700.png)

## The fix

Played sessions collapse behind a "▸ N played sessions" toggle, so the panel stays short at any viewport height and the schedule leads with what a viewer actually needs — the next (or live) session:

![after](https://raw.githubusercontent.com/alcaras/per-ankh/fd8b0f9d59cfed51a3275c7c17413c34c70d1b95/after-collapse-700.png)

- A session counts as played once it has aged out of `LIVE_WINDOW_MS` — the same boundary `liveAndUpcoming` draws — so a session being streamed right now stays inline, in order, with the upcoming ones.
- The toggle appears only at two or more played sessions; when there is nothing else to show, the most recent played session stays inline so the panel never opens empty.
- Rows keep their original "Part N" numbers (shared `numberedSessions` derived, also reused by the casting panel so both panels number from the same instances).
- Reads the shared `nowMs` clock, so a session slides into the played group as it ages out, live.

One file, UI-only, no data or API changes. `npm run lint`, `svelte-check` (0 errors), prettier all clean.
