### PR TITLE
fix(cloud): per-IP read budgets that survive server-rendered traffic

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -11,7 +11,7 @@ VITE_API_URL=http://localhost:8787/v1
 VITE_PUBLIC_ORIGIN=http://localhost:5173
 
 # Key the SSR fetch presents to the local Worker so it believes the visitor IP
-# and User-Agent we forward (src/hooks.server.ts handleFetch). Not a secret —
+# we forward (src/hooks.server.ts handleFetch). Not a secret —
 # it only has meaning against a Worker configured with the same value, which
 # locally means copying `cloud/.dev.vars.example` to `cloud/.dev.vars`. Without
 # that copy the Worker ignores the headers and logs nothing. Prod/staging use a

--- a/.env.development
+++ b/.env.development
@@ -9,3 +9,11 @@
 
 VITE_API_URL=http://localhost:8787/v1
 VITE_PUBLIC_ORIGIN=http://localhost:5173
+
+# Key the SSR fetch presents to the local Worker so it believes the visitor IP
+# we forward (src/hooks.server.ts handleFetch). Not a secret — it only has
+# meaning against a Worker configured with the same value, which locally means
+# copying `cloud/.dev.vars.example` to `cloud/.dev.vars`. Without that copy the
+# Worker ignores the headers and logs nothing. Prod/staging use a real secret
+# on both Workers.
+SSR_TRUSTED_KEY=dev-ssr-trusted-key

--- a/.env.development
+++ b/.env.development
@@ -11,9 +11,9 @@ VITE_API_URL=http://localhost:8787/v1
 VITE_PUBLIC_ORIGIN=http://localhost:5173
 
 # Key the SSR fetch presents to the local Worker so it believes the visitor IP
-# we forward (src/hooks.server.ts handleFetch). Not a secret — it only has
-# meaning against a Worker configured with the same value, which locally means
-# copying `cloud/.dev.vars.example` to `cloud/.dev.vars`. Without that copy the
-# Worker ignores the headers and logs nothing. Prod/staging use a real secret
-# on both Workers.
+# and User-Agent we forward (src/hooks.server.ts handleFetch). Not a secret —
+# it only has meaning against a Worker configured with the same value, which
+# locally means copying `cloud/.dev.vars.example` to `cloud/.dev.vars`. Without
+# that copy the Worker ignores the headers and logs nothing. Prod/staging use a
+# real secret on both Workers.
 SSR_TRUSTED_KEY=dev-ssr-trusted-key

--- a/cloud/.dev.vars.example
+++ b/cloud/.dev.vars.example
@@ -11,8 +11,8 @@
 # in docs/dev-login.md.
 DEV_LOGIN=1
 
-# Shared key that lets this Worker believe the visitor IP and User-Agent the
-# frontend Worker forwards on server-rendered requests (cloud/src/util.ts
+# Shared key that lets this Worker believe the visitor IP the frontend Worker
+# forwards on server-rendered requests (cloud/src/util.ts
 # adoptTrustedFrontend). The value below matches SSR_TRUSTED_KEY in the
 # committed `.env.development`, so copying this file as-is exercises the same
 # path locally that prod uses; leaving it out just means SSR requests count

--- a/cloud/.dev.vars.example
+++ b/cloud/.dev.vars.example
@@ -11,8 +11,8 @@
 # in docs/dev-login.md.
 DEV_LOGIN=1
 
-# Shared key that lets this Worker believe the visitor IP the frontend Worker
-# forwards on server-rendered requests (cloud/src/util.ts
+# Shared key that lets this Worker believe the visitor IP and User-Agent the
+# frontend Worker forwards on server-rendered requests (cloud/src/util.ts
 # adoptTrustedFrontend). The value below matches SSR_TRUSTED_KEY in the
 # committed `.env.development`, so copying this file as-is exercises the same
 # path locally that prod uses; leaving it out just means SSR requests count

--- a/cloud/.dev.vars.example
+++ b/cloud/.dev.vars.example
@@ -11,6 +11,17 @@
 # in docs/dev-login.md.
 DEV_LOGIN=1
 
+# Shared key that lets this Worker believe the visitor IP the frontend Worker
+# forwards on server-rendered requests (cloud/src/util.ts
+# adoptTrustedFrontend). The value below matches SSR_TRUSTED_KEY in the
+# committed `.env.development`, so copying this file as-is exercises the same
+# path locally that prod uses; leaving it out just means SSR requests count
+# against the dev server's own address, as they did before forwarding existed.
+# In prod/staging it's a real secret, set on BOTH Workers:
+#   npx wrangler secret put SSR_TRUSTED_KEY            (this Worker)
+#   npx wrangler secret put SSR_TRUSTED_KEY --config ../wrangler.toml
+SSR_TRUSTED_KEY=dev-ssr-trusted-key
+
 # Only needed for REAL Discord OAuth locally (skip it if you use DEV_LOGIN
 # above). Get the value from the Discord app at
 # https://discord.com/developers/applications. Real OAuth also requires that app

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -137,6 +137,7 @@ export type RateLimitedEventType =
 	| "anon_read"
 	| "tournament_admin"
 	| "tournament_view"
+	| "tournament_list_view"
 	| "tournament_link_view"
 	| "tournament_create"
 	| "tournament_export"

--- a/cloud/src/games.ts
+++ b/cloud/src/games.ts
@@ -137,6 +137,7 @@ export type RateLimitedEventType =
 	| "anon_read"
 	| "tournament_admin"
 	| "tournament_view"
+	| "tournament_link_view"
 	| "tournament_create"
 	| "tournament_export"
 	| "tournament_schedule"

--- a/cloud/src/index.ts
+++ b/cloud/src/index.ts
@@ -1123,9 +1123,9 @@ export default {
 		return runWithLogContext(request, async () => {
 			// Settle who the caller is before anything reads the request: on an
 			// SSR subrequest that proves it came from our frontend Worker, this
-			// swaps in the visitor's address and User-Agent so every per-IP
-			// counter downstream is keyed on a person rather than on
-			// Cloudflare's SSR egress. See util.ts.
+			// swaps in the visitor's address so every per-IP counter
+			// downstream is keyed on a person rather than on Cloudflare's SSR
+			// egress. See util.ts.
 			//
 			// Inside the log context, because the one line this can emit
 			// (`ssr_forward_rejected`) is what an operator greps during a

--- a/cloud/src/index.ts
+++ b/cloud/src/index.ts
@@ -1120,15 +1120,20 @@ export default {
 		env: RawBindings,
 		ctx: ExecutionContext,
 	): Promise<Response> {
-		// Settle who the caller is before anything reads the request: on an SSR
-		// subrequest that proves it came from our frontend Worker, this swaps in
-		// the visitor's address so every per-IP counter downstream is keyed on a
-		// person rather than on Cloudflare's SSR egress. See util.ts.
-		//
-		// The log context still gets the original — `cf` (colo) lives on the
-		// inbound request object and nothing downstream reads it.
-		const req = adoptTrustedFrontend(request, env);
 		return runWithLogContext(request, async () => {
+			// Settle who the caller is before anything reads the request: on an
+			// SSR subrequest that proves it came from our frontend Worker, this
+			// swaps in the visitor's address and User-Agent so every per-IP
+			// counter downstream is keyed on a person rather than on
+			// Cloudflare's SSR egress. See util.ts.
+			//
+			// Inside the log context, because the one line this can emit
+			// (`ssr_forward_rejected`) is what an operator greps during a
+			// botched key rotation, and outside the context it carries no
+			// request_id or path to join it to anything. The context itself is
+			// still built from the inbound request — `cf` (colo) lives on that
+			// object and doesn't survive the rewrite.
+			const req = adoptTrustedFrontend(request, env);
 			const url = new URL(request.url);
 			let response: Response;
 

--- a/cloud/src/index.ts
+++ b/cloud/src/index.ts
@@ -16,7 +16,12 @@
 // Besides `fetch`, the Worker exports a `scheduled` handler: the nightly
 // events-retention sweep (cron in wrangler.toml, policy in retention.ts).
 
-import { cloudCorsHeaders, legacyCorsHeaders } from "./util";
+import {
+	adoptTrustedFrontend,
+	cloudCorsHeaders,
+	legacyCorsHeaders,
+	type TrustedFrontendEnv,
+} from "./util";
 import { instrumentD1, staleTolerantSession } from "./d1";
 import type { QueryableD1 } from "./d1";
 import {
@@ -144,7 +149,8 @@ interface Env
 		TournamentAdminEnv,
 		ShareLegacyEnv,
 		ChannelsEnv,
-		SecurityEventsEnv {
+		SecurityEventsEnv,
+		TrustedFrontendEnv {
 	SHARE_BUCKET: R2Bucket;
 	SHARE_DB: QueryableD1;
 	EVENTS_DB: D1Database;
@@ -1114,6 +1120,14 @@ export default {
 		env: RawBindings,
 		ctx: ExecutionContext,
 	): Promise<Response> {
+		// Settle who the caller is before anything reads the request: on an SSR
+		// subrequest that proves it came from our frontend Worker, this swaps in
+		// the visitor's address so every per-IP counter downstream is keyed on a
+		// person rather than on Cloudflare's SSR egress. See util.ts.
+		//
+		// The log context still gets the original — `cf` (colo) lives on the
+		// inbound request object and nothing downstream reads it.
+		const req = adoptTrustedFrontend(request, env);
 		return runWithLogContext(request, async () => {
 			const url = new URL(request.url);
 			let response: Response;
@@ -1125,7 +1139,7 @@ export default {
 						: legacyCorsHeaders(env);
 					response = new Response(null, { status: 204, headers });
 				} else {
-					response = await dispatch(request, env, ctx);
+					response = await dispatch(req, env, ctx);
 				}
 			} catch (err) {
 				// Top-level safety net. Any uncaught throw becomes a 500 with
@@ -1158,7 +1172,7 @@ export default {
 			// writes to the dedicated SECURITY_DB via ctx.waitUntil. Fully
 			// wrapped — runs on the safety-net 500 path too, and can never alter
 			// or fail the response above.
-			emitSecurityEvent(request, response, env, ctx);
+			emitSecurityEvent(req, response, env, ctx);
 			return response;
 		});
 	},

--- a/cloud/src/retention.ts
+++ b/cloud/src/retention.ts
@@ -25,6 +25,11 @@ export const RETENTION_BUCKETS: readonly RetentionBucket[] = [
 		types: [
 			"anon_read",
 			"tournament_view",
+			// Tournament list reads (tournament/public.ts): its own budget rather
+			// than tournament_view's, so the home page's tournament strip can't
+			// drain the tournament pages' allowance. Same 1h counter role,
+			// metadata-free.
+			"tournament_list_view",
 			// Game→tournament link reads (tournament/public.ts): its own budget
 			// rather than tournament_view's, so /games/* crawls can't drain the
 			// tournament pages' allowance. Same 1h counter role, metadata-free.

--- a/cloud/src/retention.ts
+++ b/cloud/src/retention.ts
@@ -25,6 +25,10 @@ export const RETENTION_BUCKETS: readonly RetentionBucket[] = [
 		types: [
 			"anon_read",
 			"tournament_view",
+			// Game→tournament link reads (tournament/public.ts): its own budget
+			// rather than tournament_view's, so /games/* crawls can't drain the
+			// tournament pages' allowance. Same 1h counter role, metadata-free.
+			"tournament_link_view",
 			"user_search",
 			// Header people search (users.ts): same counter role as
 			// user_search, its own budget. Metadata is q_length only.

--- a/cloud/src/security-events.ts
+++ b/cloud/src/security-events.ts
@@ -13,6 +13,7 @@
 // fail the response.
 
 import { getLogContext, logError } from "./log";
+import { isTrustedFrontend } from "./util";
 
 export interface SecurityEventsEnv {
 	SECURITY_DB: D1Database;
@@ -179,10 +180,16 @@ export function emitSecurityEvent(
 		);
 		if (!resolved) return;
 
-		// Trust CF-Connecting-IP only when the request traversed the edge
-		// (CF-RAY present) — mirrors getClientIp's distrust rule, but without its
-		// duplicate cf_ray_missing warn since the access log already emitted one.
-		const actorIp = log.cf_ray ? request.headers.get("CF-Connecting-IP") : null;
+		// Trust CF-Connecting-IP when the request traversed the edge (CF-RAY
+		// present) or proved it came from our SSR Worker — mirrors getClientIp's
+		// distrust rule, but without its duplicate cf_ray_missing warn since the
+		// access log already emitted one. On a server-rendered request that
+		// address is the visitor's: adoptTrustedFrontend swapped it in before
+		// dispatch, so a security event names the person and not our egress.
+		const actorIp =
+			log.cf_ray || isTrustedFrontend(request)
+				? request.headers.get("CF-Connecting-IP")
+				: null;
 
 		const meta = resolved.rawPath
 			? JSON.stringify({ raw_path: resolved.rawPath })

--- a/cloud/src/tournament/limits.test.ts
+++ b/cloud/src/tournament/limits.test.ts
@@ -40,6 +40,33 @@ describe("tournamentViewPerHour", () => {
 		);
 	});
 
+	it("falls back below one whole read, which refuses as surely as 0", () => {
+		// The gate is `count >= limit`, so a slipped decimal point is the same
+		// outage as a fat-fingered 0 — 0.5 refuses everything after the first
+		// read, .5 and 1e-3 refuse from the first.
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "0.5" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: ".5" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "1e-3" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+	});
+
+	it("falls back on a fractional ceiling rather than rounding one", () => {
+		// 1.5 is 2 to the gate and 1.5 to whoever reads the var back. An
+		// operator retuning mid-event should see the number they set take
+		// effect or not at all.
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "1.5" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "750.5" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+	});
+
 	it("falls back on a value that only half-parses", () => {
 		// parseInt("600 per hour") is 600 — a mangled value would pass as a
 		// deliberate one. Number() rejects the whole string.

--- a/cloud/src/tournament/limits.test.ts
+++ b/cloud/src/tournament/limits.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { TOURNAMENT_VIEW_PER_HOUR, tournamentViewPerHour } from "./limits";
+import {
+	TOURNAMENT_LINK_VIEW_PER_HOUR,
+	TOURNAMENT_VIEW_PER_HOUR,
+	tournamentLinkViewPerHour,
+	tournamentViewPerHour,
+} from "./limits";
 
-// The tournament view ceiling is read off env so an operator can retune it
-// mid-event (`wrangler secret put TOURNAMENT_VIEW_PER_HOUR`) without a
+// Both read ceilings are read off env so an operator can retune one mid-event
+// (`wrangler secret put TOURNAMENT_VIEW_PER_HOUR`) without a
 // redeploy. Every way that var can be wrong resolves to the constant, because
 // the failure mode this knob exists to shorten is the tournament pages being
 // down — a value that parses to 0 or NaN must not be the thing that keeps them
@@ -47,5 +52,38 @@ describe("tournamentViewPerHour", () => {
 		expect(
 			tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "Infinity" }),
 		).toBe(TOURNAMENT_VIEW_PER_HOUR);
+	});
+});
+
+// The link ceiling shares the parse rules above (one helper, so they can't
+// drift). What's worth pinning here is the wiring: that it reads its *own*
+// var and falls back to its own constant, since the whole point of the split
+// is that the two budgets move independently.
+describe("tournamentLinkViewPerHour", () => {
+	it("uses a parseable positive value", () => {
+		expect(
+			tournamentLinkViewPerHour({ TOURNAMENT_LINK_VIEW_PER_HOUR: "50" }),
+		).toBe(50);
+	});
+
+	it("falls back to the constant when the var is absent or unparseable", () => {
+		expect(tournamentLinkViewPerHour({})).toBe(TOURNAMENT_LINK_VIEW_PER_HOUR);
+		expect(
+			tournamentLinkViewPerHour({ TOURNAMENT_LINK_VIEW_PER_HOUR: "0" }),
+		).toBe(TOURNAMENT_LINK_VIEW_PER_HOUR);
+		expect(
+			tournamentLinkViewPerHour({
+				TOURNAMENT_LINK_VIEW_PER_HOUR: "600 per hour",
+			}),
+		).toBe(TOURNAMENT_LINK_VIEW_PER_HOUR);
+	});
+
+	it("ignores the view var — the two knobs are independent", () => {
+		const env = {
+			TOURNAMENT_VIEW_PER_HOUR: "5",
+			TOURNAMENT_LINK_VIEW_PER_HOUR: "50",
+		};
+		expect(tournamentLinkViewPerHour(env)).toBe(50);
+		expect(tournamentViewPerHour(env)).toBe(5);
 	});
 });

--- a/cloud/src/tournament/limits.test.ts
+++ b/cloud/src/tournament/limits.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { TOURNAMENT_VIEW_PER_HOUR, tournamentViewPerHour } from "./limits";
+
+// The tournament view ceiling is read off env so an operator can retune it
+// mid-event (`wrangler secret put TOURNAMENT_VIEW_PER_HOUR`) without a
+// redeploy. Every way that var can be wrong resolves to the constant, because
+// the failure mode this knob exists to shorten is the tournament pages being
+// down — a value that parses to 0 or NaN must not be the thing that keeps them
+// there. The gate's end of the wiring is pinned in
+// test/integration/tournament/rate-limit-view.test.ts.
+describe("tournamentViewPerHour", () => {
+	it("uses a parseable positive value", () => {
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "50" })).toBe(50);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "5000" })).toBe(
+			5000,
+		);
+	});
+
+	it("falls back to the constant when the var is absent or blank", () => {
+		expect(tournamentViewPerHour({})).toBe(TOURNAMENT_VIEW_PER_HOUR);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "   " })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+	});
+
+	it("falls back on a non-positive value rather than refusing every read", () => {
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "0" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "-1" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+	});
+
+	it("falls back on a value that only half-parses", () => {
+		// parseInt("600 per hour") is 600 — a mangled value would pass as a
+		// deliberate one. Number() rejects the whole string.
+		expect(
+			tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "600 per hour" }),
+		).toBe(TOURNAMENT_VIEW_PER_HOUR);
+		expect(tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "six" })).toBe(
+			TOURNAMENT_VIEW_PER_HOUR,
+		);
+		expect(
+			tournamentViewPerHour({ TOURNAMENT_VIEW_PER_HOUR: "Infinity" }),
+		).toBe(TOURNAMENT_VIEW_PER_HOUR);
+	});
+});

--- a/cloud/src/tournament/limits.ts
+++ b/cloud/src/tournament/limits.ts
@@ -1,8 +1,18 @@
-// Tournament rate-limit ceilings. Hardcoded, except the two per-IP read
-// ceilings (tournamentViewPerHour / tournamentLinkViewPerHour below) — the
-// "operators need to retune during a live event" case this file anticipated
-// actually happened, so those are wrangler vars with the constants as their
-// defaults.
+// Tournament rate-limit ceilings. Hardcoded, except the three per-IP read
+// ceilings (tournamentViewPerHour / tournamentListViewPerHour /
+// tournamentLinkViewPerHour below) — the "operators need to retune during a
+// live event" case this file anticipated actually happened, so those are
+// wrangler vars with the constants as their defaults.
+//
+// Those three are separate budgets because they are drawn on by three
+// different populations. A shared budget means the busiest surface decides
+// when the others start refusing, and the surface with the most traffic is
+// never the one you meant to protect: /games/* crawling took the tournament
+// pages down on 2026-08-05, and the home page's tournament strip is a larger
+// caller than /tournaments itself. When adding a public read, give it the
+// budget of the page it is fetched by, not of the feature it belongs to.
+
+import { logWarn } from "../log";
 
 // Per-user admin mutation budget. Spec said 30/hour/tournament; we
 // simplified to per-user because the threat model (stolen admin
@@ -16,14 +26,33 @@ export const TOURNAMENT_ADMIN_ACTIONS_PER_HOUR = 30;
 // handful of edits per match per player.
 export const TOURNAMENT_SCHEDULE_ACTIONS_PER_HOUR = 60;
 
-// Per-IP budget for anonymous tournament reads (list/detail/standings/
-// bracket/rounds/matches/match-detail). Scraper User-Agents bypass.
+// Per-IP budget for the tournament page reads: detail, standings, bracket,
+// rounds, matches, match detail, both stats endpoints, and the profile
+// Tournaments tab. Scraper User-Agents bypass.
+//
+// Counted in *reads*, and every read charges — there is no cheaper class of
+// read and no caller who pays less (see enforceReadRateLimit). A cold
+// /tournaments/[slug] makes four; the stats page makes six. So this number is
+// roughly 600 tournament page loads an hour, or 400 of the stats page, and it
+// means the same thing whether the visitor arrived by a server-rendered load
+// or by clicking through a hydrated one.
+//
+// 2400 rather than the 600 it was through #196: at 600 reads a visitor met the
+// ceiling after ~150 page loads, which is reachable by browsing and is the
+// reason the number needed rethinking at all. The alternative was to charge a
+// page load once and let its sub-resources ride along free on our own SSR
+// Worker — same headroom, but the ceiling then meant reads to one caller and
+// page loads to another, and the rate limiter had to know who was asking.
+// Multiplying the number gets the headroom without either.
+//
+// Deliberately *not* the tournament list read — see
+// TOURNAMENT_LIST_VIEW_PER_HOUR.
 //
 // The default only — read the effective ceiling with tournamentViewPerHour().
-export const TOURNAMENT_VIEW_PER_HOUR = 600;
+export const TOURNAMENT_VIEW_PER_HOUR = 2400;
 
 // A ceiling read off an env var, falling back to the compiled-in default.
-// Shared by both read budgets so the two can't drift in how they parse.
+// Shared by all three read budgets so they can't drift in how they parse.
 //
 // Number(), not parseInt(): parseInt("600 per hour") is 600, which would let a
 // mangled value silently pass as a deliberate one. Anything below one whole
@@ -33,9 +62,26 @@ export const TOURNAMENT_VIEW_PER_HOUR = 600;
 // `count >= limit`, so 0.5 refuses every read after the first exactly as 0
 // refuses every read at all. Integers only, for the same reason — a ceiling of
 // 1.5 is 2 to the gate and 1.5 to whoever reads it back.
-function ceilingFrom(raw: string | undefined, fallback: number): number {
+//
+// Discarding a value is logged, once per isolate per var. Falling back is the
+// safe behaviour, but doing it silently means an operator who mistypes a
+// ceiling mid-incident sees the deploy succeed, the traffic unchanged, and no
+// reason why — and the value they most plausibly reach for under load, 0, is
+// one of the discarded ones. `name` is only carried for this line.
+const unparseableLogged = new Set<string>();
+
+function ceilingFrom(
+	raw: string | undefined,
+	fallback: number,
+	name: string,
+): number {
 	const parsed = Number(raw);
-	return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
+	if (Number.isInteger(parsed) && parsed >= 1) return parsed;
+	if (raw !== undefined && !unparseableLogged.has(name)) {
+		unparseableLogged.add(name);
+		logWarn("read_ceiling_unparseable", { var: name, value: raw, fallback });
+	}
+	return fallback;
 }
 
 // Effective per-IP tournament view ceiling: the TOURNAMENT_VIEW_PER_HOUR var
@@ -49,7 +95,44 @@ function ceilingFrom(raw: string | undefined, fallback: number): number {
 export function tournamentViewPerHour(env: {
 	TOURNAMENT_VIEW_PER_HOUR?: string;
 }): number {
-	return ceilingFrom(env.TOURNAMENT_VIEW_PER_HOUR, TOURNAMENT_VIEW_PER_HOUR);
+	return ceilingFrom(
+		env.TOURNAMENT_VIEW_PER_HOUR,
+		TOURNAMENT_VIEW_PER_HOUR,
+		"TOURNAMENT_VIEW_PER_HOUR",
+	);
+}
+
+// Per-IP budget for the tournament list read (GET /v1/tournaments). Its own
+// budget, deliberately not the tournament pages' one: the list is fetched by
+// the home page on every render (src/routes/+page.ts) as well as by
+// /tournaments, and the home page is the busiest surface on the site. Sharing
+// means ordinary landing-page traffic decides when /tournaments/[slug] starts
+// refusing — the same coupling that took the tournament pages down on
+// 2026-08-05 with /games/* as the busy surface instead.
+//
+// Not folded into anon_read either, for the reason the link read isn't: the
+// home page calls both, so sharing would spend one visitor's landing-page
+// budget twice over.
+//
+// Stays at 600 where the view ceiling is 2400, because the arithmetic differs,
+// not the generosity: this is one read per page load, so 600 is 600 loads —
+// the same headroom the view budget needs four reads each to reach.
+//
+// The default only — read the effective ceiling with tournamentListViewPerHour().
+export const TOURNAMENT_LIST_VIEW_PER_HOUR = 600;
+
+// Effective per-IP list ceiling, on the same lever as the other two. This is
+// the one whose exhaustion is most visible to an ordinary visitor — it empties
+// the home page's tournament strip — so it is also the one most likely to want
+// moving mid-event.
+export function tournamentListViewPerHour(env: {
+	TOURNAMENT_LIST_VIEW_PER_HOUR?: string;
+}): number {
+	return ceilingFrom(
+		env.TOURNAMENT_LIST_VIEW_PER_HOUR,
+		TOURNAMENT_LIST_VIEW_PER_HOUR,
+		"TOURNAMENT_LIST_VIEW_PER_HOUR",
+	);
 }
 
 // Per-IP budget for the game→tournament link read
@@ -80,6 +163,7 @@ export function tournamentLinkViewPerHour(env: {
 	return ceilingFrom(
 		env.TOURNAMENT_LINK_VIEW_PER_HOUR,
 		TOURNAMENT_LINK_VIEW_PER_HOUR,
+		"TOURNAMENT_LINK_VIEW_PER_HOUR",
 	);
 }
 

--- a/cloud/src/tournament/limits.ts
+++ b/cloud/src/tournament/limits.ts
@@ -1,7 +1,8 @@
-// Tournament rate-limit ceilings. Hardcoded, except the per-IP view ceiling
-// (see tournamentViewPerHour below) — the "operators need to retune during a
-// live event" case this file anticipated actually happened, so that one is now
-// a wrangler var with the constant as its default.
+// Tournament rate-limit ceilings. Hardcoded, except the two per-IP read
+// ceilings (tournamentViewPerHour / tournamentLinkViewPerHour below) — the
+// "operators need to retune during a live event" case this file anticipated
+// actually happened, so those are wrangler vars with the constants as their
+// defaults.
 
 // Per-user admin mutation budget. Spec said 30/hour/tournament; we
 // simplified to per-user because the threat model (stolen admin
@@ -21,27 +22,31 @@ export const TOURNAMENT_SCHEDULE_ACTIONS_PER_HOUR = 60;
 // The default only — read the effective ceiling with tournamentViewPerHour().
 export const TOURNAMENT_VIEW_PER_HOUR = 600;
 
-// Effective per-IP tournament view ceiling: the TOURNAMENT_VIEW_PER_HOUR var
-// when it parses, the constant above otherwise.
-//
-// The var exists so an operator can retune mid-event without a redeploy —
-// `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR` shadows the wrangler.toml
-// value and takes effect immediately, the same lever UPLOADS_ENABLED
-// documents. Unset behaves exactly as the constant did when it was the only
-// source.
+// A ceiling read off an env var, falling back to the compiled-in default.
+// Shared by both read budgets so the two can't drift in how they parse.
 //
 // Number(), not parseInt(): parseInt("600 per hour") is 600, which would let a
 // mangled value silently pass as a deliberate one. Non-positive is treated as
 // unset rather than "refuse everything" — a fat-fingered 0 during an incident
-// would 429 the whole tournament surface, which is the outage this knob exists
-// to shorten.
+// would 429 the whole surface, which is the outage these knobs exist to
+// shorten.
+function ceilingFrom(raw: string | undefined, fallback: number): number {
+	const parsed = Number(raw);
+	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// Effective per-IP tournament view ceiling: the TOURNAMENT_VIEW_PER_HOUR var
+// when it parses, the constant above otherwise.
+//
+// The var exists so an operator can retune mid-event without a redeploy —
+// `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR` takes effect immediately,
+// the same lever UPLOADS_ENABLED documents. It lasts until the next deploy,
+// which puts the wrangler.toml value back — the caveat is on the vars there.
+// Unset behaves exactly as the constant did when it was the only source.
 export function tournamentViewPerHour(env: {
 	TOURNAMENT_VIEW_PER_HOUR?: string;
 }): number {
-	const parsed = Number(env.TOURNAMENT_VIEW_PER_HOUR);
-	return Number.isFinite(parsed) && parsed > 0
-		? parsed
-		: TOURNAMENT_VIEW_PER_HOUR;
+	return ceilingFrom(env.TOURNAMENT_VIEW_PER_HOUR, TOURNAMENT_VIEW_PER_HOUR);
 }
 
 // Per-IP budget for the game→tournament link read
@@ -56,7 +61,24 @@ export function tournamentViewPerHour(env: {
 // it is a backstop on an endpoint that would otherwise be unmetered, not a
 // constraint on browsing. When it does fire, the game page's loader already
 // swallows the failure and hides the tournament banner.
+//
+// The default only — read the effective ceiling with tournamentLinkViewPerHour().
 export const TOURNAMENT_LINK_VIEW_PER_HOUR = 600;
+
+// Effective per-IP link ceiling, tunable on the same lever as the view one
+// above. Splitting the budgets is what keeps a game-page crawl off the
+// tournament pages; it doesn't stop the crawl from draining *this* budget, and
+// then every server-rendered game page loses its tournament banner until the
+// hour rolls. That's the case where an operator wants this number moved, and
+// it's the same incident — so the knob has to be here too, not a redeploy away.
+export function tournamentLinkViewPerHour(env: {
+	TOURNAMENT_LINK_VIEW_PER_HOUR?: string;
+}): number {
+	return ceilingFrom(
+		env.TOURNAMENT_LINK_VIEW_PER_HOUR,
+		TOURNAMENT_LINK_VIEW_PER_HOUR,
+	);
+}
 
 // Per-user budget for tournament creation. Tighter than admin mutations:
 // creating a tournament adds rows + an admin row + squats a slug, and

--- a/cloud/src/tournament/limits.ts
+++ b/cloud/src/tournament/limits.ts
@@ -1,5 +1,7 @@
-// Tournament rate-limit ceilings. Hardcoded for v1 — promote to
-// wrangler.toml vars if operators need to retune during a live event.
+// Tournament rate-limit ceilings. Hardcoded, except the per-IP view ceiling
+// (see tournamentViewPerHour below) — the "operators need to retune during a
+// live event" case this file anticipated actually happened, so that one is now
+// a wrangler var with the constant as its default.
 
 // Per-user admin mutation budget. Spec said 30/hour/tournament; we
 // simplified to per-user because the threat model (stolen admin
@@ -14,9 +16,47 @@ export const TOURNAMENT_ADMIN_ACTIONS_PER_HOUR = 30;
 export const TOURNAMENT_SCHEDULE_ACTIONS_PER_HOUR = 60;
 
 // Per-IP budget for anonymous tournament reads (list/detail/standings/
-// bracket/rounds/matches/match-detail + game tournament-link). Scraper
-// User-Agents bypass.
+// bracket/rounds/matches/match-detail). Scraper User-Agents bypass.
+//
+// The default only — read the effective ceiling with tournamentViewPerHour().
 export const TOURNAMENT_VIEW_PER_HOUR = 600;
+
+// Effective per-IP tournament view ceiling: the TOURNAMENT_VIEW_PER_HOUR var
+// when it parses, the constant above otherwise.
+//
+// The var exists so an operator can retune mid-event without a redeploy —
+// `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR` shadows the wrangler.toml
+// value and takes effect immediately, the same lever UPLOADS_ENABLED
+// documents. Unset behaves exactly as the constant did when it was the only
+// source.
+//
+// Number(), not parseInt(): parseInt("600 per hour") is 600, which would let a
+// mangled value silently pass as a deliberate one. Non-positive is treated as
+// unset rather than "refuse everything" — a fat-fingered 0 during an incident
+// would 429 the whole tournament surface, which is the outage this knob exists
+// to shorten.
+export function tournamentViewPerHour(env: {
+	TOURNAMENT_VIEW_PER_HOUR?: string;
+}): number {
+	const parsed = Number(env.TOURNAMENT_VIEW_PER_HOUR);
+	return Number.isFinite(parsed) && parsed > 0
+		? parsed
+		: TOURNAMENT_VIEW_PER_HOUR;
+}
+
+// Per-IP budget for the game→tournament link read
+// (GET /v1/games/:id/tournament-link). Its own budget, deliberately not the
+// tournament one: every /games/[id] render calls it whether or not the game is
+// linked, so on the tournament budget a crawl of game pages spends the
+// tournament pages' allowance and takes /tournaments/* down with it — which is
+// exactly what happened on 2026-08-05.
+//
+// Set above ANON_READS_PER_HOUR (200, the anonymous ceiling on the game read
+// this one accompanies) so it is never the limit a real visitor meets first;
+// it is a backstop on an endpoint that would otherwise be unmetered, not a
+// constraint on browsing. When it does fire, the game page's loader already
+// swallows the failure and hides the tournament banner.
+export const TOURNAMENT_LINK_VIEW_PER_HOUR = 600;
 
 // Per-user budget for tournament creation. Tighter than admin mutations:
 // creating a tournament adds rows + an admin row + squats a slug, and

--- a/cloud/src/tournament/limits.ts
+++ b/cloud/src/tournament/limits.ts
@@ -26,13 +26,16 @@ export const TOURNAMENT_VIEW_PER_HOUR = 600;
 // Shared by both read budgets so the two can't drift in how they parse.
 //
 // Number(), not parseInt(): parseInt("600 per hour") is 600, which would let a
-// mangled value silently pass as a deliberate one. Non-positive is treated as
-// unset rather than "refuse everything" — a fat-fingered 0 during an incident
-// would 429 the whole surface, which is the outage these knobs exist to
-// shorten.
+// mangled value silently pass as a deliberate one. Anything below one whole
+// read is treated as unset rather than "refuse everything" — a fat-fingered 0
+// during an incident would 429 the whole surface, which is the outage these
+// knobs exist to shorten, and so would a slipped decimal point: the gate is
+// `count >= limit`, so 0.5 refuses every read after the first exactly as 0
+// refuses every read at all. Integers only, for the same reason — a ceiling of
+// 1.5 is 2 to the gate and 1.5 to whoever reads it back.
 function ceilingFrom(raw: string | undefined, fallback: number): number {
 	const parsed = Number(raw);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+	return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
 }
 
 // Effective per-IP tournament view ceiling: the TOURNAMENT_VIEW_PER_HOUR var

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -150,7 +150,10 @@ async function enforceReadRateLimit(
 		.bind(ip)
 		.run()
 		.catch((e: unknown) => {
-			logError(`${budget.eventType}_audit_failed`, e, { ip });
+			logError("audit_event_log_failed", e, {
+				event_type: budget.eventType,
+				ip,
+			});
 		});
 	return null;
 }

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -125,6 +125,12 @@ const LINK_BUDGET: ReadBudget = {
 // caller we can be sure fetched the entry read first. Anyone calling
 // /standings directly is charged for it, so no path here is free — see
 // isTrustedFrontend in util.ts for how that's established.
+//
+// What the ceiling therefore bounds on server-rendered traffic is page loads,
+// not backend reads: 600 loads of the stats page is ~3,600 reads behind it.
+// That is the intended reading of the number — an operator retuning it
+// mid-event is deciding how many times a visitor may load a page — and it's
+// why the two figures are stated separately in docs/api-reference.md.
 type ReadRole = "entry" | "rider";
 
 // Per-IP rate limit on a public read. Scraper User-Agents (Discord/Slack/
@@ -132,9 +138,14 @@ type ReadRole = "entry" | "rider";
 // fan out load that's not meaningful to count. Applies to everyone else,
 // including signed-in users.
 //
-// Every read is *gated*, riders included: the ceiling is what an over-budget
-// IP meets, and it has to answer the same way whichever read of the page it
-// hits first. Only the charging differs.
+// A rider on a trusted page load skips both, and skips them before the count:
+// the entry read of that same render already gated this IP and charged it
+// milliseconds ago, so counting again is a cross-region COUNT(*) per
+// sub-resource — three on a tournament page, five on the stats page — for a
+// verdict that is already known. An over-budget visitor still meets the
+// ceiling on the entry read, which is the one the page cannot render without,
+// so what it sees is unchanged. Every other caller — a hydrated navigation,
+// anything hitting the API by hand — is gated and charged per read.
 //
 // `eventType` is interpolated into the INSERT rather than bound: event_type
 // is part of the statement's structure, not a value. The literal union closes
@@ -149,6 +160,7 @@ async function enforceReadRateLimit(
 ): Promise<Response | null> {
 	const ua = request.headers.get("User-Agent");
 	if (isScraperUA(ua)) return null;
+	if (role === "rider" && isTrustedFrontend(request)) return null;
 	const ip = getClientIp(request) ?? "untrusted";
 	const count = await countEventsSince(
 		env.EVENTS_DB,
@@ -159,7 +171,6 @@ async function enforceReadRateLimit(
 	if (count >= limit) {
 		return errorResponse(budget.message, 429, cors, budget.code);
 	}
-	if (role === "rider" && isTrustedFrontend(request)) return null;
 	env.EVENTS_DB.prepare(
 		`INSERT INTO events (event_type, ip_address)
 		 VALUES ('${budget.eventType}', ?)`,

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -14,6 +14,7 @@ import {
 	cloudCorsHeaders,
 	errorResponse,
 	getClientIp,
+	isTrustedFrontend,
 	jsonResponse,
 } from "../util";
 import { countEventsSince, isScraperUA } from "../games";
@@ -82,8 +83,8 @@ export interface TournamentPublicEnv
 	// tournamentLinkViewPerHour). Vars rather than bare consts so either can be
 	// retuned mid-event without a redeploy.
 	TOURNAMENT_VIEW_PER_HOUR?: string;
-	// Optional YouTube Data API key. When set, the Videos tab enumerates the
 	TOURNAMENT_LINK_VIEW_PER_HOUR?: string;
+	// Optional YouTube Data API key. When set, the Videos tab enumerates the
 	// whole playlist (so its search can reach every video); when unset, it falls
 	// back to the free RSS feed's most-recent entries. Same secret the channel
 	// resolver uses.
@@ -113,14 +114,27 @@ const LINK_BUDGET: ReadBudget = {
 	code: "RATE_LIMIT_TOURNAMENT_LINK",
 };
 
+// What a read is to the page it belongs to. One tournament page load makes
+// four of these calls — the tournament itself, then standings, bracket and
+// matches — and the visitor did one thing, so it should cost one slot, not
+// four. "entry" is the read a page load starts with and the one that charges;
+// "rider" is a sub-resource that only ever follows an entry read in the same
+// render (everything behind loadViewableTournament).
+//
+// The distinction is only honoured for our own SSR Worker, which is the one
+// caller we can be sure fetched the entry read first. Anyone calling
+// /standings directly is charged for it, so no path here is free — see
+// isTrustedFrontend in util.ts for how that's established.
+type ReadRole = "entry" | "rider";
+
 // Per-IP rate limit on a public read. Scraper User-Agents (Discord/Slack/
 // Twitter link previews) bypass both the gate and the audit-log insert — they
 // fan out load that's not meaningful to count. Applies to everyone else,
 // including signed-in users.
 //
-// Both budgets record every read they gate, so neither is a no-op on its own
-// path; keeping the count and the INSERT in one helper is what keeps that
-// true as budgets are added.
+// Every read is *gated*, riders included: the ceiling is what an over-budget
+// IP meets, and it has to answer the same way whichever read of the page it
+// hits first. Only the charging differs.
 //
 // `eventType` is interpolated into the INSERT rather than bound: event_type
 // is part of the statement's structure, not a value. The literal union closes
@@ -131,6 +145,7 @@ async function enforceReadRateLimit(
 	cors: Record<string, string>,
 	budget: ReadBudget,
 	limit: number,
+	role: ReadRole,
 ): Promise<Response | null> {
 	const ua = request.headers.get("User-Agent");
 	if (isScraperUA(ua)) return null;
@@ -144,6 +159,7 @@ async function enforceReadRateLimit(
 	if (count >= limit) {
 		return errorResponse(budget.message, 429, cors, budget.code);
 	}
+	if (role === "rider" && isTrustedFrontend(request)) return null;
 	env.EVENTS_DB.prepare(
 		`INSERT INTO events (event_type, ip_address)
 		 VALUES ('${budget.eventType}', ?)`,
@@ -160,12 +176,14 @@ async function enforceReadRateLimit(
 }
 
 // The tournament pages' budget: list/detail/standings/bracket/rounds/matches/
-// match-detail and both stats reads. Generous enough that no real UI traffic
-// should hit it, and retunable mid-event via the env var.
+// match-detail and both stats reads. Retunable mid-event via the env var, and
+// spent once per server-rendered page load rather than once per read — see
+// ReadRole for which call sites pass which.
 function enforceTournamentViewRateLimit(
 	env: TournamentPublicEnv,
 	request: Request,
 	cors: Record<string, string>,
+	role: ReadRole,
 ): Promise<Response | null> {
 	return enforceReadRateLimit(
 		env,
@@ -173,6 +191,7 @@ function enforceTournamentViewRateLimit(
 		cors,
 		VIEW_BUDGET,
 		tournamentViewPerHour(env),
+		role,
 	);
 }
 
@@ -185,12 +204,15 @@ function enforceTournamentLinkRateLimit(
 	request: Request,
 	cors: Record<string, string>,
 ): Promise<Response | null> {
+	// Always an entry read: the game page fetches it on its own, with no
+	// tournament read ahead of it to have paid.
 	return enforceReadRateLimit(
 		env,
 		request,
 		cors,
 		LINK_BUDGET,
 		tournamentLinkViewPerHour(env),
+		"entry",
 	);
 }
 
@@ -216,7 +238,7 @@ export async function handleTournamentList(
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
 	const session = await sessionFromRequest(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors);
+	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
 	if (rl) return rl;
 	const url = new URL(request.url);
 	const status = url.searchParams.get("status");
@@ -475,7 +497,7 @@ export async function handleTournamentDetail(
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
 	const session = await sessionFromRequest(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors);
+	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
 	if (rl) return rl;
 	const tournament = await loadTournamentBySlug(env, slug);
 	if (!tournament) {
@@ -970,6 +992,13 @@ async function setupGateHides(
 // public-read gating (visibility rule, 404 shape, rate limit) lands here once
 // and covers standings, bracket, rounds, matches, match detail, and both stats
 // endpoints alike.
+//
+// Every read behind this preamble is a "rider": each one is reached from a
+// page whose entry read (the tournament detail, or the list) already charged
+// the budget in the same render. That's what makes a page load cost one slot
+// instead of four — and it holds because this is the only way to these
+// endpoints. A handler that charges its own entry read must not be routed
+// through here.
 async function loadViewableTournament(
 	env: TournamentPublicEnv,
 	request: Request,
@@ -977,7 +1006,7 @@ async function loadViewableTournament(
 	cors: Record<string, string>,
 	session: { token: string; data: SessionData } | null,
 ): Promise<TournamentRow | Response> {
-	const rl = await enforceTournamentViewRateLimit(env, request, cors);
+	const rl = await enforceTournamentViewRateLimit(env, request, cors, "rider");
 	if (rl) return rl;
 	const tournament = await loadTournamentById(env, tournamentId);
 	if (!tournament || (await setupGateHides(env, session, tournament))) {
@@ -1685,7 +1714,10 @@ export async function handleUserTournaments(
 	env: TournamentPublicEnv,
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors);
+	// An entry read despite being a sub-resource: the profile page's Tournaments
+	// tab fetches this on its own, with no tournament read ahead of it. Making
+	// it a rider would leave a crawl of /u/*?tab=tournaments unmetered.
+	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
 	if (rl) return rl;
 	const session = await sessionFromRequest(env, request);
 

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -44,7 +44,7 @@ import {
 	type TournamentEnv,
 	type TournamentRow,
 } from "./data";
-import { TOURNAMENT_LINK_VIEW_PER_HOUR, tournamentViewPerHour } from "./limits";
+import { tournamentLinkViewPerHour, tournamentViewPerHour } from "./limits";
 import {
 	computeStandings,
 	rankStandings,
@@ -77,12 +77,13 @@ import type { EventsEnv } from "../d1";
 export interface TournamentPublicEnv
 	extends TournamentEnv, SessionEnv, EventsEnv {
 	ALLOWED_ORIGINS: string;
-	// Per-IP hourly ceiling on tournament reads. Optional: unset falls back to
-	// the TOURNAMENT_VIEW_PER_HOUR constant (see tournamentViewPerHour). A var
-	// rather than a bare const so it can be retuned mid-event without a
-	// redeploy.
+	// Per-IP hourly ceilings on the two read budgets. Optional: unset falls back
+	// to the constant of the same name (see tournamentViewPerHour /
+	// tournamentLinkViewPerHour). Vars rather than bare consts so either can be
+	// retuned mid-event without a redeploy.
 	TOURNAMENT_VIEW_PER_HOUR?: string;
 	// Optional YouTube Data API key. When set, the Videos tab enumerates the
+	TOURNAMENT_LINK_VIEW_PER_HOUR?: string;
 	// whole playlist (so its search can reach every video); when unset, it falls
 	// back to the free RSS feed's most-recent entries. Same secret the channel
 	// resolver uses.
@@ -177,7 +178,8 @@ function enforceTournamentViewRateLimit(
 
 // The game→tournament link read's own budget. Separate from the one above
 // because /games/[id] traffic is a different population from /tournaments/*
-// traffic — see TOURNAMENT_LINK_VIEW_PER_HOUR.
+// traffic — see TOURNAMENT_LINK_VIEW_PER_HOUR. Retunable mid-event via its own
+// env var, on the same lever as the view ceiling.
 function enforceTournamentLinkRateLimit(
 	env: TournamentPublicEnv,
 	request: Request,
@@ -188,7 +190,7 @@ function enforceTournamentLinkRateLimit(
 		request,
 		cors,
 		LINK_BUDGET,
-		TOURNAMENT_LINK_VIEW_PER_HOUR,
+		tournamentLinkViewPerHour(env),
 	);
 }
 

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -44,7 +44,7 @@ import {
 	type TournamentEnv,
 	type TournamentRow,
 } from "./data";
-import { TOURNAMENT_VIEW_PER_HOUR } from "./limits";
+import { TOURNAMENT_LINK_VIEW_PER_HOUR, tournamentViewPerHour } from "./limits";
 import {
 	computeStandings,
 	rankStandings,
@@ -77,6 +77,11 @@ import type { EventsEnv } from "../d1";
 export interface TournamentPublicEnv
 	extends TournamentEnv, SessionEnv, EventsEnv {
 	ALLOWED_ORIGINS: string;
+	// Per-IP hourly ceiling on tournament reads. Optional: unset falls back to
+	// the TOURNAMENT_VIEW_PER_HOUR constant (see tournamentViewPerHour). A var
+	// rather than a bare const so it can be retuned mid-event without a
+	// redeploy.
+	TOURNAMENT_VIEW_PER_HOUR?: string;
 	// Optional YouTube Data API key. When set, the Videos tab enumerates the
 	// whole playlist (so its search can reach every video); when unset, it falls
 	// back to the free RSS feed's most-recent entries. Same secret the channel
@@ -87,43 +92,101 @@ export interface TournamentPublicEnv
 const LIST_LIMIT_MAX = 100;
 const LIST_LIMIT_DEFAULT = 20;
 
-// Per-IP rate limit on anonymous tournament reads. Scraper User-Agents
-// (Discord/Slack/Twitter link previews) bypass both the gate and the
-// audit-log insert — they fan out load that's not meaningful to count.
-// Applies to everyone, including signed-in users; 600/hour is generous
-// enough that no real UI traffic should hit it.
-async function enforceTournamentViewRateLimit(
+// A per-IP read budget: which events rows count toward it, and how it answers
+// once it's spent. One shape, two instances — see the two below.
+interface ReadBudget {
+	eventType: "tournament_view" | "tournament_link_view";
+	message: string;
+	code: string;
+}
+
+const VIEW_BUDGET: ReadBudget = {
+	eventType: "tournament_view",
+	message: "Tournament view rate limit exceeded",
+	code: "RATE_LIMIT_TOURNAMENT_VIEW",
+};
+
+const LINK_BUDGET: ReadBudget = {
+	eventType: "tournament_link_view",
+	message: "Tournament link rate limit exceeded",
+	code: "RATE_LIMIT_TOURNAMENT_LINK",
+};
+
+// Per-IP rate limit on a public read. Scraper User-Agents (Discord/Slack/
+// Twitter link previews) bypass both the gate and the audit-log insert — they
+// fan out load that's not meaningful to count. Applies to everyone else,
+// including signed-in users.
+//
+// Both budgets record every read they gate, so neither is a no-op on its own
+// path; keeping the count and the INSERT in one helper is what keeps that
+// true as budgets are added.
+//
+// `eventType` is interpolated into the INSERT rather than bound: event_type
+// is part of the statement's structure, not a value. The literal union closes
+// the injection path — same reasoning as RateLimitedEventType in games.ts.
+async function enforceReadRateLimit(
 	env: TournamentPublicEnv,
 	request: Request,
 	cors: Record<string, string>,
+	budget: ReadBudget,
+	limit: number,
 ): Promise<Response | null> {
 	const ua = request.headers.get("User-Agent");
 	if (isScraperUA(ua)) return null;
 	const ip = getClientIp(request) ?? "untrusted";
 	const count = await countEventsSince(
 		env.EVENTS_DB,
-		"tournament_view",
+		budget.eventType,
 		"ip_address",
 		ip,
 	);
-	if (count >= TOURNAMENT_VIEW_PER_HOUR) {
-		return errorResponse(
-			"Tournament view rate limit exceeded",
-			429,
-			cors,
-			"RATE_LIMIT_TOURNAMENT_VIEW",
-		);
+	if (count >= limit) {
+		return errorResponse(budget.message, 429, cors, budget.code);
 	}
 	env.EVENTS_DB.prepare(
 		`INSERT INTO events (event_type, ip_address)
-		 VALUES ('tournament_view', ?)`,
+		 VALUES ('${budget.eventType}', ?)`,
 	)
 		.bind(ip)
 		.run()
 		.catch((e: unknown) => {
-			logError("tournament_view_audit_failed", e, { ip });
+			logError(`${budget.eventType}_audit_failed`, e, { ip });
 		});
 	return null;
+}
+
+// The tournament pages' budget: list/detail/standings/bracket/rounds/matches/
+// match-detail and both stats reads. Generous enough that no real UI traffic
+// should hit it, and retunable mid-event via the env var.
+function enforceTournamentViewRateLimit(
+	env: TournamentPublicEnv,
+	request: Request,
+	cors: Record<string, string>,
+): Promise<Response | null> {
+	return enforceReadRateLimit(
+		env,
+		request,
+		cors,
+		VIEW_BUDGET,
+		tournamentViewPerHour(env),
+	);
+}
+
+// The game→tournament link read's own budget. Separate from the one above
+// because /games/[id] traffic is a different population from /tournaments/*
+// traffic — see TOURNAMENT_LINK_VIEW_PER_HOUR.
+function enforceTournamentLinkRateLimit(
+	env: TournamentPublicEnv,
+	request: Request,
+	cors: Record<string, string>,
+): Promise<Response | null> {
+	return enforceReadRateLimit(
+		env,
+		request,
+		cors,
+		LINK_BUDGET,
+		TOURNAMENT_LINK_VIEW_PER_HOUR,
+	);
 }
 
 // Public-read leniency for the map_pool column: render the tournament even when
@@ -1802,13 +1865,18 @@ export async function handleUserTournaments(
 // pair if the game is linked, or null. Used by the /games/[id] page to
 // render the "linked to tournament X" preTabs banner. Public like the rest
 // of the tournament read surface.
+//
+// Metered on its own budget, not the tournament one. This runs on every game
+// page render — before it is known whether the game is linked at all — so on
+// the shared budget a crawl of /games/[id] exhausts the allowance the
+// tournament pages need and 429s them instead (the 2026-08-05 outage).
 export async function handleGameTournamentLink(
 	gameId: string,
 	request: Request,
 	env: TournamentPublicEnv,
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors);
+	const rl = await enforceTournamentLinkRateLimit(env, request, cors);
 	if (rl) return rl;
 	const row = await env.SHARE_DB.prepare(
 		`SELECT m.match_id, m.slot_a_id, m.slot_b_id, m.status, m.winner_slot_id,

--- a/cloud/src/tournament/public.ts
+++ b/cloud/src/tournament/public.ts
@@ -14,7 +14,6 @@ import {
 	cloudCorsHeaders,
 	errorResponse,
 	getClientIp,
-	isTrustedFrontend,
 	jsonResponse,
 } from "../util";
 import { countEventsSince, isScraperUA } from "../games";
@@ -45,7 +44,11 @@ import {
 	type TournamentEnv,
 	type TournamentRow,
 } from "./data";
-import { tournamentLinkViewPerHour, tournamentViewPerHour } from "./limits";
+import {
+	tournamentLinkViewPerHour,
+	tournamentListViewPerHour,
+	tournamentViewPerHour,
+} from "./limits";
 import {
 	computeStandings,
 	rankStandings,
@@ -78,11 +81,12 @@ import type { EventsEnv } from "../d1";
 export interface TournamentPublicEnv
 	extends TournamentEnv, SessionEnv, EventsEnv {
 	ALLOWED_ORIGINS: string;
-	// Per-IP hourly ceilings on the two read budgets. Optional: unset falls back
-	// to the constant of the same name (see tournamentViewPerHour /
-	// tournamentLinkViewPerHour). Vars rather than bare consts so either can be
-	// retuned mid-event without a redeploy.
+	// Per-IP hourly ceilings on the three read budgets. Optional: unset falls
+	// back to the constant of the same name (see tournamentViewPerHour /
+	// tournamentListViewPerHour / tournamentLinkViewPerHour). Vars rather than
+	// bare consts so any of them can be retuned mid-event without a redeploy.
 	TOURNAMENT_VIEW_PER_HOUR?: string;
+	TOURNAMENT_LIST_VIEW_PER_HOUR?: string;
 	TOURNAMENT_LINK_VIEW_PER_HOUR?: string;
 	// Optional YouTube Data API key. When set, the Videos tab enumerates the
 	// whole playlist (so its search can reach every video); when unset, it falls
@@ -95,9 +99,13 @@ const LIST_LIMIT_MAX = 100;
 const LIST_LIMIT_DEFAULT = 20;
 
 // A per-IP read budget: which events rows count toward it, and how it answers
-// once it's spent. One shape, two instances — see the two below.
+// once it's spent. One shape, three instances — see the three below, and
+// limits.ts for why they aren't one.
 interface ReadBudget {
-	eventType: "tournament_view" | "tournament_link_view";
+	eventType:
+		| "tournament_view"
+		| "tournament_list_view"
+		| "tournament_link_view";
 	message: string;
 	code: string;
 }
@@ -108,44 +116,37 @@ const VIEW_BUDGET: ReadBudget = {
 	code: "RATE_LIMIT_TOURNAMENT_VIEW",
 };
 
+const LIST_BUDGET: ReadBudget = {
+	eventType: "tournament_list_view",
+	message: "Tournament list rate limit exceeded",
+	code: "RATE_LIMIT_TOURNAMENT_LIST",
+};
+
 const LINK_BUDGET: ReadBudget = {
 	eventType: "tournament_link_view",
 	message: "Tournament link rate limit exceeded",
 	code: "RATE_LIMIT_TOURNAMENT_LINK",
 };
 
-// What a read is to the page it belongs to. One tournament page load makes
-// four of these calls — the tournament itself, then standings, bracket and
-// matches — and the visitor did one thing, so it should cost one slot, not
-// four. "entry" is the read a page load starts with and the one that charges;
-// "rider" is a sub-resource that only ever follows an entry read in the same
-// render (everything behind loadViewableTournament).
-//
-// The distinction is only honoured for our own SSR Worker, which is the one
-// caller we can be sure fetched the entry read first. Anyone calling
-// /standings directly is charged for it, so no path here is free — see
-// isTrustedFrontend in util.ts for how that's established.
-//
-// What the ceiling therefore bounds on server-rendered traffic is page loads,
-// not backend reads: 600 loads of the stats page is ~3,600 reads behind it.
-// That is the intended reading of the number — an operator retuning it
-// mid-event is deciding how many times a visitor may load a page — and it's
-// why the two figures are stated separately in docs/api-reference.md.
-type ReadRole = "entry" | "rider";
-
 // Per-IP rate limit on a public read. Scraper User-Agents (Discord/Slack/
 // Twitter link previews) bypass both the gate and the audit-log insert — they
 // fan out load that's not meaningful to count. Applies to everyone else,
 // including signed-in users.
 //
-// A rider on a trusted page load skips both, and skips them before the count:
-// the entry read of that same render already gated this IP and charged it
-// milliseconds ago, so counting again is a cross-region COUNT(*) per
-// sub-resource — three on a tournament page, five on the stats page — for a
-// verdict that is already known. An over-budget visitor still meets the
-// ceiling on the entry read, which is the one the page cannot render without,
-// so what it sees is unchanged. Every other caller — a hydrated navigation,
-// anything hitting the API by hand — is gated and charged per read.
+// Every read is gated and charged, on every caller. There is no cheaper class
+// of read and no caller who pays less: a tournament page load costs one slot
+// per backend read it makes, whether it was server-rendered or navigated to in
+// a hydrated client. The ceilings are set in reads to match — see
+// TOURNAMENT_VIEW_PER_HOUR for what that works out to per page.
+//
+// This was briefly a per-*page-load* charge, where a sub-resource behind
+// loadViewableTournament skipped both the gate and the count if the caller
+// proved it was our SSR Worker. That saved three to five COUNT(*) per render,
+// and cost more than it saved: the same page charged 1 via SSR and 4–6 via a
+// hydrated navigation, the ceiling meant reads on one path and page loads on
+// the other, and the rate limiter had a branch on who you are. The shared key
+// now settles exactly one question — which visitor is this — and nothing about
+// what a read costs.
 //
 // `eventType` is interpolated into the INSERT rather than bound: event_type
 // is part of the statement's structure, not a value. The literal union closes
@@ -156,11 +157,9 @@ async function enforceReadRateLimit(
 	cors: Record<string, string>,
 	budget: ReadBudget,
 	limit: number,
-	role: ReadRole,
 ): Promise<Response | null> {
 	const ua = request.headers.get("User-Agent");
 	if (isScraperUA(ua)) return null;
-	if (role === "rider" && isTrustedFrontend(request)) return null;
 	const ip = getClientIp(request) ?? "untrusted";
 	const count = await countEventsSince(
 		env.EVENTS_DB,
@@ -186,15 +185,12 @@ async function enforceReadRateLimit(
 	return null;
 }
 
-// The tournament pages' budget: list/detail/standings/bracket/rounds/matches/
-// match-detail and both stats reads. Retunable mid-event via the env var, and
-// spent once per server-rendered page load rather than once per read — see
-// ReadRole for which call sites pass which.
+// The tournament pages' budget: detail/standings/bracket/rounds/matches/
+// match-detail and both stats reads. Retunable mid-event via the env var.
 function enforceTournamentViewRateLimit(
 	env: TournamentPublicEnv,
 	request: Request,
 	cors: Record<string, string>,
-	role: ReadRole,
 ): Promise<Response | null> {
 	return enforceReadRateLimit(
 		env,
@@ -202,11 +198,28 @@ function enforceTournamentViewRateLimit(
 		cors,
 		VIEW_BUDGET,
 		tournamentViewPerHour(env),
-		role,
 	);
 }
 
-// The game→tournament link read's own budget. Separate from the one above
+// The tournament list read's own budget. Separate from the pages' one because
+// the home page fetches the list on every render — see
+// TOURNAMENT_LIST_VIEW_PER_HOUR — so on a shared budget the landing page
+// decides when /tournaments/[slug] starts refusing.
+function enforceTournamentListRateLimit(
+	env: TournamentPublicEnv,
+	request: Request,
+	cors: Record<string, string>,
+): Promise<Response | null> {
+	return enforceReadRateLimit(
+		env,
+		request,
+		cors,
+		LIST_BUDGET,
+		tournamentListViewPerHour(env),
+	);
+}
+
+// The game→tournament link read's own budget. Separate from the pages' one
 // because /games/[id] traffic is a different population from /tournaments/*
 // traffic — see TOURNAMENT_LINK_VIEW_PER_HOUR. Retunable mid-event via its own
 // env var, on the same lever as the view ceiling.
@@ -215,15 +228,12 @@ function enforceTournamentLinkRateLimit(
 	request: Request,
 	cors: Record<string, string>,
 ): Promise<Response | null> {
-	// Always an entry read: the game page fetches it on its own, with no
-	// tournament read ahead of it to have paid.
 	return enforceReadRateLimit(
 		env,
 		request,
 		cors,
 		LINK_BUDGET,
 		tournamentLinkViewPerHour(env),
-		"entry",
 	);
 }
 
@@ -249,7 +259,7 @@ export async function handleTournamentList(
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
 	const session = await sessionFromRequest(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
+	const rl = await enforceTournamentListRateLimit(env, request, cors);
 	if (rl) return rl;
 	const url = new URL(request.url);
 	const status = url.searchParams.get("status");
@@ -508,7 +518,7 @@ export async function handleTournamentDetail(
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
 	const session = await sessionFromRequest(env, request);
-	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
+	const rl = await enforceTournamentViewRateLimit(env, request, cors);
 	if (rl) return rl;
 	const tournament = await loadTournamentBySlug(env, slug);
 	if (!tournament) {
@@ -1003,13 +1013,6 @@ async function setupGateHides(
 // public-read gating (visibility rule, 404 shape, rate limit) lands here once
 // and covers standings, bracket, rounds, matches, match detail, and both stats
 // endpoints alike.
-//
-// Every read behind this preamble is a "rider": each one is reached from a
-// page whose entry read (the tournament detail, or the list) already charged
-// the budget in the same render. That's what makes a page load cost one slot
-// instead of four — and it holds because this is the only way to these
-// endpoints. A handler that charges its own entry read must not be routed
-// through here.
 async function loadViewableTournament(
 	env: TournamentPublicEnv,
 	request: Request,
@@ -1017,7 +1020,7 @@ async function loadViewableTournament(
 	cors: Record<string, string>,
 	session: { token: string; data: SessionData } | null,
 ): Promise<TournamentRow | Response> {
-	const rl = await enforceTournamentViewRateLimit(env, request, cors, "rider");
+	const rl = await enforceTournamentViewRateLimit(env, request, cors);
 	if (rl) return rl;
 	const tournament = await loadTournamentById(env, tournamentId);
 	if (!tournament || (await setupGateHides(env, session, tournament))) {
@@ -1725,10 +1728,9 @@ export async function handleUserTournaments(
 	env: TournamentPublicEnv,
 ): Promise<Response> {
 	const cors = cloudCorsHeaders(env, request);
-	// An entry read despite being a sub-resource: the profile page's Tournaments
-	// tab fetches this on its own, with no tournament read ahead of it. Making
-	// it a rider would leave a crawl of /u/*?tab=tournaments unmetered.
-	const rl = await enforceTournamentViewRateLimit(env, request, cors, "entry");
+	// Charged against the tournament pages' budget: this is the profile page's
+	// Tournaments tab, which draws on the same data and the same D1 tables.
+	const rl = await enforceTournamentViewRateLimit(env, request, cors);
 	if (rl) return rl;
 	const session = await sessionFromRequest(env, request);
 

--- a/cloud/src/util.ts
+++ b/cloud/src/util.ts
@@ -262,11 +262,24 @@ export function getClientIp(request: Request): string | null {
 // tournament pages' hourly allowance and 429'd them.
 //
 // The frontend Worker fixes the attribution at the source: it forwards the
-// visitor's edge address and User-Agent and proves it is us with a shared key
-// (`handleFetch` in src/hooks.server.ts). This is the only place that key is
-// checked and the only place those headers are believed — every reader
-// downstream keeps calling getClientIp (or reads User-Agent) and gets the
-// right answer.
+// visitor's edge address and proves it is us with a shared key (`handleFetch`
+// in src/hooks.server.ts). This is the only place that key is checked and the
+// only place the forwarded address is believed — every reader downstream keeps
+// calling getClientIp and gets the right answer.
+//
+// The address is *all* that's forwarded, deliberately. The visitor's
+// User-Agent doesn't survive the hop either, and carrying it would switch on
+// the scraper exemption in games.ts (isScraperUA) for site traffic — an
+// exemption keyed on a string the caller picks, granted before both the gate
+// and the audit INSERT. Anyone sending `User-Agent: Discordbot/2.0` to
+// per-ankh.app would then be unmetered *and* absent from the `events` table
+// the bucket query in docs/cloudflare-waf.md reads during an incident. The
+// exemption has never applied to an unfurl in the first place — every unfurl
+// arrives as a page fetch that this Worker only ever sees as an SSR
+// subrequest, so isScraperUA has seen `null` for the whole SSR era and
+// preview cards have worked regardless. With the address forwarded, a
+// link-preview crawler is now metered against its own IP rather than pooled
+// on the egress, which is strictly better than what it had.
 //
 // Both sides must have the key for any of it to take effect, so the two
 // Workers can be deployed in either order: until both are set, forwarding is
@@ -275,13 +288,6 @@ export function getClientIp(request: Request): string | null {
 // Presented by the caller.
 export const SSR_KEY_HEADER = "X-SSR-Key";
 export const SSR_CLIENT_IP_HEADER = "X-SSR-Client-IP";
-// The visitor's User-Agent, which doesn't survive the SSR hop either:
-// SvelteKit's server-side fetch copies cookie/origin/authorization/accept onto
-// a subrequest and nothing else, so without this the read limiters see no UA at
-// all. They exempt link-preview scrapers by UA (isScraperUA in games.ts), and a
-// Discord or Slack unfurl is *always* a server-rendered load — so the exemption
-// applies to nothing at all unless the UA is carried across with the address.
-export const SSR_CLIENT_UA_HEADER = "X-SSR-Client-UA";
 // Our own verdict, never believed from the wire: adoptTrustedFrontend strips
 // this off every inbound request and re-adds it only after the key checks out,
 // so a handler reading it is reading this module's conclusion and not the
@@ -298,10 +304,6 @@ export interface TrustedFrontendEnv {
 // A forwarded address becomes a rate-limit bucket key and an `events` row, so
 // it gets a shape check before either. Deliberately loose — IPv4, IPv6, and
 // nothing else long enough to be a payload.
-//
-// The forwarded User-Agent gets no equivalent check: it is never stored and
-// never a key, only prefix-compared against the scraper list, so there is
-// nothing for a malformed one to corrupt.
 const FORWARDED_IP_RE = /^[0-9a-fA-F:.]{3,45}$/;
 
 // Whether this isolate has already reported each of the two ways forwarding
@@ -311,23 +313,16 @@ let rejectionLogged = false;
 let missingIpLogged = false;
 
 // Resolve the trust question once, at the top of `fetch`, and hand the rest of
-// the Worker a request whose CF-Connecting-IP and User-Agent are the visitor's.
-// Returns the request untouched when no SSR headers are in play (all browser
-// traffic).
+// the Worker a request whose CF-Connecting-IP is the visitor's. Returns the
+// request untouched when no SSR headers are in play (all browser traffic).
 export function adoptTrustedFrontend(
 	request: Request,
 	env: TrustedFrontendEnv,
 ): Request {
 	const presented = request.headers.get(SSR_KEY_HEADER);
 	const forwarded = request.headers.get(SSR_CLIENT_IP_HEADER);
-	const forwardedUa = request.headers.get(SSR_CLIENT_UA_HEADER);
 	const claimed = request.headers.get(SSR_TRUSTED_HEADER);
-	if (
-		presented === null &&
-		forwarded === null &&
-		forwardedUa === null &&
-		claimed === null
-	) {
+	if (presented === null && forwarded === null && claimed === null) {
 		return request;
 	}
 
@@ -351,7 +346,6 @@ export function adoptTrustedFrontend(
 	const headers = new Headers(request.headers);
 	headers.delete(SSR_KEY_HEADER);
 	headers.delete(SSR_CLIENT_IP_HEADER);
-	headers.delete(SSR_CLIENT_UA_HEADER);
 	headers.delete(SSR_TRUSTED_HEADER);
 
 	if (trusted) {
@@ -368,7 +362,6 @@ export function adoptTrustedFrontend(
 			missingIpLogged = true;
 			logWarn("ssr_forward_no_client_ip");
 		}
-		if (forwardedUa !== null) headers.set("User-Agent", forwardedUa);
 	} else if (key !== undefined && !rejectionLogged) {
 		// A key is configured and this one didn't match: a botched rotation, or
 		// someone probing the header. Worth a line either way.
@@ -387,7 +380,17 @@ export function adoptTrustedFrontend(
 		logWarn("ssr_forward_rejected");
 	}
 
-	return new Request(request, { headers });
+	// `cf` is carried across explicitly: the Request constructor does not
+	// inherit it from the request being copied, and the rewrite above happens
+	// for *any* caller that presents an SSR header — including a junk one. So
+	// without this, `X-SSR-Key: anything` is a one-header way for a caller to
+	// delete its own edge metadata (country, ASN, bot score) before a handler
+	// can read it. Nothing downstream reads `request.cf` today — log.ts builds
+	// its context from the inbound request, before this runs — which is exactly
+	// why it has to be preserved now rather than after something starts.
+	// Pinned by "preserves the edge cf metadata" in test/integration/
+	// ssr-trust.test.ts.
+	return new Request(request, { headers, cf: request.cf });
 }
 
 // Whether this request is our SSR Worker's subrequest, as decided above.

--- a/cloud/src/util.ts
+++ b/cloud/src/util.ts
@@ -262,10 +262,11 @@ export function getClientIp(request: Request): string | null {
 // tournament pages' hourly allowance and 429'd them.
 //
 // The frontend Worker fixes the attribution at the source: it forwards the
-// visitor's edge address and proves it is us with a shared key
+// visitor's edge address and User-Agent and proves it is us with a shared key
 // (`handleFetch` in src/hooks.server.ts). This is the only place that key is
 // checked and the only place those headers are believed — every reader
-// downstream keeps calling getClientIp and gets the right answer.
+// downstream keeps calling getClientIp (or reads User-Agent) and gets the
+// right answer.
 //
 // Both sides must have the key for any of it to take effect, so the two
 // Workers can be deployed in either order: until both are set, forwarding is
@@ -274,6 +275,13 @@ export function getClientIp(request: Request): string | null {
 // Presented by the caller.
 export const SSR_KEY_HEADER = "X-SSR-Key";
 export const SSR_CLIENT_IP_HEADER = "X-SSR-Client-IP";
+// The visitor's User-Agent, which doesn't survive the SSR hop either:
+// SvelteKit's server-side fetch copies cookie/origin/authorization/accept onto
+// a subrequest and nothing else, so without this the read limiters see no UA at
+// all. They exempt link-preview scrapers by UA (isScraperUA in games.ts), and a
+// Discord or Slack unfurl is *always* a server-rendered load — so the exemption
+// applies to nothing at all unless the UA is carried across with the address.
+export const SSR_CLIENT_UA_HEADER = "X-SSR-Client-UA";
 // Our own verdict, never believed from the wire: adoptTrustedFrontend strips
 // this off every inbound request and re-adds it only after the key checks out,
 // so a handler reading it is reading this module's conclusion and not the
@@ -290,23 +298,50 @@ export interface TrustedFrontendEnv {
 // A forwarded address becomes a rate-limit bucket key and an `events` row, so
 // it gets a shape check before either. Deliberately loose — IPv4, IPv6, and
 // nothing else long enough to be a payload.
+//
+// The forwarded User-Agent gets no equivalent check: it is never stored and
+// never a key, only prefix-compared against the scraper list, so there is
+// nothing for a malformed one to corrupt.
 const FORWARDED_IP_RE = /^[0-9a-fA-F:.]{3,45}$/;
 
+// Whether this isolate has already reported each of the two ways forwarding
+// can be misconfigured — see the warns below for why one line is the whole
+// signal, and why a second state needs a second flag rather than sharing one.
+let rejectionLogged = false;
+let missingIpLogged = false;
+
 // Resolve the trust question once, at the top of `fetch`, and hand the rest of
-// the Worker a request whose CF-Connecting-IP is the visitor's. Returns the
-// request untouched when no SSR headers are in play (all browser traffic).
+// the Worker a request whose CF-Connecting-IP and User-Agent are the visitor's.
+// Returns the request untouched when no SSR headers are in play (all browser
+// traffic).
 export function adoptTrustedFrontend(
 	request: Request,
 	env: TrustedFrontendEnv,
 ): Request {
 	const presented = request.headers.get(SSR_KEY_HEADER);
 	const forwarded = request.headers.get(SSR_CLIENT_IP_HEADER);
+	const forwardedUa = request.headers.get(SSR_CLIENT_UA_HEADER);
 	const claimed = request.headers.get(SSR_TRUSTED_HEADER);
-	if (presented === null && forwarded === null && claimed === null) {
+	if (
+		presented === null &&
+		forwarded === null &&
+		forwardedUa === null &&
+		claimed === null
+	) {
 		return request;
 	}
 
-	const key = env.SSR_TRUSTED_KEY;
+	// A blank secret is an unset secret, and normalising it here is what keeps
+	// every `key !== undefined` test below honest. Empty is how a secret gets
+	// half-set — a `wrangler secret put` with nothing pasted, a `.dev.vars` line
+	// left as `SSR_TRUSTED_KEY=` — and treating it as configured would make
+	// timingSafeEqual("", "") true for anyone sending a bare `X-SSR-Key:`, so
+	// the empty value that means "off" would instead trust the whole internet.
+	// The frontend already reads it this way (`if (ssrKey)` in
+	// src/hooks.server.ts); this is what makes the two sides agree on what
+	// "configured" means.
+	const configured = env.SSR_TRUSTED_KEY;
+	const key = configured === "" ? undefined : configured;
 	const trusted =
 		key !== undefined && presented !== null && timingSafeEqual(key, presented);
 
@@ -316,20 +351,39 @@ export function adoptTrustedFrontend(
 	const headers = new Headers(request.headers);
 	headers.delete(SSR_KEY_HEADER);
 	headers.delete(SSR_CLIENT_IP_HEADER);
+	headers.delete(SSR_CLIENT_UA_HEADER);
 	headers.delete(SSR_TRUSTED_HEADER);
 
 	if (trusted) {
 		headers.set(SSR_TRUSTED_HEADER, "1");
 		if (forwarded !== null && FORWARDED_IP_RE.test(forwarded)) {
 			headers.set("CF-Connecting-IP", forwarded);
+		} else if (!missingIpLogged) {
+			// Keyed, but carrying no address we can use: CF-Connecting-IP stays
+			// the SSR egress, so every server-rendered visitor pools into one
+			// bucket again — the 2026-08-05 outage, and previously it arrived
+			// with no line at all because the warn below only fires on a
+			// mismatch. Only a holder of the key reaches this branch, so what
+			// it reports is our own frontend, not a caller.
+			missingIpLogged = true;
+			logWarn("ssr_forward_no_client_ip");
 		}
-	} else if (key !== undefined) {
+		if (forwardedUa !== null) headers.set("User-Agent", forwardedUa);
+	} else if (key !== undefined && !rejectionLogged) {
 		// A key is configured and this one didn't match: a botched rotation, or
 		// someone probing the header. Worth a line either way.
+		//
+		// Once per isolate, not once per request: every header that reaches this
+		// branch is caller-supplied, so a per-request line is a log-flood lever
+		// for anyone who notices it — and it would bury the rotation case in
+		// noise at the moment an operator is grepping for exactly that. What
+		// this reports is a configuration state rather than an event, so the
+		// first line says everything the thousandth would.
 		//
 		// No line when the key is unset — that's the feature switched off, and
 		// it's also the window where the frontend has shipped forwarding and this
 		// Worker hasn't yet, which is a supported deploy order and not an event.
+		rejectionLogged = true;
 		logWarn("ssr_forward_rejected");
 	}
 

--- a/cloud/src/util.ts
+++ b/cloud/src/util.ts
@@ -229,12 +229,116 @@ export function isSecureRequest(request: Request): boolean {
 // in a misconfigured topology. Rate-limit callers should fall back to
 // global/per-user limits when this returns null and treat the warn line
 // as a misconfiguration signal.
+//
+// For a server-rendered page load this reads the visitor's address rather than
+// the frontend Worker's, because `adoptTrustedFrontend` has already replaced
+// CF-Connecting-IP on requests that proved they came from our SSR Worker. Call
+// sites need no branch for it — see the block below for why.
+//
+// A trusted request skips the CF-RAY test rather than failing it. That test
+// asks "did this reach us through the edge, or is someone calling the Worker
+// directly and setting whatever address they like" — a question the shared key
+// already answers, and answers better. Keeping the test would leave the whole
+// of forwarding hostage to a header on Worker-to-Worker subrequests that we
+// don't control and can't assert here.
 export function getClientIp(request: Request): string | null {
-	if (!request.headers.get("CF-RAY")) {
+	if (!isTrustedFrontend(request) && !request.headers.get("CF-RAY")) {
 		logWarn("cf_ray_missing");
 		return null;
 	}
 	return request.headers.get("CF-Connecting-IP");
+}
+
+// === Trusted frontend (SSR) requests ===
+//
+// per-ankh.app is server-rendered by our own Worker, and its subrequests to
+// this API don't carry the visitor: SvelteKit's server-side fetch is a fresh
+// request out of Cloudflare's egress, so CF-Connecting-IP on it is one address
+// standing in for every SSR visitor at once (on 2026-08-05, every
+// server-rendered request in production arrived from 2a06:98c0:3600::103).
+// Every per-IP budget here — anon_read, the tournament budgets, uploads,
+// downloads, search — was therefore counting the whole site into a single
+// bucket for that traffic, which is how a crawl of /games/* spent the
+// tournament pages' hourly allowance and 429'd them.
+//
+// The frontend Worker fixes the attribution at the source: it forwards the
+// visitor's edge address and proves it is us with a shared key
+// (`handleFetch` in src/hooks.server.ts). This is the only place that key is
+// checked and the only place those headers are believed — every reader
+// downstream keeps calling getClientIp and gets the right answer.
+//
+// Both sides must have the key for any of it to take effect, so the two
+// Workers can be deployed in either order: until both are set, forwarding is
+// ignored and every counter behaves exactly as it did before.
+
+// Presented by the caller.
+export const SSR_KEY_HEADER = "X-SSR-Key";
+export const SSR_CLIENT_IP_HEADER = "X-SSR-Client-IP";
+// Our own verdict, never believed from the wire: adoptTrustedFrontend strips
+// this off every inbound request and re-adds it only after the key checks out,
+// so a handler reading it is reading this module's conclusion and not the
+// caller's claim.
+const SSR_TRUSTED_HEADER = "X-SSR-Trusted";
+
+export interface TrustedFrontendEnv {
+	// Shared key proving a request is our SSR Worker's subrequest. Set with
+	// `wrangler secret put SSR_TRUSTED_KEY` on both Workers; unset disables
+	// forwarding rather than failing anything.
+	SSR_TRUSTED_KEY?: string;
+}
+
+// A forwarded address becomes a rate-limit bucket key and an `events` row, so
+// it gets a shape check before either. Deliberately loose — IPv4, IPv6, and
+// nothing else long enough to be a payload.
+const FORWARDED_IP_RE = /^[0-9a-fA-F:.]{3,45}$/;
+
+// Resolve the trust question once, at the top of `fetch`, and hand the rest of
+// the Worker a request whose CF-Connecting-IP is the visitor's. Returns the
+// request untouched when no SSR headers are in play (all browser traffic).
+export function adoptTrustedFrontend(
+	request: Request,
+	env: TrustedFrontendEnv,
+): Request {
+	const presented = request.headers.get(SSR_KEY_HEADER);
+	const forwarded = request.headers.get(SSR_CLIENT_IP_HEADER);
+	const claimed = request.headers.get(SSR_TRUSTED_HEADER);
+	if (presented === null && forwarded === null && claimed === null) {
+		return request;
+	}
+
+	const key = env.SSR_TRUSTED_KEY;
+	const trusted =
+		key !== undefined && presented !== null && timingSafeEqual(key, presented);
+
+	// Strip first, unconditionally: a request that arrives claiming to be
+	// trusted must lose that claim before any handler can read it, whatever the
+	// key check then decides.
+	const headers = new Headers(request.headers);
+	headers.delete(SSR_KEY_HEADER);
+	headers.delete(SSR_CLIENT_IP_HEADER);
+	headers.delete(SSR_TRUSTED_HEADER);
+
+	if (trusted) {
+		headers.set(SSR_TRUSTED_HEADER, "1");
+		if (forwarded !== null && FORWARDED_IP_RE.test(forwarded)) {
+			headers.set("CF-Connecting-IP", forwarded);
+		}
+	} else if (key !== undefined) {
+		// A key is configured and this one didn't match: a botched rotation, or
+		// someone probing the header. Worth a line either way.
+		//
+		// No line when the key is unset — that's the feature switched off, and
+		// it's also the window where the frontend has shipped forwarding and this
+		// Worker hasn't yet, which is a supported deploy order and not an event.
+		logWarn("ssr_forward_rejected");
+	}
+
+	return new Request(request, { headers });
+}
+
+// Whether this request is our SSR Worker's subrequest, as decided above.
+export function isTrustedFrontend(request: Request): boolean {
+	return request.headers.get(SSR_TRUSTED_HEADER) === "1";
 }
 
 // base64url encoding of an ArrayBuffer or Uint8Array, no padding.

--- a/cloud/test/env.d.ts
+++ b/cloud/test/env.d.ts
@@ -23,6 +23,10 @@ declare global {
 			// (see tournament/rate-limit-view.test.ts).
 			TOURNAMENT_VIEW_PER_HOUR: string;
 			TOURNAMENT_LINK_VIEW_PER_HOUR: string;
+			// Shared key for trusted SSR requests, bound in vitest.config.mts.
+			// Declared so a test can clear it and prove forwarding goes dark
+			// (see integration/ssr-trust.test.ts).
+			SSR_TRUSTED_KEY: string;
 		}
 	}
 }

--- a/cloud/test/env.d.ts
+++ b/cloud/test/env.d.ts
@@ -18,10 +18,11 @@ declare global {
 			TEST_SECURITY_MIGRATIONS: D1Migration[];
 			ALLOWED_ORIGINS: string;
 			ALLOWED_ORIGIN: string;
-			// Tunable per-IP tournament read ceiling. Declared so the rate-limit
-			// tests can substitute a value the way `wrangler secret put` does in
-			// production (see tournament/rate-limit-view.test.ts).
+			// Tunable per-IP read ceilings. Declared so the rate-limit tests can
+			// substitute a value the way `wrangler secret put` does in production
+			// (see tournament/rate-limit-view.test.ts).
 			TOURNAMENT_VIEW_PER_HOUR: string;
+			TOURNAMENT_LINK_VIEW_PER_HOUR: string;
 		}
 	}
 }

--- a/cloud/test/env.d.ts
+++ b/cloud/test/env.d.ts
@@ -22,6 +22,7 @@ declare global {
 			// substitute a value the way `wrangler secret put` does in production
 			// (see tournament/rate-limit-view.test.ts).
 			TOURNAMENT_VIEW_PER_HOUR: string;
+			TOURNAMENT_LIST_VIEW_PER_HOUR: string;
 			TOURNAMENT_LINK_VIEW_PER_HOUR: string;
 			// Shared key for trusted SSR requests, bound in vitest.config.mts.
 			// Declared so a test can clear it and prove forwarding goes dark

--- a/cloud/test/env.d.ts
+++ b/cloud/test/env.d.ts
@@ -18,6 +18,10 @@ declare global {
 			TEST_SECURITY_MIGRATIONS: D1Migration[];
 			ALLOWED_ORIGINS: string;
 			ALLOWED_ORIGIN: string;
+			// Tunable per-IP tournament read ceiling. Declared so the rate-limit
+			// tests can substitute a value the way `wrangler secret put` does in
+			// production (see tournament/rate-limit-view.test.ts).
+			TOURNAMENT_VIEW_PER_HOUR: string;
 		}
 	}
 }

--- a/cloud/test/helpers/ssr-identity.ts
+++ b/cloud/test/helpers/ssr-identity.ts
@@ -9,16 +9,17 @@
 export const SSR_TRUSTED_TEST_KEY = "test-ssr-trusted-key";
 
 // Headers a server-rendered page load arrives with: the frontend Worker's key
-// plus the visitor's address and User-Agent, which is the whole point — the
-// request itself comes from Cloudflare's SSR egress (`CF-Connecting-IP` below)
-// and carries no UA of its own, and what the API must count and inspect is the
-// visitor's.
+// plus the visitor's address, which is the whole point — the request itself
+// comes from Cloudflare's SSR egress (`CF-Connecting-IP` below) and what the
+// API must count is the visitor.
+//
+// The visitor's User-Agent is deliberately not among them. It doesn't survive
+// the hop either, and forwarding it would hand the scraper exemption in
+// games.ts to anyone who types `Discordbot/2.0` — see the SSR block in
+// cloud/src/util.ts. So an SSR request carries no UA at all, which is the
+// shape these tests are written against.
 export function ssrHeaders(opts: {
 	clientIp: string;
-	// The visitor's User-Agent. Omitted by default because SvelteKit's server
-	// fetch sends none unless the frontend forwards it — the shape every test
-	// here should be written against unless it's the forwarding under test.
-	clientUa?: string;
 	// The address the subrequest itself arrives from — one shared egress in
 	// production, so it defaults to a single fixed value here for the same
 	// reason: any test that leaks it into a counter should collide loudly.
@@ -34,7 +35,6 @@ export function ssrHeaders(opts: {
 		"X-SSR-Key": opts.key ?? SSR_TRUSTED_TEST_KEY,
 		"X-SSR-Client-IP": opts.clientIp,
 	};
-	if (opts.clientUa) headers["X-SSR-Client-UA"] = opts.clientUa;
 	if (!opts.omitCfRay) headers["CF-RAY"] = "test-ray";
 	return headers;
 }

--- a/cloud/test/helpers/ssr-identity.ts
+++ b/cloud/test/helpers/ssr-identity.ts
@@ -9,11 +9,16 @@
 export const SSR_TRUSTED_TEST_KEY = "test-ssr-trusted-key";
 
 // Headers a server-rendered page load arrives with: the frontend Worker's key
-// plus the visitor's address, which is the whole point — the request itself
-// comes from Cloudflare's SSR egress (`CF-Connecting-IP` below), and what the
-// API must count is `clientIp`.
+// plus the visitor's address and User-Agent, which is the whole point — the
+// request itself comes from Cloudflare's SSR egress (`CF-Connecting-IP` below)
+// and carries no UA of its own, and what the API must count and inspect is the
+// visitor's.
 export function ssrHeaders(opts: {
 	clientIp: string;
+	// The visitor's User-Agent. Omitted by default because SvelteKit's server
+	// fetch sends none unless the frontend forwards it — the shape every test
+	// here should be written against unless it's the forwarding under test.
+	clientUa?: string;
 	// The address the subrequest itself arrives from — one shared egress in
 	// production, so it defaults to a single fixed value here for the same
 	// reason: any test that leaks it into a counter should collide loudly.
@@ -29,6 +34,7 @@ export function ssrHeaders(opts: {
 		"X-SSR-Key": opts.key ?? SSR_TRUSTED_TEST_KEY,
 		"X-SSR-Client-IP": opts.clientIp,
 	};
+	if (opts.clientUa) headers["X-SSR-Client-UA"] = opts.clientUa;
 	if (!opts.omitCfRay) headers["CF-RAY"] = "test-ray";
 	return headers;
 }

--- a/cloud/test/helpers/ssr-identity.ts
+++ b/cloud/test/helpers/ssr-identity.ts
@@ -1,0 +1,34 @@
+// The shared key the integration Worker accepts as "this came from our SSR
+// Worker" (SSR_TRUSTED_KEY, checked by adoptTrustedFrontend in
+// cloud/src/util.ts).
+//
+// vitest.config.mts binds this value and ssrHeaders() presents it — both
+// import it from here so they can't drift. Not a secret: it only has meaning
+// against a Worker configured with the same string, and this one is a test
+// isolate.
+export const SSR_TRUSTED_TEST_KEY = "test-ssr-trusted-key";
+
+// Headers a server-rendered page load arrives with: the frontend Worker's key
+// plus the visitor's address, which is the whole point — the request itself
+// comes from Cloudflare's SSR egress (`CF-Connecting-IP` below), and what the
+// API must count is `clientIp`.
+export function ssrHeaders(opts: {
+	clientIp: string;
+	// The address the subrequest itself arrives from — one shared egress in
+	// production, so it defaults to a single fixed value here for the same
+	// reason: any test that leaks it into a counter should collide loudly.
+	egressIp?: string;
+	// Presented instead of the real key, for the spoofing cases.
+	key?: string;
+	// Drop CF-RAY, which we don't control on a Worker-to-Worker subrequest.
+	// The key is the stronger signal and getClientIp treats it that way.
+	omitCfRay?: boolean;
+}): Record<string, string> {
+	const headers: Record<string, string> = {
+		"CF-Connecting-IP": opts.egressIp ?? "203.0.113.200",
+		"X-SSR-Key": opts.key ?? SSR_TRUSTED_TEST_KEY,
+		"X-SSR-Client-IP": opts.clientIp,
+	};
+	if (!opts.omitCfRay) headers["CF-RAY"] = "test-ray";
+	return headers;
+}

--- a/cloud/test/integration/ssr-trust.test.ts
+++ b/cloud/test/integration/ssr-trust.test.ts
@@ -1,4 +1,5 @@
-// Trusted server-rendered requests: who a read is counted against.
+// Trusted server-rendered requests: who a read is counted against, and how
+// many slots a page load spends.
 //
 // per-ankh.app renders its pages in a Worker, and that Worker's subrequests
 // reach this API from Cloudflare's SSR egress — one address standing in for
@@ -8,13 +9,18 @@
 //
 // The frontend forwards the visitor's address and proves it's ours with
 // SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
-// cloud/src/util.ts), so a trusted request is counted against the visitor and
-// never against the egress — and an untrusted one can't claim an address it
-// doesn't have.
+// cloud/src/util.ts). Two properties follow, and this file pins both:
+//
+//   1. A trusted request is counted against the visitor, never the egress —
+//      and an untrusted one can't claim an address it doesn't have.
+//   2. A trusted page load spends one slot, not one per read: the entry read
+//      charges and the sub-resources ride along. A browser making the same
+//      reads directly pays for each, so no endpoint is free.
 
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
-import { beforeAll, describe, expect, it } from "vitest";
-import { expectOk } from "../helpers/assertions";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { expectErrorCode, expectOk } from "../helpers/assertions";
+import { makeTournament } from "../helpers/builders";
 import { ssrHeaders } from "../helpers/ssr-identity";
 
 beforeAll(async () => {
@@ -52,6 +58,12 @@ async function expectEventsToReach(
 
 function get(path: string, headers: Record<string, string>): Promise<Response> {
 	return SELF.fetch(`http://test${path}`, { headers });
+}
+
+// A browser's own request: no forwarding involved, the address on the wire is
+// the visitor's.
+function directHeaders(ip: string): Record<string, string> {
+	return { "CF-Connecting-IP": ip, "CF-RAY": "test-ray" };
 }
 
 describe("forwarded visitor IP", () => {
@@ -158,5 +170,109 @@ describe("forwarded visitor IP", () => {
 		});
 
 		expect(res.status).toBe(400);
+	});
+});
+
+describe("one page load, one slot", () => {
+	it("charges a trusted page load once across its four reads", async () => {
+		const t = await makeTournament({
+			slug: "ssr-page-load",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const visitor = "203.0.113.70";
+		const headers = ssrHeaders({ clientIp: visitor });
+
+		// What /tournaments/[slug] fetches on a cold load: the tournament, then
+		// standings + bracket + matches (src/routes/tournaments/[slug]/+layout.ts).
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
+		);
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/bracket`, headers),
+		);
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/matches`, headers),
+		);
+
+		// One visitor action, one slot — the entry read's. Before this, the same
+		// page load spent four, so ~150 cold loads exhausted the hourly budget
+		// for the whole site.
+		await expectEventsToReach("tournament_view", visitor, 1);
+	});
+
+	it("charges a browser for every read it makes directly", async () => {
+		// The same four reads without the trust marker — a hydrated navigation,
+		// or anyone hitting the API by hand. Riding along is a property of a
+		// server-rendered page load, not of the endpoints.
+		const t = await makeTournament({
+			slug: "ssr-page-load-direct",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const visitor = "203.0.113.71";
+		const headers = directHeaders(visitor);
+
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
+		);
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/bracket`, headers),
+		);
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/matches`, headers),
+		);
+
+		await expectEventsToReach("tournament_view", visitor, 4);
+	});
+
+	it("does not let a caller declare itself trusted", async () => {
+		// X-SSR-Trusted is this Worker's own verdict; adoptTrustedFrontend strips
+		// it off every inbound request before deciding. A caller setting it must
+		// gain nothing — so this read is still charged.
+		const t = await makeTournament({
+			slug: "ssr-self-declared",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const caller = "203.0.113.72";
+
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, {
+				...directHeaders(caller),
+				"X-SSR-Trusted": "1",
+			}),
+		);
+
+		await expectEventsToReach("tournament_view", caller, 1);
+	});
+});
+
+describe("riders are gated, not exempt", () => {
+	const configured = env.TOURNAMENT_VIEW_PER_HOUR;
+	afterEach(() => {
+		env.TOURNAMENT_VIEW_PER_HOUR = configured;
+	});
+
+	it("429s a rider read on an IP whose budget is spent", async () => {
+		// Not charging a rider must not mean not stopping one: an over-budget
+		// visitor has to meet the ceiling whichever read of the page arrives
+		// first, or the page renders half-broken instead of saying why.
+		env.TOURNAMENT_VIEW_PER_HOUR = "1";
+		const t = await makeTournament({
+			slug: "ssr-rider-gate",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const visitor = "203.0.113.73";
+		const headers = ssrHeaders({ clientIp: visitor });
+
+		// The entry read spends the only slot...
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
+		await expectEventsToReach("tournament_view", visitor, 1);
+
+		// ...and the rider that follows it is refused, same as any other read.
+		await expectErrorCode(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
+			{ status: 429, code: "RATE_LIMIT_TOURNAMENT_VIEW" },
+		);
 	});
 });

--- a/cloud/test/integration/ssr-trust.test.ts
+++ b/cloud/test/integration/ssr-trust.test.ts
@@ -7,21 +7,24 @@
 // site into one bucket, which is how a crawl of /games/* spent the tournament
 // pages' hourly allowance on 2026-08-05.
 //
-// The frontend forwards the visitor's address and proves it's ours with
-// SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
-// cloud/src/util.ts). Two properties follow, and this file pins both:
+// The frontend forwards the visitor's address and User-Agent and proves it's
+// ours with SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
+// cloud/src/util.ts). Three properties follow, and this file pins all three:
 //
 //   1. A trusted request is counted against the visitor, never the egress —
 //      and an untrusted one can't claim an address it doesn't have.
 //   2. A trusted page load spends one slot, not one per read: the entry read
 //      charges and the sub-resources ride along. A browser making the same
 //      reads directly pays for each, so no endpoint is free.
+//   3. The visitor's UA arrives too, which is what makes the scraper exemption
+//      reach the traffic it was written for — a link-preview unfurl is a
+//      server-rendered load and never anything else.
 
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { expectErrorCode, expectOk } from "../helpers/assertions";
 import { makeTournament } from "../helpers/builders";
-import { ssrHeaders } from "../helpers/ssr-identity";
+import { SSR_TRUSTED_TEST_KEY, ssrHeaders } from "../helpers/ssr-identity";
 
 beforeAll(async () => {
 	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
@@ -130,6 +133,52 @@ describe("forwarded visitor IP", () => {
 		} finally {
 			env.SSR_TRUSTED_KEY = configured;
 		}
+	});
+
+	it("treats a blank key as no key rather than as a match", async () => {
+		// Empty is how a secret gets half-set — a `wrangler secret put` with
+		// nothing pasted, a `.dev.vars` line left bare — and an empty presented
+		// value compares equal to an empty configured one. So this is the case
+		// where forwarding would trust the whole internet: the read has to land
+		// on the caller's own address, and the claimed one has to stay clean.
+		const configured = env.SSR_TRUSTED_KEY;
+		try {
+			env.SSR_TRUSTED_KEY = "";
+			const caller = "203.0.113.68";
+			const victim = "203.0.113.69";
+
+			await expectOk(
+				await get("/v1/tournaments", {
+					...ssrHeaders({ clientIp: victim, key: "" }),
+					"CF-Connecting-IP": caller,
+				}),
+			);
+
+			await expectEventsToReach("tournament_view", caller, 1);
+			expect(await countEvents("tournament_view", victim)).toBe(0);
+		} finally {
+			env.SSR_TRUSTED_KEY = configured;
+		}
+	});
+
+	it("falls back to the egress when a trusted request forwards no address", async () => {
+		// The key proves who's calling; it doesn't conjure an address. With
+		// nothing usable to swap in, the counter is the address on the wire
+		// again — in production the shared egress, which is the pooling this
+		// whole path exists to undo, so it's what `ssr_forward_no_client_ip`
+		// reports. Its own address rather than EGRESS_IP so the count here
+		// can't be confused with another test's.
+		const egress = "203.0.113.201";
+
+		await expectOk(
+			await get("/v1/tournaments", {
+				"CF-Connecting-IP": egress,
+				"CF-RAY": "test-ray",
+				"X-SSR-Key": SSR_TRUSTED_TEST_KEY,
+			}),
+		);
+
+		await expectEventsToReach("tournament_view", egress, 1);
 	});
 
 	it("attributes a trusted read without CF-RAY, and an untrusted one to nobody", async () => {
@@ -247,32 +296,149 @@ describe("one page load, one slot", () => {
 	});
 });
 
-describe("riders are gated, not exempt", () => {
+describe("the ceiling is what an over-budget visitor meets", () => {
 	const configured = env.TOURNAMENT_VIEW_PER_HOUR;
 	afterEach(() => {
 		env.TOURNAMENT_VIEW_PER_HOUR = configured;
 	});
 
-	it("429s a rider read on an IP whose budget is spent", async () => {
-		// Not charging a rider must not mean not stopping one: an over-budget
-		// visitor has to meet the ceiling whichever read of the page arrives
-		// first, or the page renders half-broken instead of saying why.
+	it("429s the entry read, which is the one the page can't render without", async () => {
+		// Riding along means a rider is neither charged nor counted, so what
+		// stops an over-budget visitor is the entry read — and it has to, since
+		// nothing downstream of it re-checks.
 		env.TOURNAMENT_VIEW_PER_HOUR = "1";
 		const t = await makeTournament({
-			slug: "ssr-rider-gate",
+			slug: "ssr-entry-gate",
 			advanceTo: "swiss-round-1-generated",
 		});
 		const visitor = "203.0.113.73";
 		const headers = ssrHeaders({ clientIp: visitor });
 
-		// The entry read spends the only slot...
+		// The first page load spends the only slot...
 		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
 		await expectEventsToReach("tournament_view", visitor, 1);
 
-		// ...and the rider that follows it is refused, same as any other read.
+		// ...and the next one is refused before it renders anything.
+		await expectErrorCode(await get(`/v1/tournaments/${t.slug}`, headers), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_VIEW",
+		});
+	});
+
+	it("still gates a rider read that isn't riding on anything", async () => {
+		// Untrusted callers get no short-circuit: /standings on its own is a
+		// read like any other, gated and charged, however many the caller has
+		// already spent.
+		env.TOURNAMENT_VIEW_PER_HOUR = "1";
+		const t = await makeTournament({
+			slug: "ssr-rider-direct-gate",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const visitor = "203.0.113.74";
+		const headers = directHeaders(visitor);
+
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
+		await expectEventsToReach("tournament_view", visitor, 1);
+
 		await expectErrorCode(
 			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
 			{ status: 429, code: "RATE_LIMIT_TOURNAMENT_VIEW" },
 		);
+	});
+
+	it("charges a trusted rider nothing, even with the budget wide open", async () => {
+		// The counter side of riding along: the sub-resource reads leave no
+		// rows at all, so the visitor's bucket holds page loads and not reads.
+		const t = await makeTournament({
+			slug: "ssr-rider-uncharged",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const visitor = "203.0.113.75";
+		const headers = ssrHeaders({ clientIp: visitor });
+
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
+		);
+		await expectOk(
+			await get(`/v1/tournaments/${t.tournamentId}/bracket`, headers),
+		);
+
+		// Followed by an entry read, so the assertion is on a settled count
+		// rather than on a row that simply hasn't been written yet: exactly one
+		// row exists, and it's the entry read's.
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
+		await expectEventsToReach("tournament_view", visitor, 1);
+	});
+});
+
+describe("forwarded visitor User-Agent", () => {
+	// The scraper exemption exists for link-preview crawlers, and an unfurl is
+	// always a server-rendered load — so it only ever applies to a request that
+	// arrived through forwarding. Without the UA riding along with the address,
+	// the exemption covers nothing that actually happens in production.
+	it("exempts a scraper whose UA arrived over the SSR hop", async () => {
+		const crawler = "203.0.113.80";
+		const headers = ssrHeaders({ clientIp: crawler });
+
+		await expectOk(
+			await get("/v1/tournaments", {
+				...headers,
+				"X-SSR-Client-UA": "Twitterbot/1.0",
+			}),
+		);
+
+		// An ordinary read from the same address afterwards, so the count this
+		// settles on is one that has actually been written: if the crawler's
+		// read had been charged, this would find two rows.
+		await expectOk(await get("/v1/tournaments", headers));
+		await expectEventsToReach("tournament_view", crawler, 1);
+	});
+
+	it("applies to every budget that reads the UA, not just the tournament one", async () => {
+		const crawler = "203.0.113.81";
+		const headers = ssrHeaders({ clientIp: crawler });
+
+		await expectOk(
+			await get("/v1/games/public-recent", {
+				...headers,
+				"X-SSR-Client-UA": "Discordbot/2.0 (+https://discordapp.com)",
+			}),
+		);
+
+		await expectOk(await get("/v1/games/public-recent", headers));
+		await expectEventsToReach("anon_read", crawler, 1);
+	});
+
+	it("counts a forwarded browser UA like any other visitor", async () => {
+		// The other half: forwarding a UA must not exempt anything by itself.
+		const visitor = "203.0.113.82";
+
+		await expectOk(
+			await get(
+				"/v1/tournaments",
+				ssrHeaders({ clientIp: visitor, clientUa: "Mozilla/5.0" }),
+			),
+		);
+
+		await expectEventsToReach("tournament_view", visitor, 1);
+	});
+
+	it("ignores a claimed UA from a caller without the key", async () => {
+		// Same spoofing rule as the address: worth nothing unkeyed, so a
+		// scraper UA can't be borrowed to skip the counter.
+		const spoofer = "203.0.113.83";
+
+		await expectOk(
+			await get("/v1/tournaments", {
+				...ssrHeaders({
+					clientIp: spoofer,
+					clientUa: "Slackbot/1.0",
+					key: "not-the-key",
+				}),
+				"CF-Connecting-IP": spoofer,
+			}),
+		);
+
+		await expectEventsToReach("tournament_view", spoofer, 1);
 	});
 });

--- a/cloud/test/integration/ssr-trust.test.ts
+++ b/cloud/test/integration/ssr-trust.test.ts
@@ -1,0 +1,162 @@
+// Trusted server-rendered requests: who a read is counted against.
+//
+// per-ankh.app renders its pages in a Worker, and that Worker's subrequests
+// reach this API from Cloudflare's SSR egress — one address standing in for
+// every visitor at once. Left alone, every per-IP budget counts the whole
+// site into one bucket, which is how a crawl of /games/* spent the tournament
+// pages' hourly allowance on 2026-08-05.
+//
+// The frontend forwards the visitor's address and proves it's ours with
+// SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
+// cloud/src/util.ts), so a trusted request is counted against the visitor and
+// never against the egress — and an untrusted one can't claim an address it
+// doesn't have.
+
+import { applyD1Migrations, env, SELF } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import { expectOk } from "../helpers/assertions";
+import { ssrHeaders } from "../helpers/ssr-identity";
+
+beforeAll(async () => {
+	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
+});
+
+// The address every SSR subrequest in this file arrives from, standing in for
+// the production egress. Nothing should ever be counted against it.
+const EGRESS_IP = "203.0.113.200";
+
+async function countEvents(eventType: string, ip: string): Promise<number> {
+	const row = await env.SHARE_DB.prepare(
+		`SELECT COUNT(*) AS n FROM events
+		 WHERE event_type = ? AND ip_address = ?`,
+	)
+		.bind(eventType, ip)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+// The audit INSERT that spends a slot is fire-and-forget — the handler starts
+// it and returns without awaiting — so a count read straight after a response
+// can race it. Poll to the expected value, then assert it stayed there.
+async function expectEventsToReach(
+	eventType: string,
+	ip: string,
+	expected: number,
+): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if ((await countEvents(eventType, ip)) >= expected) break;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	expect(await countEvents(eventType, ip)).toBe(expected);
+}
+
+function get(path: string, headers: Record<string, string>): Promise<Response> {
+	return SELF.fetch(`http://test${path}`, { headers });
+}
+
+describe("forwarded visitor IP", () => {
+	it("counts a server-rendered read against the visitor, not the egress", async () => {
+		const visitor = "203.0.113.60";
+
+		await expectOk(
+			await get("/v1/tournaments", ssrHeaders({ clientIp: visitor })),
+		);
+
+		await expectEventsToReach("tournament_view", visitor, 1);
+		expect(await countEvents("tournament_view", EGRESS_IP)).toBe(0);
+	});
+
+	it("applies to every per-IP budget, not just the tournament one", async () => {
+		// The adoption happens once at the Worker's entry, so a read with its own
+		// unrelated limiter (anon_read, on the game endpoints) is attributed the
+		// same way without knowing forwarding exists.
+		const visitor = "203.0.113.61";
+
+		await expectOk(
+			await get("/v1/games/public-recent", ssrHeaders({ clientIp: visitor })),
+		);
+
+		await expectEventsToReach("anon_read", visitor, 1);
+		expect(await countEvents("anon_read", EGRESS_IP)).toBe(0);
+	});
+
+	it("ignores a forwarded address from a caller without the key", async () => {
+		// The spoofing case: anyone can send the header, so it has to be worth
+		// nothing without the key. The read is charged to the caller's own
+		// address, and the claimed victim's bucket is untouched.
+		const spoofer = "203.0.113.62";
+		const victim = "203.0.113.63";
+
+		await expectOk(
+			await get("/v1/tournaments", {
+				...ssrHeaders({ clientIp: victim, key: "not-the-key" }),
+				"CF-Connecting-IP": spoofer,
+			}),
+		);
+
+		await expectEventsToReach("tournament_view", spoofer, 1);
+		expect(await countEvents("tournament_view", victim)).toBe(0);
+	});
+
+	it("ignores forwarding entirely when this Worker has no key", async () => {
+		// The deploy window where the frontend ships forwarding first. Nothing
+		// is trusted, so everything counts the way it did before — including the
+		// key-bearing request, which is now just an ordinary caller.
+		const configured = env.SSR_TRUSTED_KEY;
+		try {
+			// @ts-expect-error — the binding is declared required; unsetting it is
+			// exactly the state under test.
+			delete env.SSR_TRUSTED_KEY;
+			const visitor = "203.0.113.64";
+
+			await expectOk(
+				await get("/v1/tournaments", ssrHeaders({ clientIp: visitor })),
+			);
+
+			await expectEventsToReach("tournament_view", EGRESS_IP, 1);
+			expect(await countEvents("tournament_view", visitor)).toBe(0);
+		} finally {
+			env.SSR_TRUSTED_KEY = configured;
+		}
+	});
+
+	it("attributes a trusted read without CF-RAY, and an untrusted one to nobody", async () => {
+		// CF-RAY is the "did this come through the edge" test, and it's not ours
+		// to guarantee on a Worker-to-Worker subrequest. A valid key answers the
+		// same question, so a trusted read still lands on the visitor...
+		const visitor = "203.0.113.66";
+		await expectOk(
+			await get(
+				"/v1/tournaments",
+				ssrHeaders({ clientIp: visitor, omitCfRay: true }),
+			),
+		);
+		await expectEventsToReach("tournament_view", visitor, 1);
+
+		// ...while a caller with no key and no CF-RAY still can't name itself:
+		// it goes to the shared "untrusted" bucket, exactly as before.
+		await expectOk(
+			await get("/v1/tournaments", { "CF-Connecting-IP": "203.0.113.67" }),
+		);
+		await expectEventsToReach("tournament_view", "untrusted", 1);
+		expect(await countEvents("tournament_view", "203.0.113.67")).toBe(0);
+	});
+
+	it("carries the request body through the rewrite", async () => {
+		// Adopting a forwarded address means handing the rest of the Worker a
+		// rebuilt Request, and a rebuilt Request that dropped its body would break
+		// every write silently. Malformed JSON is the discriminator: the handler
+		// answers 400 for a body it can't parse and 204 for no body at all, so a
+		// lost body would pass as success.
+		const res = await SELF.fetch("http://test/v1/csp-report", {
+			method: "POST",
+			headers: {
+				...ssrHeaders({ clientIp: "203.0.113.65" }),
+				"Content-Type": "application/csp-report",
+			},
+			body: "{ not json",
+		});
+
+		expect(res.status).toBe(400);
+	});
+});

--- a/cloud/test/integration/ssr-trust.test.ts
+++ b/cloud/test/integration/ssr-trust.test.ts
@@ -7,21 +7,24 @@
 // site into one bucket, which is how a crawl of /games/* spent the tournament
 // pages' hourly allowance on 2026-08-05.
 //
-// The frontend forwards the visitor's address and User-Agent and proves it's
-// ours with SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
-// cloud/src/util.ts). Three properties follow, and this file pins all three:
+// The frontend forwards the visitor's address and proves it's ours with
+// SSR_TRUSTED_KEY (src/hooks.server.ts → adoptTrustedFrontend in
+// cloud/src/util.ts). Four properties follow, and this file pins all four:
 //
 //   1. A trusted request is counted against the visitor, never the egress —
 //      and an untrusted one can't claim an address it doesn't have.
-//   2. A trusted page load spends one slot, not one per read: the entry read
-//      charges and the sub-resources ride along. A browser making the same
-//      reads directly pays for each, so no endpoint is free.
-//   3. The visitor's UA arrives too, which is what makes the scraper exemption
-//      reach the traffic it was written for — a link-preview unfurl is a
-//      server-rendered load and never anything else.
+//   2. That is the *only* thing the key buys. Every read is gated and charged
+//      the same for every caller, so a page load costs the same whether it was
+//      server-rendered or navigated to in a hydrated client.
+//   3. The address is all that's forwarded. The visitor's UA is not, because
+//      the scraper exemption it would switch on is keyed on a string the
+//      caller picks and skips the audit row as well as the gate.
+//   4. The rewrite preserves everything else about the request — body, and the
+//      edge `cf` metadata.
 
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { adoptTrustedFrontend } from "../../src/util";
 import { expectErrorCode, expectOk } from "../helpers/assertions";
 import { makeTournament } from "../helpers/builders";
 import { SSR_TRUSTED_TEST_KEY, ssrHeaders } from "../helpers/ssr-identity";
@@ -77,8 +80,8 @@ describe("forwarded visitor IP", () => {
 			await get("/v1/tournaments", ssrHeaders({ clientIp: visitor })),
 		);
 
-		await expectEventsToReach("tournament_view", visitor, 1);
-		expect(await countEvents("tournament_view", EGRESS_IP)).toBe(0);
+		await expectEventsToReach("tournament_list_view", visitor, 1);
+		expect(await countEvents("tournament_list_view", EGRESS_IP)).toBe(0);
 	});
 
 	it("applies to every per-IP budget, not just the tournament one", async () => {
@@ -109,8 +112,8 @@ describe("forwarded visitor IP", () => {
 			}),
 		);
 
-		await expectEventsToReach("tournament_view", spoofer, 1);
-		expect(await countEvents("tournament_view", victim)).toBe(0);
+		await expectEventsToReach("tournament_list_view", spoofer, 1);
+		expect(await countEvents("tournament_list_view", victim)).toBe(0);
 	});
 
 	it("ignores forwarding entirely when this Worker has no key", async () => {
@@ -128,8 +131,8 @@ describe("forwarded visitor IP", () => {
 				await get("/v1/tournaments", ssrHeaders({ clientIp: visitor })),
 			);
 
-			await expectEventsToReach("tournament_view", EGRESS_IP, 1);
-			expect(await countEvents("tournament_view", visitor)).toBe(0);
+			await expectEventsToReach("tournament_list_view", EGRESS_IP, 1);
+			expect(await countEvents("tournament_list_view", visitor)).toBe(0);
 		} finally {
 			env.SSR_TRUSTED_KEY = configured;
 		}
@@ -154,8 +157,8 @@ describe("forwarded visitor IP", () => {
 				}),
 			);
 
-			await expectEventsToReach("tournament_view", caller, 1);
-			expect(await countEvents("tournament_view", victim)).toBe(0);
+			await expectEventsToReach("tournament_list_view", caller, 1);
+			expect(await countEvents("tournament_list_view", victim)).toBe(0);
 		} finally {
 			env.SSR_TRUSTED_KEY = configured;
 		}
@@ -178,7 +181,7 @@ describe("forwarded visitor IP", () => {
 			}),
 		);
 
-		await expectEventsToReach("tournament_view", egress, 1);
+		await expectEventsToReach("tournament_list_view", egress, 1);
 	});
 
 	it("attributes a trusted read without CF-RAY, and an untrusted one to nobody", async () => {
@@ -192,15 +195,15 @@ describe("forwarded visitor IP", () => {
 				ssrHeaders({ clientIp: visitor, omitCfRay: true }),
 			),
 		);
-		await expectEventsToReach("tournament_view", visitor, 1);
+		await expectEventsToReach("tournament_list_view", visitor, 1);
 
 		// ...while a caller with no key and no CF-RAY still can't name itself:
 		// it goes to the shared "untrusted" bucket, exactly as before.
 		await expectOk(
 			await get("/v1/tournaments", { "CF-Connecting-IP": "203.0.113.67" }),
 		);
-		await expectEventsToReach("tournament_view", "untrusted", 1);
-		expect(await countEvents("tournament_view", "203.0.113.67")).toBe(0);
+		await expectEventsToReach("tournament_list_view", "untrusted", 1);
+		expect(await countEvents("tournament_list_view", "203.0.113.67")).toBe(0);
 	});
 
 	it("carries the request body through the rewrite", async () => {
@@ -222,8 +225,8 @@ describe("forwarded visitor IP", () => {
 	});
 });
 
-describe("one page load, one slot", () => {
-	it("charges a trusted page load once across its four reads", async () => {
+describe("what a page load costs", () => {
+	it("charges a trusted page load for every read it makes", async () => {
 		const t = await makeTournament({
 			slug: "ssr-page-load",
 			advanceTo: "swiss-round-1-generated",
@@ -244,16 +247,16 @@ describe("one page load, one slot", () => {
 			await get(`/v1/tournaments/${t.tournamentId}/matches`, headers),
 		);
 
-		// One visitor action, one slot — the entry read's. Before this, the same
-		// page load spent four, so ~150 cold loads exhausted the hourly budget
-		// for the whole site.
-		await expectEventsToReach("tournament_view", visitor, 1);
+		// Four reads, four slots. The trust marker settles which visitor the
+		// rows belong to and nothing about what they cost — a page load is the
+		// same price however the reads arrived.
+		await expectEventsToReach("tournament_view", visitor, 4);
 	});
 
-	it("charges a browser for every read it makes directly", async () => {
-		// The same four reads without the trust marker — a hydrated navigation,
-		// or anyone hitting the API by hand. Riding along is a property of a
-		// server-rendered page load, not of the endpoints.
+	it("charges a browser exactly the same for the same four reads", async () => {
+		// The identical sequence without the trust marker — a hydrated
+		// navigation, or anyone hitting the API by hand. The two must agree, or
+		// the ceiling means page loads on one path and reads on the other.
 		const t = await makeTournament({
 			slug: "ssr-page-load-direct",
 			advanceTo: "swiss-round-1-generated",
@@ -278,7 +281,8 @@ describe("one page load, one slot", () => {
 	it("does not let a caller declare itself trusted", async () => {
 		// X-SSR-Trusted is this Worker's own verdict; adoptTrustedFrontend strips
 		// it off every inbound request before deciding. A caller setting it must
-		// gain nothing — so this read is still charged.
+		// gain nothing — including nothing it could gain here, now that trust
+		// buys no discount at all.
 		const t = await makeTournament({
 			slug: "ssr-self-declared",
 			advanceTo: "swiss-round-1-generated",
@@ -302,10 +306,7 @@ describe("the ceiling is what an over-budget visitor meets", () => {
 		env.TOURNAMENT_VIEW_PER_HOUR = configured;
 	});
 
-	it("429s the entry read, which is the one the page can't render without", async () => {
-		// Riding along means a rider is neither charged nor counted, so what
-		// stops an over-budget visitor is the entry read — and it has to, since
-		// nothing downstream of it re-checks.
+	it("429s a server-rendered read once the budget is spent", async () => {
 		env.TOURNAMENT_VIEW_PER_HOUR = "1";
 		const t = await makeTournament({
 			slug: "ssr-entry-gate",
@@ -314,131 +315,131 @@ describe("the ceiling is what an over-budget visitor meets", () => {
 		const visitor = "203.0.113.73";
 		const headers = ssrHeaders({ clientIp: visitor });
 
-		// The first page load spends the only slot...
 		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
 		await expectEventsToReach("tournament_view", visitor, 1);
 
-		// ...and the next one is refused before it renders anything.
 		await expectErrorCode(await get(`/v1/tournaments/${t.slug}`, headers), {
 			status: 429,
 			code: "RATE_LIMIT_TOURNAMENT_VIEW",
 		});
 	});
 
-	it("still gates a rider read that isn't riding on anything", async () => {
-		// Untrusted callers get no short-circuit: /standings on its own is a
-		// read like any other, gated and charged, however many the caller has
-		// already spent.
+	it("gates a sub-resource read on its own, trusted or not", async () => {
+		// /standings reached directly is a read like any other. It was briefly
+		// exempt for our own SSR Worker; the pair below is what pins that the
+		// two callers now meet the ceiling identically.
 		env.TOURNAMENT_VIEW_PER_HOUR = "1";
 		const t = await makeTournament({
-			slug: "ssr-rider-direct-gate",
+			slug: "ssr-subresource-gate",
 			advanceTo: "swiss-round-1-generated",
 		});
-		const visitor = "203.0.113.74";
-		const headers = directHeaders(visitor);
 
+		const direct = "203.0.113.74";
+		await expectOk(
+			await get(`/v1/tournaments/${t.slug}`, directHeaders(direct)),
+		);
+		await expectEventsToReach("tournament_view", direct, 1);
+		await expectErrorCode(
+			await get(
+				`/v1/tournaments/${t.tournamentId}/standings`,
+				directHeaders(direct),
+			),
+			{ status: 429, code: "RATE_LIMIT_TOURNAMENT_VIEW" },
+		);
+
+		const trusted = "203.0.113.75";
+		const headers = ssrHeaders({ clientIp: trusted });
 		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
-		await expectEventsToReach("tournament_view", visitor, 1);
-
+		await expectEventsToReach("tournament_view", trusted, 1);
 		await expectErrorCode(
 			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
 			{ status: 429, code: "RATE_LIMIT_TOURNAMENT_VIEW" },
 		);
 	});
-
-	it("charges a trusted rider nothing, even with the budget wide open", async () => {
-		// The counter side of riding along: the sub-resource reads leave no
-		// rows at all, so the visitor's bucket holds page loads and not reads.
-		const t = await makeTournament({
-			slug: "ssr-rider-uncharged",
-			advanceTo: "swiss-round-1-generated",
-		});
-		const visitor = "203.0.113.75";
-		const headers = ssrHeaders({ clientIp: visitor });
-
-		await expectOk(
-			await get(`/v1/tournaments/${t.tournamentId}/standings`, headers),
-		);
-		await expectOk(
-			await get(`/v1/tournaments/${t.tournamentId}/bracket`, headers),
-		);
-
-		// Followed by an entry read, so the assertion is on a settled count
-		// rather than on a row that simply hasn't been written yet: exactly one
-		// row exists, and it's the entry read's.
-		await expectOk(await get(`/v1/tournaments/${t.slug}`, headers));
-		await expectEventsToReach("tournament_view", visitor, 1);
-	});
 });
 
-describe("forwarded visitor User-Agent", () => {
-	// The scraper exemption exists for link-preview crawlers, and an unfurl is
-	// always a server-rendered load — so it only ever applies to a request that
-	// arrived through forwarding. Without the UA riding along with the address,
-	// the exemption covers nothing that actually happens in production.
-	it("exempts a scraper whose UA arrived over the SSR hop", async () => {
+describe("the visitor's User-Agent is not forwarded", () => {
+	// The address is forwarded; the UA deliberately isn't. Carrying it would
+	// switch on the scraper exemption in games.ts for site traffic, and that
+	// exemption is keyed on a string the caller picks and is granted before
+	// both the gate and the audit INSERT — so `User-Agent: Discordbot/2.0`
+	// would be an unmetered *and* unlogged path through every read budget. The
+	// tests below are the regression guard on that decision: a request may not
+	// buy the exemption by claiming a UA, keyed or not.
+	it("does not honour a scraper UA claimed over the SSR hop", async () => {
 		const crawler = "203.0.113.80";
-		const headers = ssrHeaders({ clientIp: crawler });
 
 		await expectOk(
 			await get("/v1/tournaments", {
-				...headers,
+				...ssrHeaders({ clientIp: crawler }),
 				"X-SSR-Client-UA": "Twitterbot/1.0",
 			}),
 		);
 
-		// An ordinary read from the same address afterwards, so the count this
-		// settles on is one that has actually been written: if the crawler's
-		// read had been charged, this would find two rows.
-		await expectOk(await get("/v1/tournaments", headers));
-		await expectEventsToReach("tournament_view", crawler, 1);
+		// Charged like any other visitor. A row here is also what proves the
+		// read stayed *visible*: the exemption skips the INSERT, so an exempted
+		// read leaves nothing for the incident query in docs/cloudflare-waf.md.
+		await expectEventsToReach("tournament_list_view", crawler, 1);
 	});
 
-	it("applies to every budget that reads the UA, not just the tournament one", async () => {
+	it("does not honour one on a budget with its own limiter either", async () => {
+		// Same rule wherever the exemption is read — the adoption happens once at
+		// the Worker's entry, so anon_read on the game endpoints must not see a
+		// forwarded UA any more than the tournament budgets do.
 		const crawler = "203.0.113.81";
-		const headers = ssrHeaders({ clientIp: crawler });
 
 		await expectOk(
 			await get("/v1/games/public-recent", {
-				...headers,
+				...ssrHeaders({ clientIp: crawler }),
 				"X-SSR-Client-UA": "Discordbot/2.0 (+https://discordapp.com)",
 			}),
 		);
 
-		await expectOk(await get("/v1/games/public-recent", headers));
 		await expectEventsToReach("anon_read", crawler, 1);
 	});
 
-	it("counts a forwarded browser UA like any other visitor", async () => {
-		// The other half: forwarding a UA must not exempt anything by itself.
-		const visitor = "203.0.113.82";
-
-		await expectOk(
-			await get(
-				"/v1/tournaments",
-				ssrHeaders({ clientIp: visitor, clientUa: "Mozilla/5.0" }),
-			),
-		);
-
-		await expectEventsToReach("tournament_view", visitor, 1);
-	});
-
-	it("ignores a claimed UA from a caller without the key", async () => {
-		// Same spoofing rule as the address: worth nothing unkeyed, so a
-		// scraper UA can't be borrowed to skip the counter.
-		const spoofer = "203.0.113.83";
-
-		await expectOk(
-			await get("/v1/tournaments", {
-				...ssrHeaders({
-					clientIp: spoofer,
-					clientUa: "Slackbot/1.0",
-					key: "not-the-key",
-				}),
-				"CF-Connecting-IP": spoofer,
+	it("leaves the real User-Agent alone on a trusted request", async () => {
+		// Adoption swaps the address and nothing else. Whatever UA a handler
+		// reads is the one that arrived on the wire — there is no header a caller
+		// can send that replaces it, which is what keeps the scraper exemption
+		// out of reach of the SSR path.
+		const adopted = adoptTrustedFrontend(
+			new Request("http://test/v1/tournaments", {
+				headers: {
+					...ssrHeaders({ clientIp: "203.0.113.82" }),
+					"User-Agent": "SvelteKit-SSR",
+					"X-SSR-Client-UA": "Slackbot/1.0",
+				},
 			}),
+			{ SSR_TRUSTED_KEY: SSR_TRUSTED_TEST_KEY },
 		);
 
-		await expectEventsToReach("tournament_view", spoofer, 1);
+		expect(adopted.headers.get("User-Agent")).toBe("SvelteKit-SSR");
+	});
+});
+
+describe("edge metadata", () => {
+	it("preserves the edge cf metadata across the rewrite", async () => {
+		// Adopting a forwarded address hands the rest of the Worker a rebuilt
+		// Request, and `cf` is not inherited by the constructor. The rewrite runs
+		// for anyone presenting an SSR header — including a junk one — so a
+		// dropped `cf` would let `X-SSR-Key: anything` delete a caller's own
+		// country/ASN/bot-score before a handler could read it.
+		//
+		// Asserted on the request object rather than through SELF.fetch: the
+		// access log builds its context from the *inbound* request (log.ts), so
+		// nothing downstream can witness the rewrite today. That's the point —
+		// this pins the property before something starts depending on it.
+		const inbound = new Request("http://test/v1/tournaments", {
+			headers: ssrHeaders({ clientIp: "203.0.113.85" }),
+			cf: { colo: "LHR", asOrganization: "Example ISP" },
+		} as RequestInit);
+
+		const adopted = adoptTrustedFrontend(inbound, {
+			SSR_TRUSTED_KEY: SSR_TRUSTED_TEST_KEY,
+		});
+
+		expect(adopted.headers.get("CF-Connecting-IP")).toBe("203.0.113.85");
+		expect(adopted.cf?.colo).toBe("LHR");
 	});
 });

--- a/cloud/test/integration/tournament/rate-limit-view.test.ts
+++ b/cloud/test/integration/tournament/rate-limit-view.test.ts
@@ -251,4 +251,35 @@ describe("game tournament-link rate limit", () => {
 
 		await expectOk(await get(linkPath(), { ip, ua: "Twitterbot/1.0" }));
 	});
+
+	// Its own knob, not the view one: the incident that drains this budget is
+	// the incident an operator is retuning during, and the two must move
+	// independently or the split they're built on is undone by the fix.
+	describe("ceiling is env-tunable", () => {
+		const configured = env.TOURNAMENT_LINK_VIEW_PER_HOUR;
+		afterEach(() => {
+			env.TOURNAMENT_LINK_VIEW_PER_HOUR = configured;
+		});
+
+		it("gates at its own env value, leaving the view ceiling alone", async () => {
+			env.TOURNAMENT_LINK_VIEW_PER_HOUR = "5";
+
+			const ip = "203.0.113.45";
+			await seedEvents("tournament_link_view", ip, 5);
+			await expectErrorCode(await get(linkPath(), { ip }), {
+				status: 429,
+				code: "RATE_LIMIT_TOURNAMENT_LINK",
+			});
+
+			// Same IP, same moment: the tournament pages are gated by the other
+			// var, which this override didn't touch.
+			await expectOk(await get("/v1/tournaments", { ip }));
+		});
+
+		it("wrangler.toml's configured value is what the gate uses by default", async () => {
+			expect(env.TOURNAMENT_LINK_VIEW_PER_HOUR).toBe(
+				String(TOURNAMENT_LINK_VIEW_PER_HOUR),
+			);
+		});
+	});
 });

--- a/cloud/test/integration/tournament/rate-limit-view.test.ts
+++ b/cloud/test/integration/tournament/rate-limit-view.test.ts
@@ -1,43 +1,119 @@
-// Tournament-view rate limit: 600/hour/IP across the tournament read
-// endpoints. The limit applies to every caller — anonymous and signed-in
-// alike. Scraper User-Agents (Discord/Slack/Twitter previewers) are exempt
-// from the limit so link unfurls always resolve.
+// Per-IP read limits on the tournament surface. Two independent budgets:
+//
+//   tournament_view       — the tournament read endpoints (list, detail,
+//                           standings, bracket, rounds, matches, stats).
+//                           Ceiling from the TOURNAMENT_VIEW_PER_HOUR var,
+//                           defaulting to the constant of the same name.
+//   tournament_link_view  — GET /v1/games/:id/tournament-link, called on every
+//                           /games/[id] render.
+//
+// The split is the fix for the 2026-08-05 outage (#196): the link read used to
+// charge the tournament budget, so a crawl of ~270 game pages a minute spent
+// the tournament pages' whole hourly allowance and 429'd them. The tests below
+// pin both halves — that each budget is enforced *and recorded* on its own
+// path, and that draining one leaves the other alone.
+//
+// Both limits apply to every caller — anonymous and signed-in alike. Scraper
+// User-Agents (Discord/Slack/Twitter previewers) are exempt so link unfurls
+// always resolve.
 
 import { applyD1Migrations, env, SELF } from "cloudflare:test";
-import { beforeAll, describe, it } from "vitest";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { nanoid } from "nanoid";
 import { expectErrorCode, expectOk } from "../../helpers/assertions";
 import { makeTournament } from "../../helpers/builders";
-import { TOURNAMENT_VIEW_PER_HOUR } from "../../../src/tournament/limits";
+import {
+	TOURNAMENT_LINK_VIEW_PER_HOUR,
+	TOURNAMENT_VIEW_PER_HOUR,
+	tournamentViewPerHour,
+} from "../../../src/tournament/limits";
 
 beforeAll(async () => {
 	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
 });
 
-async function seedViewEvents(ip: string, count: number): Promise<void> {
-	for (let i = 0; i < count; i++) {
-		await env.SHARE_DB.prepare(
-			`INSERT INTO events (event_type, ip_address) VALUES ('tournament_view', ?)`,
-		)
-			.bind(ip)
-			.run();
-	}
+type ReadEventType = "tournament_view" | "tournament_link_view";
+
+// Fill an IP's hourly bucket for one event type without firing N real reads.
+//
+// One statement, not a row-per-await loop: this file seeds several full
+// buckets, and per-row seeding puts enough extra work through the shared test
+// runtime to start tipping already-marginal timing-sensitive tests in *other*
+// files into timeouts. Same recursive CTE, and the same reason, as the sibling
+// anon_read test (games/anon-read-rate-limit.test.ts seedAnonReads).
+async function seedEvents(
+	eventType: ReadEventType,
+	ip: string,
+	count: number,
+): Promise<void> {
+	await env.SHARE_DB.prepare(
+		`INSERT INTO events (event_type, ip_address)
+		 WITH RECURSIVE seq(i) AS (
+		   SELECT 1 UNION ALL SELECT i + 1 FROM seq WHERE i < ?
+		 )
+		 SELECT ?, ? FROM seq`,
+	)
+		.bind(count, eventType, ip)
+		.run();
 }
+
+async function countEvents(
+	eventType: ReadEventType,
+	ip: string,
+): Promise<number> {
+	const row = await env.SHARE_DB.prepare(
+		`SELECT COUNT(*) AS n FROM events
+		 WHERE event_type = ? AND ip_address = ?`,
+	)
+		.bind(eventType, ip)
+		.first<{ n: number }>();
+	return row?.n ?? 0;
+}
+
+// The audit INSERT that spends a budget slot is fire-and-forget — the handler
+// starts it and returns without awaiting, so it can land after the response.
+// Poll rather than assert once.
+async function expectEventsToReach(
+	eventType: ReadEventType,
+	ip: string,
+	expected: number,
+): Promise<void> {
+	for (let i = 0; i < 50; i++) {
+		if ((await countEvents(eventType, ip)) >= expected) break;
+		await new Promise((resolve) => setTimeout(resolve, 10));
+	}
+	expect(await countEvents(eventType, ip)).toBe(expected);
+}
+
+// getClientIp ignores CF-Connecting-IP unless CF-RAY is present (an untrusted
+// topology collapses to one shared bucket, which would make these tests
+// interfere), so every request here carries both.
+function get(
+	path: string,
+	opts: { ip: string; ua?: string },
+): Promise<Response> {
+	const headers: Record<string, string> = {
+		"CF-Connecting-IP": opts.ip,
+		"CF-RAY": "test-ray",
+	};
+	if (opts.ua) headers["User-Agent"] = opts.ua;
+	return SELF.fetch(`http://test${path}`, { headers });
+}
+
+// An unlinked game still exercises the whole gate: the link handler charges
+// the budget before it knows whether the game is linked, which is the property
+// that made the shared budget an outage.
+const linkPath = () => `/v1/games/${nanoid(21)}/tournament-link`;
 
 describe("tournament view rate limit", () => {
 	it("returns 429 once the per-IP limit is reached (anonymous caller)", async () => {
 		const t = await makeTournament({ slug: "rl-view-test-a" });
 		const ip = "203.0.113.10";
-		await seedViewEvents(ip, TOURNAMENT_VIEW_PER_HOUR);
+		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
 
 		// The rate-limit check runs before the setup-visibility check, so an
 		// over-limit anonymous request 429s regardless of the tournament phase.
-		const res = await SELF.fetch(`http://test/v1/tournaments/${t.slug}`, {
-			headers: {
-				"CF-Connecting-IP": ip,
-				"CF-RAY": "test-ray",
-			},
-		});
-		await expectErrorCode(res, {
+		await expectErrorCode(await get(`/v1/tournaments/${t.slug}`, { ip }), {
 			status: 429,
 			code: "RATE_LIMIT_TOURNAMENT_VIEW",
 		});
@@ -49,32 +125,130 @@ describe("tournament view rate limit", () => {
 			advanceTo: "swiss-round-1-generated",
 		});
 		const ip = "203.0.113.11";
-		await seedViewEvents(ip, TOURNAMENT_VIEW_PER_HOUR);
+		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
 
 		// Scraper UAs bypass the limit, so the public read proceeds even though
 		// this IP is over the cap.
-		const res = await SELF.fetch(`http://test/v1/tournaments/${t.slug}`, {
-			headers: {
-				"CF-Connecting-IP": ip,
-				"CF-RAY": "test-ray",
-				"User-Agent": "Twitterbot/1.0",
-			},
-		});
-		await expectOk(res);
+		await expectOk(
+			await get(`/v1/tournaments/${t.slug}`, { ip, ua: "Twitterbot/1.0" }),
+		);
 	});
 
 	it("limit applies to GET /v1/tournaments (list) too", async () => {
 		const ip = "203.0.113.12";
-		await seedViewEvents(ip, TOURNAMENT_VIEW_PER_HOUR);
-		const res = await SELF.fetch(`http://test/v1/tournaments`, {
-			headers: {
-				"CF-Connecting-IP": ip,
-				"CF-RAY": "test-ray",
-			},
-		});
-		await expectErrorCode(res, {
+		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
+		await expectErrorCode(await get("/v1/tournaments", { ip }), {
 			status: 429,
 			code: "RATE_LIMIT_TOURNAMENT_VIEW",
 		});
+	});
+});
+
+// The ceiling is read off env on every request so an operator can retune it
+// during a live event with `wrangler secret put TOURNAMENT_VIEW_PER_HOUR`
+// instead of a redeploy. Substituting the binding here is what that does.
+describe("tournament view ceiling is env-tunable", () => {
+	const configured = env.TOURNAMENT_VIEW_PER_HOUR;
+	afterEach(() => {
+		env.TOURNAMENT_VIEW_PER_HOUR = configured;
+	});
+
+	it("gates at the env value rather than the compiled-in default", async () => {
+		env.TOURNAMENT_VIEW_PER_HOUR = "5";
+
+		// One below the override — far below the constant either way.
+		const under = "203.0.113.30";
+		await seedEvents("tournament_view", under, 4);
+		await expectOk(await get("/v1/tournaments", { ip: under }));
+
+		const at = "203.0.113.31";
+		await seedEvents("tournament_view", at, 5);
+		await expectErrorCode(await get("/v1/tournaments", { ip: at }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_VIEW",
+		});
+	});
+
+	it("falls back to the constant when the var doesn't parse", async () => {
+		// Neither open (a NaN ceiling that never fires) nor shut (a 0 ceiling
+		// that 429s everyone) — a mangled value must land exactly where the
+		// unset var does.
+		env.TOURNAMENT_VIEW_PER_HOUR = "600 per hour";
+
+		const under = "203.0.113.32";
+		await seedEvents("tournament_view", under, TOURNAMENT_VIEW_PER_HOUR - 1);
+		await expectOk(await get("/v1/tournaments", { ip: under }));
+
+		const at = "203.0.113.33";
+		await seedEvents("tournament_view", at, TOURNAMENT_VIEW_PER_HOUR);
+		await expectErrorCode(await get("/v1/tournaments", { ip: at }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_VIEW",
+		});
+	});
+
+	it("wrangler.toml's configured value is what the gate uses by default", async () => {
+		// The var ships set in both [vars] blocks, so the deployed ceiling is
+		// that number, not the constant. They agree today; this fails if the two
+		// are ever changed apart.
+		expect(tournamentViewPerHour(env)).toBe(TOURNAMENT_VIEW_PER_HOUR);
+	});
+});
+
+describe("game tournament-link rate limit", () => {
+	it("records a tournament_link_view for a served read", async () => {
+		const ip = "203.0.113.40";
+
+		const body = await expectOk<{ link: null }>(await get(linkPath(), { ip }));
+		expect(body.link).toBeNull();
+
+		// Reading consumes a slot of its own budget — the guard that keeps the
+		// limit from being a no-op on this route now that it no longer records
+		// to the tournament one.
+		await expectEventsToReach("tournament_link_view", ip, 1);
+		// ...and it consumes nothing of the tournament budget. This is the
+		// outage: 600 of these used to leave the tournament pages with none.
+		expect(await countEvents("tournament_view", ip)).toBe(0);
+	});
+
+	it("429s once its own per-IP limit is reached", async () => {
+		const ip = "203.0.113.41";
+		await seedEvents("tournament_link_view", ip, TOURNAMENT_LINK_VIEW_PER_HOUR);
+
+		await expectErrorCode(await get(linkPath(), { ip }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_LINK",
+		});
+	});
+
+	it("serves the link read on an IP whose tournament budget is spent", async () => {
+		const ip = "203.0.113.42";
+		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
+
+		await expectOk(await get(linkPath(), { ip }));
+	});
+
+	it("leaves the tournament pages up when the link budget is drained", async () => {
+		const t = await makeTournament({
+			slug: "rl-link-test",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const ip = "203.0.113.43";
+		await seedEvents("tournament_link_view", ip, TOURNAMENT_LINK_VIEW_PER_HOUR);
+
+		// The crawler's own endpoint is capped...
+		await expectErrorCode(await get(linkPath(), { ip }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_LINK",
+		});
+		// ...and the tournament page it used to take down still serves.
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip }));
+	});
+
+	it("scraper User-Agent is exempt from the limit", async () => {
+		const ip = "203.0.113.44";
+		await seedEvents("tournament_link_view", ip, TOURNAMENT_LINK_VIEW_PER_HOUR);
+
+		await expectOk(await get(linkPath(), { ip, ua: "Twitterbot/1.0" }));
 	});
 });

--- a/cloud/test/integration/tournament/rate-limit-view.test.ts
+++ b/cloud/test/integration/tournament/rate-limit-view.test.ts
@@ -191,6 +191,13 @@ describe("tournament view ceiling is env-tunable", () => {
 		// The var ships set in both [vars] blocks, so the deployed ceiling is
 		// that number, not the constant. They agree today; this fails if the two
 		// are ever changed apart.
+		//
+		// Asserted on the binding, not through tournamentViewPerHour(): every
+		// way the var can be missing or mangled resolves to the constant, so
+		// routing this through the fallback would pass with no var at all —
+		// which is the one thing it exists to catch. Same shape as the link
+		// budget's below.
+		expect(env.TOURNAMENT_VIEW_PER_HOUR).toBe(String(TOURNAMENT_VIEW_PER_HOUR));
 		expect(tournamentViewPerHour(env)).toBe(TOURNAMENT_VIEW_PER_HOUR);
 	});
 });

--- a/cloud/test/integration/tournament/rate-limit-view.test.ts
+++ b/cloud/test/integration/tournament/rate-limit-view.test.ts
@@ -1,19 +1,24 @@
-// Per-IP read limits on the tournament surface. Two independent budgets:
+// Per-IP read limits on the tournament surface. Three independent budgets:
 //
-//   tournament_view       — the tournament read endpoints (list, detail,
-//                           standings, bracket, rounds, matches, stats).
+//   tournament_view       — a tournament page load: the detail read plus
+//                           standings, bracket, rounds, matches and stats.
 //                           Ceiling from the TOURNAMENT_VIEW_PER_HOUR var,
 //                           defaulting to the constant of the same name.
+//   tournament_list_view  — GET /v1/tournaments, which the *home page* fetches
+//                           on every render as well as /tournaments.
 //   tournament_link_view  — GET /v1/games/:id/tournament-link, called on every
 //                           /games/[id] render.
 //
-// The split is the fix for the 2026-08-05 outage (#196): the link read used to
-// charge the tournament budget, so a crawl of ~270 game pages a minute spent
-// the tournament pages' whole hourly allowance and 429'd them. The tests below
-// pin both halves — that each budget is enforced *and recorded* on its own
-// path, and that draining one leaves the other alone.
+// The splits are the fix for the 2026-08-05 outage (#196) and its sibling: a
+// read that a high-traffic page makes on every render must not share a budget
+// with the pages it can take down. The link read charged the tournament budget,
+// so a crawl of ~270 game pages a minute spent the tournament pages' whole
+// hourly allowance and 429'd them; the list read had the same relationship to
+// the home page. The tests below pin all three — that each budget is enforced
+// *and recorded* on its own path, and that draining one leaves the others
+// alone.
 //
-// Both limits apply to every caller — anonymous and signed-in alike. Scraper
+// Every limit applies to every caller — anonymous and signed-in alike. Scraper
 // User-Agents (Discord/Slack/Twitter previewers) are exempt so link unfurls
 // always resolve.
 
@@ -24,6 +29,7 @@ import { expectErrorCode, expectOk } from "../../helpers/assertions";
 import { makeTournament } from "../../helpers/builders";
 import {
 	TOURNAMENT_LINK_VIEW_PER_HOUR,
+	TOURNAMENT_LIST_VIEW_PER_HOUR,
 	TOURNAMENT_VIEW_PER_HOUR,
 	tournamentViewPerHour,
 } from "../../../src/tournament/limits";
@@ -32,7 +38,10 @@ beforeAll(async () => {
 	await applyD1Migrations(env.SHARE_DB, env.TEST_MIGRATIONS);
 });
 
-type ReadEventType = "tournament_view" | "tournament_link_view";
+type ReadEventType =
+	| "tournament_view"
+	| "tournament_list_view"
+	| "tournament_link_view";
 
 // Fill an IP's hourly bucket for one event type without firing N real reads.
 //
@@ -134,13 +143,20 @@ describe("tournament view rate limit", () => {
 		);
 	});
 
-	it("limit applies to GET /v1/tournaments (list) too", async () => {
+	it("limit applies to the sub-resource reads behind a page load too", async () => {
+		const t = await makeTournament({
+			slug: "rl-view-test-c",
+			advanceTo: "swiss-round-1-generated",
+		});
 		const ip = "203.0.113.12";
 		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
-		await expectErrorCode(await get("/v1/tournaments", { ip }), {
-			status: 429,
-			code: "RATE_LIMIT_TOURNAMENT_VIEW",
-		});
+
+		// Riders are gated for anyone who isn't our SSR Worker, so a spent budget
+		// is met the same way whichever read of the page arrives first.
+		await expectErrorCode(
+			await get(`/v1/tournaments/${t.tournamentId}/standings`, { ip }),
+			{ status: 429, code: "RATE_LIMIT_TOURNAMENT_VIEW" },
+		);
 	});
 });
 
@@ -154,16 +170,20 @@ describe("tournament view ceiling is env-tunable", () => {
 	});
 
 	it("gates at the env value rather than the compiled-in default", async () => {
+		const t = await makeTournament({
+			slug: "rl-view-tune-a",
+			advanceTo: "swiss-round-1-generated",
+		});
 		env.TOURNAMENT_VIEW_PER_HOUR = "5";
 
 		// One below the override — far below the constant either way.
 		const under = "203.0.113.30";
 		await seedEvents("tournament_view", under, 4);
-		await expectOk(await get("/v1/tournaments", { ip: under }));
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip: under }));
 
 		const at = "203.0.113.31";
 		await seedEvents("tournament_view", at, 5);
-		await expectErrorCode(await get("/v1/tournaments", { ip: at }), {
+		await expectErrorCode(await get(`/v1/tournaments/${t.slug}`, { ip: at }), {
 			status: 429,
 			code: "RATE_LIMIT_TOURNAMENT_VIEW",
 		});
@@ -173,15 +193,19 @@ describe("tournament view ceiling is env-tunable", () => {
 		// Neither open (a NaN ceiling that never fires) nor shut (a 0 ceiling
 		// that 429s everyone) — a mangled value must land exactly where the
 		// unset var does.
+		const t = await makeTournament({
+			slug: "rl-view-tune-b",
+			advanceTo: "swiss-round-1-generated",
+		});
 		env.TOURNAMENT_VIEW_PER_HOUR = "600 per hour";
 
 		const under = "203.0.113.32";
 		await seedEvents("tournament_view", under, TOURNAMENT_VIEW_PER_HOUR - 1);
-		await expectOk(await get("/v1/tournaments", { ip: under }));
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip: under }));
 
 		const at = "203.0.113.33";
 		await seedEvents("tournament_view", at, TOURNAMENT_VIEW_PER_HOUR);
-		await expectErrorCode(await get("/v1/tournaments", { ip: at }), {
+		await expectErrorCode(await get(`/v1/tournaments/${t.slug}`, { ip: at }), {
 			status: 429,
 			code: "RATE_LIMIT_TOURNAMENT_VIEW",
 		});
@@ -199,6 +223,92 @@ describe("tournament view ceiling is env-tunable", () => {
 		// budget's below.
 		expect(env.TOURNAMENT_VIEW_PER_HOUR).toBe(String(TOURNAMENT_VIEW_PER_HOUR));
 		expect(tournamentViewPerHour(env)).toBe(TOURNAMENT_VIEW_PER_HOUR);
+	});
+});
+
+describe("tournament list rate limit", () => {
+	it("records a tournament_list_view for a served read", async () => {
+		const ip = "203.0.113.50";
+
+		await expectOk(await get("/v1/tournaments", { ip }));
+
+		await expectEventsToReach("tournament_list_view", ip, 1);
+		// And nothing of the tournament pages' budget — the whole point of the
+		// split, since the home page makes this read on every render.
+		expect(await countEvents("tournament_view", ip)).toBe(0);
+	});
+
+	it("429s once its own per-IP limit is reached", async () => {
+		const ip = "203.0.113.51";
+		await seedEvents("tournament_list_view", ip, TOURNAMENT_LIST_VIEW_PER_HOUR);
+
+		await expectErrorCode(await get("/v1/tournaments", { ip }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_LIST",
+		});
+	});
+
+	it("leaves the tournament pages up when the list budget is drained", async () => {
+		const t = await makeTournament({
+			slug: "rl-list-test",
+			advanceTo: "swiss-round-1-generated",
+		});
+		const ip = "203.0.113.52";
+		await seedEvents("tournament_list_view", ip, TOURNAMENT_LIST_VIEW_PER_HOUR);
+
+		// A visitor who has exhausted the home page's read...
+		await expectErrorCode(await get("/v1/tournaments", { ip }), {
+			status: 429,
+			code: "RATE_LIMIT_TOURNAMENT_LIST",
+		});
+		// ...can still open a tournament.
+		await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip }));
+	});
+
+	it("serves the list read on an IP whose tournament budget is spent", async () => {
+		const ip = "203.0.113.53";
+		await seedEvents("tournament_view", ip, TOURNAMENT_VIEW_PER_HOUR);
+
+		await expectOk(await get("/v1/tournaments", { ip }));
+	});
+
+	it("scraper User-Agent is exempt from the limit", async () => {
+		const ip = "203.0.113.54";
+		await seedEvents("tournament_list_view", ip, TOURNAMENT_LIST_VIEW_PER_HOUR);
+
+		await expectOk(await get("/v1/tournaments", { ip, ua: "Twitterbot/1.0" }));
+	});
+
+	describe("ceiling is env-tunable", () => {
+		const configured = env.TOURNAMENT_LIST_VIEW_PER_HOUR;
+		afterEach(() => {
+			env.TOURNAMENT_LIST_VIEW_PER_HOUR = configured;
+		});
+
+		it("gates at its own env value, leaving the view ceiling alone", async () => {
+			const t = await makeTournament({
+				slug: "rl-list-tune",
+				advanceTo: "swiss-round-1-generated",
+			});
+			env.TOURNAMENT_LIST_VIEW_PER_HOUR = "5";
+
+			const ip = "203.0.113.55";
+			await seedEvents("tournament_list_view", ip, 5);
+			await expectErrorCode(await get("/v1/tournaments", { ip }), {
+				status: 429,
+				code: "RATE_LIMIT_TOURNAMENT_LIST",
+			});
+
+			// Same IP, same moment: the tournament pages are gated by the other
+			// var, which this override didn't touch.
+			await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip }));
+		});
+
+		it("wrangler.toml's configured value is what the gate uses by default", async () => {
+			expect(env.TOURNAMENT_LIST_VIEW_PER_HOUR).toBe(
+				String(TOURNAMENT_LIST_VIEW_PER_HOUR),
+			);
+		});
 	});
 });
 
@@ -278,9 +388,13 @@ describe("game tournament-link rate limit", () => {
 				code: "RATE_LIMIT_TOURNAMENT_LINK",
 			});
 
-			// Same IP, same moment: the tournament pages are gated by the other
+			// Same IP, same moment: the tournament pages are gated by another
 			// var, which this override didn't touch.
-			await expectOk(await get("/v1/tournaments", { ip }));
+			const t = await makeTournament({
+				slug: "rl-link-tune",
+				advanceTo: "swiss-round-1-generated",
+			});
+			await expectOk(await get(`/v1/tournaments/${t.slug}`, { ip }));
 		});
 
 		it("wrangler.toml's configured value is what the gate uses by default", async () => {

--- a/cloud/vitest.config.mts
+++ b/cloud/vitest.config.mts
@@ -5,6 +5,7 @@ import {
 } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 import { SITE_ADMIN_DISCORD_ID } from "./test/helpers/admin-identity";
+import { SSR_TRUSTED_TEST_KEY } from "./test/helpers/ssr-identity";
 
 const MIGRATIONS_PATH = path.resolve(import.meta.dirname, "./migrations");
 const SECURITY_MIGRATIONS_PATH = path.resolve(
@@ -56,6 +57,13 @@ export default defineConfig({
 								// endpoints are reachable via makeSiteAdmin(). No
 								// makeUser-generated id can collide with it.
 								ADMIN_DISCORD_ID: SITE_ADMIN_DISCORD_ID,
+								// The frontend Worker's shared key, so tests can send a
+								// server-rendered request the way per-ankh.app does and
+								// assert what the API believes about the visitor
+								// (adoptTrustedFrontend in src/util.ts). Bound here rather
+								// than read from .dev.vars — that file is gitignored, and
+								// these tests must pass on a fresh checkout.
+								SSR_TRUSTED_KEY: SSR_TRUSTED_TEST_KEY,
 							},
 						},
 					})),

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -184,11 +184,21 @@ GLOBAL_UPLOADS_PER_HOUR = "5000"
 # an incident-time secret survives only until the next deploy — to keep a new
 # ceiling, change it here and ship it.
 #
-# TOURNAMENT_VIEW_PER_HOUR gates the tournament pages; _LINK_ gates
-# GET /v1/games/:id/tournament-link, which every game-page render calls.
-# Separate budgets so a /games/* crawl can't spend the tournament pages'
-# allowance (the 2026-08-05 outage) — keep them separate when retuning.
-TOURNAMENT_VIEW_PER_HOUR = "600"
+# Three budgets, by the surface that spends them, not by feature:
+#   _VIEW_ — the tournament pages (detail + standings/bracket/matches/stats)
+#   _LIST_ — GET /v1/tournaments, which the *home page* fetches every render
+#   _LINK_ — GET /v1/games/:id/tournament-link, every game-page render
+# Separate so the busiest surface can't decide when the others start refusing
+# — that coupling is what took the tournament pages down on 2026-08-05, with
+# /games/* as the busy surface. Keep them separate when retuning.
+#
+# All three count *reads*, not page loads, and the numbers differ because the
+# fan-out does: _VIEW_ is ~4 reads per tournament page (6 on stats), the other
+# two are one read each. So all three are about 600 page loads an hour per
+# visitor. Retuning one is deciding how much *browsing* to allow — convert
+# through the fan-out, don't copy a number across.
+TOURNAMENT_VIEW_PER_HOUR = "2400"
+TOURNAMENT_LIST_VIEW_PER_HOUR = "600"
 TOURNAMENT_LINK_VIEW_PER_HOUR = "600"
 
 # === Cloud rewrite (/v1/auth/*, /v1/games/*) ===
@@ -300,7 +310,8 @@ UPLOADS_ENABLED = "true"
 PER_USER_UPLOADS_PER_HOUR = "100"
 PER_IP_UPLOADS_PER_HOUR = "200"
 GLOBAL_UPLOADS_PER_HOUR = "5000"
-TOURNAMENT_VIEW_PER_HOUR = "600"
+TOURNAMENT_VIEW_PER_HOUR = "2400"
+TOURNAMENT_LIST_VIEW_PER_HOUR = "600"
 TOURNAMENT_LINK_VIEW_PER_HOUR = "600"
 ALLOWED_ORIGINS = "https://staging.per-ankh.app"
 # Separate staging Discord OAuth app — paste its client ID:

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -169,6 +169,15 @@ PER_IP_UPLOADS_PER_HOUR = "200"
 # a real "something is wrong" threshold, not a normal-growth ceiling.
 GLOBAL_UPLOADS_PER_HOUR = "5000"
 
+# === Tournament read limits ===
+# Per-IP hourly ceiling on the tournament read endpoints
+# (cloud/src/tournament/limits.ts). A var, not just a code const, so the
+# ceiling can be retuned during a live event without a redeploy — same lever
+# as UPLOADS_ENABLED: `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR`
+# shadows this value and takes effect immediately. Unset or unparseable falls
+# back to the code default, which is this number.
+TOURNAMENT_VIEW_PER_HOUR = "600"
+
 # === Cloud rewrite (/v1/auth/*, /v1/games/*) ===
 # CORS allowlist for new routes — comma-separated origins. Cookie-based
 # auth requires Access-Control-Allow-Credentials: true, which forbids the
@@ -278,6 +287,7 @@ UPLOADS_ENABLED = "true"
 PER_USER_UPLOADS_PER_HOUR = "100"
 PER_IP_UPLOADS_PER_HOUR = "200"
 GLOBAL_UPLOADS_PER_HOUR = "5000"
+TOURNAMENT_VIEW_PER_HOUR = "600"
 ALLOWED_ORIGINS = "https://staging.per-ankh.app"
 # Separate staging Discord OAuth app — paste its client ID:
 DISCORD_CLIENT_ID = "1512545079493922927"

--- a/cloud/wrangler.toml
+++ b/cloud/wrangler.toml
@@ -170,13 +170,26 @@ PER_IP_UPLOADS_PER_HOUR = "200"
 GLOBAL_UPLOADS_PER_HOUR = "5000"
 
 # === Tournament read limits ===
-# Per-IP hourly ceiling on the tournament read endpoints
-# (cloud/src/tournament/limits.ts). A var, not just a code const, so the
-# ceiling can be retuned during a live event without a redeploy — same lever
-# as UPLOADS_ENABLED: `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR`
-# shadows this value and takes effect immediately. Unset or unparseable falls
-# back to the code default, which is this number.
+# Per-IP hourly ceilings on the two tournament read budgets
+# (cloud/src/tournament/limits.ts). Vars, not just code consts, so either can
+# be retuned during a live event without a redeploy — same lever as
+# UPLOADS_ENABLED: `npx wrangler secret put TOURNAMENT_VIEW_PER_HOUR` takes
+# effect immediately. Unset or unparseable falls back to the code default,
+# which is this number.
+#
+# The override is temporary. A secret and a var of the same name collide, and
+# the var wins: the next `wrangler deploy` warns "Configuration values (…)
+# conflict with existing remote secrets. This deployment will replace these
+# remote secrets with the configuration values" and puts this number back. So
+# an incident-time secret survives only until the next deploy — to keep a new
+# ceiling, change it here and ship it.
+#
+# TOURNAMENT_VIEW_PER_HOUR gates the tournament pages; _LINK_ gates
+# GET /v1/games/:id/tournament-link, which every game-page render calls.
+# Separate budgets so a /games/* crawl can't spend the tournament pages'
+# allowance (the 2026-08-05 outage) — keep them separate when retuning.
 TOURNAMENT_VIEW_PER_HOUR = "600"
+TOURNAMENT_LINK_VIEW_PER_HOUR = "600"
 
 # === Cloud rewrite (/v1/auth/*, /v1/games/*) ===
 # CORS allowlist for new routes — comma-separated origins. Cookie-based
@@ -288,6 +301,7 @@ PER_USER_UPLOADS_PER_HOUR = "100"
 PER_IP_UPLOADS_PER_HOUR = "200"
 GLOBAL_UPLOADS_PER_HOUR = "5000"
 TOURNAMENT_VIEW_PER_HOUR = "600"
+TOURNAMENT_LINK_VIEW_PER_HOUR = "600"
 ALLOWED_ORIGINS = "https://staging.per-ankh.app"
 # Separate staging Discord OAuth app — paste its client ID:
 DISCORD_CLIENT_ID = "1512545079493922927"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -85,6 +85,11 @@ From there it's the user's: [`POST /v1/users/me/slug`](#post-v1usersmeslug) rena
 
 Counters live in the D1 `events` table (or the Cache API for legacy downloads) and are keyed per-user, per-IP, or globally depending on the endpoint. Notable buckets:
 
+Two things shape what "per IP" means for traffic that arrives through `per-ankh.app`'s server-side rendering, since those subrequests leave Cloudflare's SSR egress rather than the visitor's connection:
+
+- **The visitor is the bucket.** The frontend Worker forwards the visitor's edge address and authenticates itself with the `SSR_TRUSTED_KEY` shared secret; `adoptTrustedFrontend` (`cloud/src/util.ts`) verifies it once at the Worker's entry and swaps the address in before any handler reads it. Without a valid key those headers are stripped, so a caller can't claim an address it doesn't have — and with the secret unset on either Worker, nothing is forwarded and every counter behaves as it did before.
+- **A server-rendered page load spends one slot, not one per read.** `/tournaments/[slug]` fetches the tournament, then standings, bracket and matches; on a trusted page load only the first charges `tournament_view` (`ReadRole` in `cloud/src/tournament/public.ts`). Sub-resource reads made directly — a hydrated navigation, or anything hitting the API by hand — are charged individually, and every read is still *gated* whether or not it charges.
+
 | Bucket | Limit | Applies to |
 | --- | --- | --- |
 | `anon_read` | 200 / hr per IP | anonymous game reads (`GET /v1/games/:id`, `public-recent`) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -87,14 +87,17 @@ Counters live in the D1 `events` table (or the Cache API for legacy downloads) a
 
 Two things shape what "per IP" means for traffic that arrives through `per-ankh.app`'s server-side rendering, since those subrequests leave Cloudflare's SSR egress rather than the visitor's connection:
 
-- **The visitor is the bucket.** The frontend Worker forwards the visitor's edge address and User-Agent and authenticates itself with the `SSR_TRUSTED_KEY` shared secret; `adoptTrustedFrontend` (`cloud/src/util.ts`) verifies it once at the Worker's entry and swaps both in before any handler reads them. Without a valid key those headers are stripped, so a caller can't claim an address it doesn't have — and with the secret unset on either Worker, nothing is forwarded and every counter behaves as it did before. The UA travels for the sake of the scraper exemption below: SvelteKit's server fetch sends none of its own, and a link-preview unfurl is always a server-rendered load, so without forwarding the exemption would apply to nothing.
-- **A server-rendered page load spends one slot, not one per read.** `/tournaments/[slug]` fetches the tournament, then standings, bracket and matches; on a trusted page load only the first is gated and charged, and the sub-resources ride along uncounted (`ReadRole` in `cloud/src/tournament/public.ts`). So on server-rendered traffic `tournament_view` bounds **page loads**, and the reads behind them are a multiple of that — six per load on the stats page. Sub-resource reads made directly — a hydrated navigation, or anything hitting the API by hand — are gated and charged individually, so no endpoint is free.
+- **The visitor is the bucket.** The frontend Worker forwards the visitor's edge address and authenticates itself with the `SSR_TRUSTED_KEY` shared secret; `adoptTrustedFrontend` (`cloud/src/util.ts`) verifies it once at the Worker's entry and swaps the address in before any handler reads it. Without a valid key those headers are stripped, so a caller can't claim an address it doesn't have — and with the secret unset on either Worker, nothing is forwarded and every counter behaves as it did before. The address is all that travels: the visitor's User-Agent is deliberately **not** forwarded, because it would extend the scraper exemption below to anyone who types `Discordbot/2.0` into a header.
+- **The address is the only thing the key buys.** Every read is gated and charged the same for every caller — there is no cheaper class of read and no discount for being our own SSR Worker. A cold `/tournaments/[slug]` costs four slots (the tournament, then standings, bracket and matches) whether it was server-rendered or reached by a hydrated navigation, and the stats page costs six. That is why the ceilings below are stated in **reads**, and why the tournament-page one is four times the others: converting to page loads is the operator's job, and the fan-out is the conversion factor.
+
+The three tournament read buckets are split by the *surface that spends them*, not by feature: a read a busy page makes on every render must not share a budget with the pages it could otherwise take down (see `cloud/src/tournament/limits.ts`).
 
 | Bucket | Limit | Applies to |
 | --- | --- | --- |
 | `anon_read` | 200 / hr per IP | anonymous game reads (`GET /v1/games/:id`, `public-recent`) |
-| `tournament_view` | 600 / hr per IP | anonymous tournament reads. The ceiling is the `TOURNAMENT_VIEW_PER_HOUR` var (600 by default), so it can be retuned mid-event with `wrangler secret put` instead of a redeploy — until the next deploy restores the `wrangler.toml` value |
-| `tournament_link_view` | 600 / hr per IP | `GET /v1/games/:id/tournament-link`. Its own budget, not `tournament_view`'s: every game-page render calls it, so sharing let a `/games/*` crawl 429 the tournament pages. Own ceiling var too (`TOURNAMENT_LINK_VIEW_PER_HOUR`), retuned the same way |
+| `tournament_view` | 2400 reads / hr per IP | the tournament page reads: detail, standings, bracket, rounds, matches, match detail, both stats endpoints, and the profile Tournaments tab. ~4 reads per page load (6 on stats), so ~600 page loads an hour. The ceiling is the `TOURNAMENT_VIEW_PER_HOUR` var, so it can be retuned mid-event with `wrangler secret put` instead of a redeploy — until the next deploy restores the `wrangler.toml` value |
+| `tournament_list_view` | 600 reads / hr per IP | `GET /v1/tournaments`. Its own budget, not `tournament_view`'s: the **home page** fetches the list on every render, so sharing would let ordinary landing-page traffic decide when `/tournaments/[slug]` starts refusing. Own ceiling var (`TOURNAMENT_LIST_VIEW_PER_HOUR`), retuned the same way |
+| `tournament_link_view` | 600 reads / hr per IP | `GET /v1/games/:id/tournament-link`. Its own budget for the same reason: every game-page render calls it, and sharing let a `/games/*` crawl 429 the tournament pages. Own ceiling var too (`TOURNAMENT_LINK_VIEW_PER_HOUR`) |
 | `tournament_export` | 30 / hr per user | `GET /v1/tournaments/:id/export` |
 | `tournament_admin` | 30 / hr per user | tournament admin mutations |
 | `tournament_schedule` | 60 / hr per user | match schedule + caster self-service |
@@ -104,7 +107,7 @@ Two things shape what "per IP" means for traffic that arrives through `per-ankh.
 | `slug_claim_attempt` | 15 / hr per user | `POST` + `DELETE /v1/users/me/slug` (counts attempts, not successes) |
 | upload / download | per-user + per-IP + global | game upload / download |
 
-Over-limit → `429` with an endpoint-specific `code`. Known scraper User-Agents are exempt from the anonymous read/view limits (and their audit rows) — on server-rendered traffic that turns on the forwarded UA above.
+Over-limit → `429` with an endpoint-specific `code`. Known scraper User-Agents are exempt from the anonymous read/view limits, and from their audit rows too — so an exempt read leaves no trace in `events`. The exemption is keyed on a self-declared header, which is why the visitor's UA isn't forwarded across the SSR hop: it applies to a caller hitting the API directly and not to page traffic through `per-ankh.app`.
 
 ### CORS
 
@@ -418,14 +421,15 @@ _(Account settings live at [`POST /v1/auth/settings`](#post-v1authsettings).)_
 
 ## Tournaments — reads
 
-All reads in this section are **Public (owner extras)** unless noted: a session is optional and only unlocks admin/owner fields; anonymous callers see the public shape. Setup-phase tournaments return a `404`-shape to non-admins (unless signups are open). All are per-IP rate-limited via the `tournament_view` bucket (600/hr; `429 RATE_LIMIT_TOURNAMENT_VIEW`), and all take the 21-char tournament `id` **except** detail-by-slug.
+All reads in this section are **Public (owner extras)** unless noted: a session is optional and only unlocks admin/owner fields; anonymous callers see the public shape. Setup-phase tournaments return a `404`-shape to non-admins (unless signups are open). All are per-IP rate-limited via the `tournament_view` bucket (2400 reads/hr; `429 RATE_LIMIT_TOURNAMENT_VIEW`) **except the list**, which has its own — see below. All take the 21-char tournament `id` except detail-by-slug.
 
 ### `GET /v1/tournaments`
 List tournaments.
 
 - **Query:** `status` (`setup`|`swiss`|`championship`|`complete`), `limit` (default 20, 1–100), `offset` (default 0).
 - **Response 200:** `{ tournaments: [{ tournament_id, slug, name, status, signups_open, created_at, updated_at, swiss_wins_to_advance, swiss_losses_to_eliminate, swiss_max_rounds, map_pool_size, player_count, active_round: { round_number, matches_total, matches_reported } | null, champion: { display_name, avatar_url } | null }], limit, offset }`.
-- **Notes:** Setup-phase rows appear only to their admins or when `signups_open`.
+- **Errors:** `429 RATE_LIMIT_TOURNAMENT_LIST`.
+- **Notes:** Setup-phase rows appear only to their admins or when `signups_open`. `tournament_list_view` bucket (600/hr per IP), **not** the `tournament_view` one the rest of this section draws on: the home page fetches this list on every render, so a shared budget would let landing-page traffic close the tournament pages.
 
 ### `GET /v1/tournaments/:slug`
 Tournament detail (the only read keyed by **slug**).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -88,8 +88,8 @@ Counters live in the D1 `events` table (or the Cache API for legacy downloads) a
 | Bucket | Limit | Applies to |
 | --- | --- | --- |
 | `anon_read` | 200 / hr per IP | anonymous game reads (`GET /v1/games/:id`, `public-recent`) |
-| `tournament_view` | 600 / hr per IP | anonymous tournament reads. The ceiling is the `TOURNAMENT_VIEW_PER_HOUR` var (600 by default), so it can be retuned mid-event with `wrangler secret put` instead of a redeploy |
-| `tournament_link_view` | 600 / hr per IP | `GET /v1/games/:id/tournament-link`. Its own budget, not `tournament_view`'s: every game-page render calls it, so sharing let a `/games/*` crawl 429 the tournament pages |
+| `tournament_view` | 600 / hr per IP | anonymous tournament reads. The ceiling is the `TOURNAMENT_VIEW_PER_HOUR` var (600 by default), so it can be retuned mid-event with `wrangler secret put` instead of a redeploy — until the next deploy restores the `wrangler.toml` value |
+| `tournament_link_view` | 600 / hr per IP | `GET /v1/games/:id/tournament-link`. Its own budget, not `tournament_view`'s: every game-page render calls it, so sharing let a `/games/*` crawl 429 the tournament pages. Own ceiling var too (`TOURNAMENT_LINK_VIEW_PER_HOUR`), retuned the same way |
 | `tournament_export` | 30 / hr per user | `GET /v1/tournaments/:id/export` |
 | `tournament_admin` | 30 / hr per user | tournament admin mutations |
 | `tournament_schedule` | 60 / hr per user | match schedule + caster self-service |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -87,8 +87,8 @@ Counters live in the D1 `events` table (or the Cache API for legacy downloads) a
 
 Two things shape what "per IP" means for traffic that arrives through `per-ankh.app`'s server-side rendering, since those subrequests leave Cloudflare's SSR egress rather than the visitor's connection:
 
-- **The visitor is the bucket.** The frontend Worker forwards the visitor's edge address and authenticates itself with the `SSR_TRUSTED_KEY` shared secret; `adoptTrustedFrontend` (`cloud/src/util.ts`) verifies it once at the Worker's entry and swaps the address in before any handler reads it. Without a valid key those headers are stripped, so a caller can't claim an address it doesn't have — and with the secret unset on either Worker, nothing is forwarded and every counter behaves as it did before.
-- **A server-rendered page load spends one slot, not one per read.** `/tournaments/[slug]` fetches the tournament, then standings, bracket and matches; on a trusted page load only the first charges `tournament_view` (`ReadRole` in `cloud/src/tournament/public.ts`). Sub-resource reads made directly — a hydrated navigation, or anything hitting the API by hand — are charged individually, and every read is still *gated* whether or not it charges.
+- **The visitor is the bucket.** The frontend Worker forwards the visitor's edge address and User-Agent and authenticates itself with the `SSR_TRUSTED_KEY` shared secret; `adoptTrustedFrontend` (`cloud/src/util.ts`) verifies it once at the Worker's entry and swaps both in before any handler reads them. Without a valid key those headers are stripped, so a caller can't claim an address it doesn't have — and with the secret unset on either Worker, nothing is forwarded and every counter behaves as it did before. The UA travels for the sake of the scraper exemption below: SvelteKit's server fetch sends none of its own, and a link-preview unfurl is always a server-rendered load, so without forwarding the exemption would apply to nothing.
+- **A server-rendered page load spends one slot, not one per read.** `/tournaments/[slug]` fetches the tournament, then standings, bracket and matches; on a trusted page load only the first is gated and charged, and the sub-resources ride along uncounted (`ReadRole` in `cloud/src/tournament/public.ts`). So on server-rendered traffic `tournament_view` bounds **page loads**, and the reads behind them are a multiple of that — six per load on the stats page. Sub-resource reads made directly — a hydrated navigation, or anything hitting the API by hand — are gated and charged individually, so no endpoint is free.
 
 | Bucket | Limit | Applies to |
 | --- | --- | --- |
@@ -104,7 +104,7 @@ Two things shape what "per IP" means for traffic that arrives through `per-ankh.
 | `slug_claim_attempt` | 15 / hr per user | `POST` + `DELETE /v1/users/me/slug` (counts attempts, not successes) |
 | upload / download | per-user + per-IP + global | game upload / download |
 
-Over-limit → `429` with an endpoint-specific `code`. Known scraper User-Agents are exempt from the anonymous read/view limits (and their audit rows).
+Over-limit → `429` with an endpoint-specific `code`. Known scraper User-Agents are exempt from the anonymous read/view limits (and their audit rows) — on server-rendered traffic that turns on the forwarded UA above.
 
 ### CORS
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -88,7 +88,8 @@ Counters live in the D1 `events` table (or the Cache API for legacy downloads) a
 | Bucket | Limit | Applies to |
 | --- | --- | --- |
 | `anon_read` | 200 / hr per IP | anonymous game reads (`GET /v1/games/:id`, `public-recent`) |
-| `tournament_view` | 600 / hr per IP | anonymous tournament reads |
+| `tournament_view` | 600 / hr per IP | anonymous tournament reads. The ceiling is the `TOURNAMENT_VIEW_PER_HOUR` var (600 by default), so it can be retuned mid-event with `wrangler secret put` instead of a redeploy |
+| `tournament_link_view` | 600 / hr per IP | `GET /v1/games/:id/tournament-link`. Its own budget, not `tournament_view`'s: every game-page render calls it, so sharing let a `/games/*` crawl 429 the tournament pages |
 | `tournament_export` | 30 / hr per user | `GET /v1/tournaments/:id/export` |
 | `tournament_admin` | 30 / hr per user | tournament admin mutations |
 | `tournament_schedule` | 60 / hr per user | match schedule + caster self-service |
@@ -245,8 +246,8 @@ Whether a game is linked to a tournament match.
 - **Auth:** Public (IP rate-limited).
 - **Path:** `id` (21-char).
 - **Response 200:** `{ link: GameTournamentLink | null }` — `link.tournament` `{ tournament_id, slug, name, status }` + `link.match` `{ match_id, phase, division, round_number, map_script, status, slot_a_id, slot_b_id, winner_slot_id, slot_a_display_name, slot_b_display_name }`; `{ link: null }` when unlinked.
-- **Errors:** `429 RATE_LIMIT_TOURNAMENT_VIEW`.
-- **Notes:** `tournament_view` bucket (600/hr per IP; scraper UAs exempt).
+- **Errors:** `429 RATE_LIMIT_TOURNAMENT_LINK`.
+- **Notes:** `tournament_link_view` bucket (600/hr per IP; scraper UAs exempt) — its own, deliberately not the `tournament_view` one the tournament pages draw on. The budget is charged before the link is looked up, so an unlinked game costs a slot too.
 
 ### `PATCH /v1/games/:id`
 Update a game's visibility, collection, or display name.

--- a/docs/cloud-deploy-plan.md
+++ b/docs/cloud-deploy-plan.md
@@ -79,10 +79,9 @@ npx wrangler secret put DISCORD_CLIENT_SECRET   # from Discord developer portal
 production Worker (it's the only entry in the preflight's required-secrets list).
 
 **`SSR_TRUSTED_KEY` goes on both Workers, with the same value.** It's what lets
-the API believe the visitor address and User-Agent the frontend forwards on
+the API believe the visitor address the frontend forwards on
 server-rendered requests; without it every SSR visitor is counted into one
-bucket, a single crawler can spend the whole site's per-IP budget, and the
-scraper exemption stops applying to the link-preview crawlers it exists for
+bucket and a single crawler can spend the whole site's per-IP budget
 (`adoptTrustedFrontend` in `cloud/src/util.ts`, and the 2026-08-05 outage in
 `docs/cloudflare-waf.md`).
 
@@ -94,14 +93,20 @@ openssl rand -base64 32
 npx wrangler secret put SSR_TRUSTED_KEY                 # frontend Worker (repo root)
 ```
 
-Not in the preflight's required list, because unset is a working state — both
-sides check it, so forwarding stays off until both have it and the two Workers
-can be deployed in either order. The cost of leaving it unset is silent, and
-silent in the logs too: `ssr_forward_rejected` means a key was presented and
-didn't match (a half-finished rotation), and a Worker with no key at all has
-nothing to reject, so it says nothing. What surfaces the unset case is the
-counters — a Cloudflare egress address at the top of the per-IP bucket query in
-`docs/cloudflare-waf.md` means SSR traffic is pooling again.
+Not in the preflight's **required** list, because unset is a working state —
+both sides check it, so forwarding stays off until both have it and the two
+Workers can be deployed in either order.
+
+It is checked, though. Leaving it unset costs nothing at deploy time and
+everything at runtime, silently: `ssr_forward_rejected` means a key was
+presented and didn't match (a half-finished rotation), and a Worker with no key
+at all has nothing to reject, so it says nothing. The `secrets.ssr_trust`
+preflight check stands in for that missing signal — it lists the secrets on
+both Workers and **warns** when neither has the key, **fails non-blockingly**
+when only one does. Neither state stops a deploy; both are printed, so the
+deploy window can't quietly become permanent. The runtime confirmation is still
+the counters — a Cloudflare egress address at the top of the per-IP bucket
+query in `docs/cloudflare-waf.md` means SSR traffic is pooling again.
 
 ### 3.3. Discord OAuth app
 

--- a/docs/cloud-deploy-plan.md
+++ b/docs/cloud-deploy-plan.md
@@ -78,6 +78,26 @@ npx wrangler secret put DISCORD_CLIENT_SECRET   # from Discord developer portal
 `./per-ankh prod preflight` will fail if `DISCORD_CLIENT_SECRET` is unset on the
 production Worker (it's the only entry in the preflight's required-secrets list).
 
+**`SSR_TRUSTED_KEY` goes on both Workers, with the same value.** It's what lets
+the API believe the visitor address the frontend forwards on server-rendered
+requests; without it every SSR visitor is counted into one bucket and a single
+crawler can spend the whole site's per-IP budget (`adoptTrustedFrontend` in
+`cloud/src/util.ts`, and the 2026-08-05 outage in `docs/cloudflare-waf.md`).
+
+```bash
+# Generate one value and give it to both:
+openssl rand -base64 32
+
+(cd cloud && npx wrangler secret put SSR_TRUSTED_KEY)   # API Worker
+npx wrangler secret put SSR_TRUSTED_KEY                 # frontend Worker (repo root)
+```
+
+Not in the preflight's required list, because unset is a working state — both
+sides check it, so forwarding stays off until both have it and the two Workers
+can be deployed in either order. The cost of leaving it unset is silent: the
+counters go back to pooling SSR traffic. `ssr_forward_rejected` in the API's
+logs means one side has a value the other doesn't.
+
 ### 3.3. Discord OAuth app
 
 Both prod and dev redirect URIs are already configured in the Discord
@@ -703,7 +723,12 @@ All commands from `cloud/` unless noted. Each authenticates via `wrangler login`
    ```bash
    npx wrangler secret put DISCORD_CLIENT_SECRET --env staging
    npx wrangler secret put ADMIN_DISCORD_ID --env staging   # optional: staging site-admin
+   npx wrangler secret put SSR_TRUSTED_KEY --env staging    # same value on both staging Workers
    ```
+
+   `SSR_TRUSTED_KEY` also goes on the staging *frontend* Worker
+   (`npx wrangler secret put SSR_TRUSTED_KEY --env staging` from the repo root)
+   — its own value, not prod's. See §3.2 for what it does.
 
    Wrangler stores secrets on a worker, and the staging worker doesn't exist before the first deploy — so the first `secret put` asks *"There doesn't seem to be a Worker called per-ankh-share-api-staging — create it?"*. Answer **yes**: it creates an empty worker shell that the real deploy then overwrites. (Declining silently discards the secret, and staging preflight then blocks on `secrets.required`.)
 

--- a/docs/cloud-deploy-plan.md
+++ b/docs/cloud-deploy-plan.md
@@ -79,10 +79,12 @@ npx wrangler secret put DISCORD_CLIENT_SECRET   # from Discord developer portal
 production Worker (it's the only entry in the preflight's required-secrets list).
 
 **`SSR_TRUSTED_KEY` goes on both Workers, with the same value.** It's what lets
-the API believe the visitor address the frontend forwards on server-rendered
-requests; without it every SSR visitor is counted into one bucket and a single
-crawler can spend the whole site's per-IP budget (`adoptTrustedFrontend` in
-`cloud/src/util.ts`, and the 2026-08-05 outage in `docs/cloudflare-waf.md`).
+the API believe the visitor address and User-Agent the frontend forwards on
+server-rendered requests; without it every SSR visitor is counted into one
+bucket, a single crawler can spend the whole site's per-IP budget, and the
+scraper exemption stops applying to the link-preview crawlers it exists for
+(`adoptTrustedFrontend` in `cloud/src/util.ts`, and the 2026-08-05 outage in
+`docs/cloudflare-waf.md`).
 
 ```bash
 # Generate one value and give it to both:
@@ -94,9 +96,12 @@ npx wrangler secret put SSR_TRUSTED_KEY                 # frontend Worker (repo 
 
 Not in the preflight's required list, because unset is a working state — both
 sides check it, so forwarding stays off until both have it and the two Workers
-can be deployed in either order. The cost of leaving it unset is silent: the
-counters go back to pooling SSR traffic. `ssr_forward_rejected` in the API's
-logs means one side has a value the other doesn't.
+can be deployed in either order. The cost of leaving it unset is silent, and
+silent in the logs too: `ssr_forward_rejected` means a key was presented and
+didn't match (a half-finished rotation), and a Worker with no key at all has
+nothing to reject, so it says nothing. What surfaces the unset case is the
+counters — a Cloudflare egress address at the top of the per-IP bucket query in
+`docs/cloudflare-waf.md` means SSR traffic is pooling again.
 
 ### 3.3. Discord OAuth app
 

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -26,6 +26,8 @@ Client-side navigations *are* different: once a page has hydrated, the browser c
 
 The application layer is no longer in the same position, and the distinction matters when reading the counters below. The frontend Worker now forwards the visitor's address on its subrequests and authenticates itself with a shared secret, so the API's own per-IP budgets are keyed on the visitor even for server-rendered traffic (`adoptTrustedFrontend` in `cloud/src/util.ts`). **A WAF rule still cannot see that** — `ip.src` at the API hostname is the network peer, which for SSR is still the egress, and no forwarded header changes it. So: application counters attribute correctly; WAF rules keyed on the client still belong at `per-ankh.app`.
 
+One thing the application layer deliberately cannot see is the visitor's User-Agent. It doesn't survive the SSR hop and isn't forwarded, because the Worker's scraper exemption (`isScraperUA`) is keyed on a self-declared string and skips the audit row as well as the gate — forwarding it would make `User-Agent: Discordbot/2.0` an unmetered and unlogged path through every read budget. **UA-based rules therefore belong at the edge**, where Cloudflare can also tell you whether the bot is verified. Recipe 2 below is that rule.
+
 ## Worked example: the 2026-08-05 tournament outage
 
 `/tournaments/2026-community-tournament` began returning 500. The cause was not the tournament:
@@ -39,27 +41,29 @@ It self-healed an hour later when the burst aged out of the window.
 
 Steps 2, 3 and 4 have since been fixed in code:
 
-- **2** — the link read has its own budget (`tournament_link_view`, `TOURNAMENT_LINK_VIEW_PER_HOUR`), so game-page traffic no longer spends the tournament pages' allowance.
-- **3** — the frontend forwards each visitor's address on its SSR subrequests, so the burst would now land in the crawler's own bucket instead of pooling with every other visitor on the egress address. A tournament page load also charges one slot now rather than four.
+- **2** — the link read has its own budget (`tournament_link_view`, `TOURNAMENT_LINK_VIEW_PER_HOUR`), so game-page traffic no longer spends the tournament pages' allowance. The tournament *list* read was split out the same way (`tournament_list_view`), because the home page fetches it on every render and had the identical relationship to the pages.
+- **3** — the frontend forwards each visitor's address on its SSR subrequests, so the burst would now land in the crawler's own bucket instead of pooling with every other visitor on the egress address.
 - **4** — every rate-limited loader answers a spent budget with a 429 page (`rethrowRateLimit` in `src/lib/utils/load-errors.ts`) rather than a 500.
 
 Step 1 is the part no code fix reaches: a crawler with its own bucket can still drain that bucket, and 270 page renders a minute is load we are simply serving. **A WAF rate limit on `/games/*` at `per-ankh.app` stops it there**, keyed on the crawler's real IP, with no deploy.
 
-Confirm the application-layer symptom with a read-only query before reaching for a rule. Both read budgets at once, because which one is draining tells you which surface is degraded — `tournament_view` means the tournament pages are 429ing, `tournament_link_view` means game pages are quietly losing their tournament banner:
+Confirm the application-layer symptom with a read-only query before reaching for a rule. All the read budgets at once, because which one is draining tells you which surface is degraded — `tournament_view` means the tournament pages are 429ing, `tournament_list_view` means the home page's tournament strip is emptying, `tournament_link_view` means game pages are quietly losing their tournament banner:
 
 ```bash
 cd cloud && npx wrangler d1 execute per-ankh-share-index --remote --command \
 "SELECT event_type, ip_address, COUNT(*) AS n FROM events \
- WHERE event_type IN ('tournament_view','tournament_link_view','anon_read') \
+ WHERE event_type IN ('tournament_view','tournament_list_view','tournament_link_view','anon_read') \
    AND created_at > datetime('now','-1 hour') \
  GROUP BY event_type, ip_address ORDER BY n DESC LIMIT 10;"
 ```
 
-A bucket at its ceiling is currently rejecting: 600 for either tournament budget (`cloud/src/tournament/limits.ts`, or whatever the matching var is set to), 200 for `anon_read` — which is the tightest of the three and gates the game reads themselves, so a `/games/*` crawl hits it first.
+A bucket at its ceiling is currently rejecting: 2400 for `tournament_view`, 600 for the list and link budgets (`cloud/src/tournament/limits.ts`, or whatever the matching var is set to), 200 for `anon_read` — which is the tightest and gates the game reads themselves, so a `/games/*` crawl hits it first. These count reads, not page loads: `tournament_view` is ~4 reads per tournament page, which is why its number is the larger one for the same amount of browsing.
+
+Read a *quiet* result with suspicion. A scraper-UA caller is exempt from the audit row as well as the gate, so traffic claiming to be a link-preview crawler leaves nothing here at all. If the site is visibly under load and this query looks calm, that's the case to check at the edge (**Security → Events**), not a sign that nothing is happening.
 
 The top bucket is the address to write a rule for: since forwarding shipped, a server-rendered page load is counted against the visitor, so a single abuser shows up as itself rather than pooling into the egress address. Two readings worth knowing:
 
-- **A Cloudflare egress address at the top** now means forwarding is *not* working — the shared secret is missing or mismatched on one of the two Workers. This query is the diagnostic: an egress address topping it is the symptom, and the logs may say nothing at all, since `ssr_forward_rejected` fires on a *mismatched* key and there is nothing to reject when one side simply has no key. Check that both Workers carry `SSR_TRUSTED_KEY` (§3.2 of `docs/cloud-deploy-plan.md`). Meanwhile every SSR visitor is sharing one bucket, so treat the number as site-wide load rather than as one abuser.
+- **A Cloudflare egress address at the top** now means forwarding is *not* working — the shared secret is missing or mismatched on one of the two Workers. This query is the diagnostic: an egress address topping it is the symptom, and the logs may say nothing at all, since `ssr_forward_rejected` fires on a *mismatched* key and there is nothing to reject when one side simply has no key. The `secrets.ssr_trust` preflight check (`./per-ankh prod preflight`) answers the same question without waiting for an incident; §3.2 of `docs/cloud-deploy-plan.md` covers setting the key on both Workers. Meanwhile every SSR visitor is sharing one bucket, so treat the number as site-wide load rather than as one abuser.
 - **A real address at the top** is the crawler, and `per-ankh.app` is still where the rule goes — the API hostname sees the egress as `ip.src` no matter what the counters say.
 
 ## Where the controls live
@@ -98,7 +102,9 @@ When a single misbehaving agent is identifiable by User-Agent. **Security rules 
 
 Action: Managed Challenge, or Block if it is unambiguously hostile. Prefer this over a rate limit when the agent is known, because it costs nothing to evaluate and does not risk catching real users.
 
-To find the agent string, use **Security → Events**, filter to the affected path and time window, and read the User-Agent column. Note this is the only place you can see it: the `events` table in D1 records `ip_address` but not User-Agent, and for SSR traffic it would show the frontend Worker's subrequest anyway, not the visitor's.
+To find the agent string, use **Security → Events**, filter to the affected path and time window, and read the User-Agent column. Note this is the only place you can see it: the `events` table in D1 records `ip_address` but not User-Agent, and the visitor's UA is deliberately not carried across the SSR hop, so the API never sees one for server-rendered traffic either.
+
+This is also the rule to reach for when a crawler is claiming a link-preview UA to stay under the application limits — the exemption is a self-declared header the Worker can't verify, and this is the layer that can.
 
 ## Recipe 3 — emergency brake on a path
 

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -24,28 +24,43 @@ An IP-keyed rate limit or block on `api.per-ankh.app` does not throttle an abuse
 
 Client-side navigations *are* different: once a page has hydrated, the browser calls the API directly and `ip.src` there is the real visitor. So API traffic is a mix of real visitor IPs and one shared egress address, which is precisely why it is not a safe thing to key rules on.
 
+The application layer is no longer in the same position, and the distinction matters when reading the counters below. The frontend Worker now forwards the visitor's address on its subrequests and authenticates itself with a shared secret, so the API's own per-IP budgets are keyed on the visitor even for server-rendered traffic (`adoptTrustedFrontend` in `cloud/src/util.ts`). **A WAF rule still cannot see that** — `ip.src` at the API hostname is the network peer, which for SSR is still the egress, and no forwarded header changes it. So: application counters attribute correctly; WAF rules keyed on the client still belong at `per-ankh.app`.
+
 ## Worked example: the 2026-08-05 tournament outage
 
 `/tournaments/2026-community-tournament` began returning 500. The cause was not the tournament:
 
 1. Something crawled roughly 270 `/games/[id]` pages a minute at 17:07 and again at 17:09.
-2. Every game page render calls `GET /v1/games/:id/tournament-link`, and that handler charges the **tournament** view budget (`TOURNAMENT_VIEW_PER_HOUR`, 600/hour) before checking whether the game is even linked to a tournament.
+2. Every game page render calls `GET /v1/games/:id/tournament-link`, and that handler charged the **tournament** view budget (`TOURNAMENT_VIEW_PER_HOUR`, 600/hour) before checking whether the game was even linked to a tournament.
 3. All those renders were server-side, so all 536 requests landed on the single SSR egress address, which hit exactly 600 in the rolling hour and started returning 429.
 4. The tournament page loader had no 429 branch, so the 429 surfaced as a 500.
 
-It self-healed an hour later when the burst aged out of the window. The application-layer fixes are tracked separately; the point here is that **a WAF rate limit on `/games/*` at `per-ankh.app` would have stopped it at step 1**, keyed on the crawler's real IP, with no deploy.
+It self-healed an hour later when the burst aged out of the window.
 
-Confirm the application-layer symptom with a read-only query before reaching for a rule:
+Steps 2, 3 and 4 have since been fixed in code:
+
+- **2** — the link read has its own budget (`tournament_link_view`, `TOURNAMENT_LINK_VIEW_PER_HOUR`), so game-page traffic no longer spends the tournament pages' allowance.
+- **3** — the frontend forwards each visitor's address on its SSR subrequests, so the burst would now land in the crawler's own bucket instead of pooling with every other visitor on the egress address. A tournament page load also charges one slot now rather than four.
+- **4** — every rate-limited loader answers a spent budget with a 429 page (`rethrowRateLimit` in `src/lib/utils/load-errors.ts`) rather than a 500.
+
+Step 1 is the part no code fix reaches: a crawler with its own bucket can still drain that bucket, and 270 page renders a minute is load we are simply serving. **A WAF rate limit on `/games/*` at `per-ankh.app` stops it there**, keyed on the crawler's real IP, with no deploy.
+
+Confirm the application-layer symptom with a read-only query before reaching for a rule. Both read budgets at once, because which one is draining tells you which surface is degraded — `tournament_view` means the tournament pages are 429ing, `tournament_link_view` means game pages are quietly losing their tournament banner:
 
 ```bash
 cd cloud && npx wrangler d1 execute per-ankh-share-index --remote --command \
-"SELECT ip_address, COUNT(*) AS n FROM events \
- WHERE event_type = 'tournament_view' \
+"SELECT event_type, ip_address, COUNT(*) AS n FROM events \
+ WHERE event_type IN ('tournament_view','tournament_link_view','anon_read') \
    AND created_at > datetime('now','-1 hour') \
- GROUP BY ip_address ORDER BY n DESC LIMIT 10;"
+ GROUP BY event_type, ip_address ORDER BY n DESC LIMIT 10;"
 ```
 
-A bucket at 600 or above is currently rejecting. If the top bucket is a Cloudflare egress address rather than a real visitor, the load is arriving through SSR and the rule you want belongs at `per-ankh.app`.
+A bucket at its ceiling is currently rejecting: 600 for either tournament budget (`cloud/src/tournament/limits.ts`, or whatever the matching var is set to), 200 for `anon_read` — which is the tightest of the three and gates the game reads themselves, so a `/games/*` crawl hits it first.
+
+The top bucket is the address to write a rule for: since forwarding shipped, a server-rendered page load is counted against the visitor, so a single abuser shows up as itself rather than pooling into the egress address. Two readings worth knowing:
+
+- **A Cloudflare egress address at the top** now means forwarding is *not* working — the shared secret is missing or mismatched on one of the two Workers (grep the API's logs for `ssr_forward_rejected`). Every SSR visitor is sharing one bucket again, so treat the number as site-wide load, not as one abuser, and fix the secret.
+- **A real address at the top** is the crawler, and `per-ankh.app` is still where the rule goes — the API hostname sees the egress as `ip.src` no matter what the counters say.
 
 ## Where the controls live
 

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -1,0 +1,132 @@
+# Cloudflare WAF for Per-Ankh
+
+Per-Ankh has two rate-limiting layers, and they see different things. The **application** layer lives in the Worker — per-IP budgets counted in D1 (`cloud/src/tournament/limits.ts`, `countEventsSince` in `cloud/src/games.ts`). The **edge** layer is Cloudflare's WAF, configured in the dashboard. This doc covers the edge layer: when to reach for it, how to write rules that work correctly given how this app is deployed, and the one mistake that takes the whole site down.
+
+The edge layer's distinguishing property is that **it needs no deploy**. Application limits are compiled into the Worker, so retuning one means shipping code. A WAF rule takes effect in seconds and rolls back just as fast. That makes it the right tool for an active incident and the wrong tool for a permanent invariant — a rule in the dashboard is invisible to anyone reading this repository, so anything meant to be durable belongs in code.
+
+## The critical fact: where a rule can see the visitor
+
+Per-Ankh is two Workers on one zone:
+
+| Hostname | Worker | Config |
+| --- | --- | --- |
+| `per-ankh.app` | `per-ankh-frontend` (SvelteKit SSR) | `wrangler.toml` |
+| `api.per-ankh.app` | `per-ankh-share-api` | `cloud/wrangler.toml` |
+| `legacy.per-ankh.app` | frozen share viewer | `web/` |
+
+When a visitor loads a page, the frontend Worker server-renders it, and that render makes its own subrequests to `api.per-ankh.app`. **Those subrequests do not carry the visitor's IP.** They arrive at the API from a Cloudflare egress address — on 2026-08-05 every server-rendered request in production came from `2a06:98c0:3600::103`.
+
+The consequence for rule-writing is absolute:
+
+> **Match on `per-ankh.app`, not `api.per-ankh.app`, whenever a rule keys on the client.** At the frontend hostname `ip.src` is the real visitor. At the API hostname, for server-rendered traffic, it is one shared Cloudflare address representing every visitor at once.
+
+An IP-keyed rate limit or block on `api.per-ankh.app` does not throttle an abuser. It throttles the SSR egress, which means it throttles **every visitor simultaneously** — a total outage, triggered by whatever traffic volume the site happens to be serving. Do not do it. The same reasoning forbids ever adding a Cloudflare egress address to an IP Access Rule block.
+
+Client-side navigations *are* different: once a page has hydrated, the browser calls the API directly and `ip.src` there is the real visitor. So API traffic is a mix of real visitor IPs and one shared egress address, which is precisely why it is not a safe thing to key rules on.
+
+## Worked example: the 2026-08-05 tournament outage
+
+`/tournaments/2026-community-tournament` began returning 500. The cause was not the tournament:
+
+1. Something crawled roughly 270 `/games/[id]` pages a minute at 17:07 and again at 17:09.
+2. Every game page render calls `GET /v1/games/:id/tournament-link`, and that handler charges the **tournament** view budget (`TOURNAMENT_VIEW_PER_HOUR`, 600/hour) before checking whether the game is even linked to a tournament.
+3. All those renders were server-side, so all 536 requests landed on the single SSR egress address, which hit exactly 600 in the rolling hour and started returning 429.
+4. The tournament page loader had no 429 branch, so the 429 surfaced as a 500.
+
+It self-healed an hour later when the burst aged out of the window. The application-layer fixes are tracked separately; the point here is that **a WAF rate limit on `/games/*` at `per-ankh.app` would have stopped it at step 1**, keyed on the crawler's real IP, with no deploy.
+
+Confirm the application-layer symptom with a read-only query before reaching for a rule:
+
+```bash
+cd cloud && npx wrangler d1 execute per-ankh-share-index --remote --command \
+"SELECT ip_address, COUNT(*) AS n FROM events \
+ WHERE event_type = 'tournament_view' \
+   AND created_at > datetime('now','-1 hour') \
+ GROUP BY ip_address ORDER BY n DESC LIMIT 10;"
+```
+
+A bucket at 600 or above is currently rejecting. If the top bucket is a Cloudflare egress address rather than a real visitor, the load is arriving through SSR and the rule you want belongs at `per-ankh.app`.
+
+## Where the controls live
+
+In the dashboard: select the `per-ankh.app` zone, then **Security**. The relevant sections are **Security rules** (custom rules and rate limiting rules), **Events** (what rules actually fired), and **Settings** (bot controls, managed `robots.txt`).
+
+Capability varies by plan — the number of rate limiting rules, the granularity of the counting period, and whether Bot Management scores are available all depend on it. Check what the zone offers before writing a rule that depends on a field. The recipes below stick to fields available broadly.
+
+`robots.txt` is served from **Cloudflare Managed content**, not from `static/` in this repo. That is why there is no `static/robots.txt` — editing the live file means editing it in the dashboard. It already disallows a list of AI crawlers. It is advisory: a crawler that ignores `robots.txt` is exactly the kind that causes the incident above, which is what the rules below are for.
+
+## Recipe 1 — rate-limit game page crawling
+
+This is the direct fix for the 2026-08-05 pattern. **Security rules → Rate limiting rules → Create rule.**
+
+- **Expression:**
+  ```
+  (http.host eq "per-ankh.app" and starts_with(http.request.uri.path, "/games/") and not cf.client.bot)
+  ```
+- **Characteristics:** IP with NAT support (falls back to `ip.src` where unavailable)
+- **Period:** 1 minute
+- **Requests:** 60
+- **Action:** Managed Challenge
+- **Duration:** 10 minutes
+
+`not cf.client.bot` excludes Cloudflare's verified-bot list, so Googlebot and other search crawlers you want indexing the site are not challenged. Unverified automation is.
+
+Sixty game pages a minute is far above human browsing and far below the ~270/minute burst that caused the outage. Managed Challenge rather than Block means a real user who trips it gets through after a challenge instead of hitting a wall.
+
+## Recipe 2 — challenge or block a specific crawler
+
+When a single misbehaving agent is identifiable by User-Agent. **Security rules → Custom rules → Create rule.**
+
+```
+(http.host eq "per-ankh.app" and http.user_agent contains "<agent-string>")
+```
+
+Action: Managed Challenge, or Block if it is unambiguously hostile. Prefer this over a rate limit when the agent is known, because it costs nothing to evaluate and does not risk catching real users.
+
+To find the agent string, use **Security → Events**, filter to the affected path and time window, and read the User-Agent column. Note this is the only place you can see it: the `events` table in D1 records `ip_address` but not User-Agent, and for SSR traffic it would show the frontend Worker's subrequest anyway, not the visitor's.
+
+## Recipe 3 — emergency brake on a path
+
+If a single route is being hammered and you need it to stop right now, with correctness secondary to survival:
+
+```
+(http.host eq "per-ankh.app" and starts_with(http.request.uri.path, "/<path>/") and not cf.client.bot)
+```
+
+Action: Managed Challenge, applied to everyone unverified. This degrades the experience for real users on that path and should be reverted as soon as the underlying cause is addressed. Note in the rule description why it exists and when it can go.
+
+## Verifying a rule
+
+After creating any rule, confirm the site still serves:
+
+```bash
+for u in \
+  "https://per-ankh.app/tournaments/2026-community-tournament" \
+  "https://per-ankh.app/tournaments" \
+  "https://per-ankh.app/games/<a-known-public-game-id>" ; do
+  curl -s -o /dev/null -w "%{http_code}  $u\n" "$u"
+done
+```
+
+All should be 200. A 403 or 503 means the rule is catching ordinary traffic — the usual cause is matching `api.per-ankh.app`, or omitting the `http.host` clause so the rule applies zone-wide including the API hostname.
+
+Then watch **Security → Events** for a few minutes. A correct rule shows a small number of matches against one or a few source IPs. Hundreds of matches spread across many IPs means it is catching real visitors; revert.
+
+## Rolling back
+
+Every rule has an enable/disable toggle. Disable rather than delete during an incident — it preserves the expression for the post-mortem and can be re-enabled instantly. Delete once the application-layer fix has shipped and the rule is genuinely obsolete.
+
+## Rules to never write
+
+- **Anything IP-keyed on `api.per-ankh.app`.** Explained above. This is the one that causes a full outage.
+- **An IP Access Rule blocking a Cloudflare egress address.** Same failure, arrived at from the other direction. If a Cloudflare-owned address shows up as your top talker, that is SSR, not an attacker.
+- **A zone-wide rule with no `http.host` clause**, when you meant to target the frontend. It will apply to the API hostname too and inherit the problem above.
+- **A permanent rule standing in for a code fix.** Edge rules are invisible to the repository. If a limit is part of how the app is supposed to behave, it belongs in `cloud/src/tournament/limits.ts` or alongside the other per-IP budgets, where it is reviewable and testable.
+
+## See also
+
+- `cloud/src/tournament/limits.ts` — application-layer rate-limit ceilings
+- `cloud/src/games.ts` — `countEventsSince`, the shared 1-hour per-IP counter
+- `cloud/src/retention.ts` — how rate-limit counter rows age out (24h)
+- `cloud/src/util.ts` — `getClientIp`, which reads `CF-Connecting-IP`
+- `docs/security-events.md` — the `security_events` tee and its drain

--- a/docs/cloudflare-waf.md
+++ b/docs/cloudflare-waf.md
@@ -59,7 +59,7 @@ A bucket at its ceiling is currently rejecting: 600 for either tournament budget
 
 The top bucket is the address to write a rule for: since forwarding shipped, a server-rendered page load is counted against the visitor, so a single abuser shows up as itself rather than pooling into the egress address. Two readings worth knowing:
 
-- **A Cloudflare egress address at the top** now means forwarding is *not* working — the shared secret is missing or mismatched on one of the two Workers (grep the API's logs for `ssr_forward_rejected`). Every SSR visitor is sharing one bucket again, so treat the number as site-wide load, not as one abuser, and fix the secret.
+- **A Cloudflare egress address at the top** now means forwarding is *not* working — the shared secret is missing or mismatched on one of the two Workers. This query is the diagnostic: an egress address topping it is the symptom, and the logs may say nothing at all, since `ssr_forward_rejected` fires on a *mismatched* key and there is nothing to reject when one side simply has no key. Check that both Workers carry `SSR_TRUSTED_KEY` (§3.2 of `docs/cloud-deploy-plan.md`). Meanwhile every SSR visitor is sharing one bucket, so treat the number as site-wide load rather than as one abuser.
 - **A real address at the top** is the crawler, and `per-ankh.app` is still where the rule goes — the API hostname sees the egress as `ip.src` no matter what the counters say.
 
 ## Where the controls live

--- a/docs/security-events.md
+++ b/docs/security-events.md
@@ -70,9 +70,11 @@ no declared pattern, so the tee synthesizes a coarse one (`<METHOD> /v1/admin/*`
 
 ## `actor_ip`
 
-Populated from `CF-Connecting-IP` only when the request traversed Cloudflare's
-edge (`CF-RAY` present) — the same distrust rule as `getClientIp`. `NULL`
-otherwise, which is why local-dev rows have a null `actor_ip` (no edge).
+Populated from `CF-Connecting-IP` when the request traversed Cloudflare's edge (`CF-RAY` present) **or** proved it came from our SSR Worker with `SSR_TRUSTED_KEY` — the same trust rule as `getClientIp`. `NULL` otherwise.
+
+On a trusted server-rendered request the address is the **visitor's**, forwarded by the frontend Worker and swapped in before dispatch (`adoptTrustedFrontend`, `cloud/src/util.ts`) — which is the point: an event names the person rather than Cloudflare's SSR egress, where every server-rendered visitor would otherwise appear as one address. It is an assertion by a caller holding the shared secret rather than a peer address this Worker observed, and the column doesn't distinguish the two, so it is exactly as good as that secret.
+
+Local-dev rows are null for the browser's own API calls (no edge, nothing forwarded). Requests that came through SSR carry the dev machine's address, since `cloud/.dev.vars.example` ships the same key as the committed `.env.development` so the forwarding path is exercised locally.
 
 ## Schema
 

--- a/scripts/prod/checks/secrets.ts
+++ b/scripts/prod/checks/secrets.ts
@@ -8,6 +8,9 @@
 //                       the top level (wrangler does not inherit vars or
 //                       bindings into named envs, so drift is silent)
 //   secrets.leak     — regex pass over tracked files for common token shapes
+//   secrets.ssr_trust — SSR_TRUSTED_KEY is on BOTH Workers (API + frontend).
+//                       Non-blocking: unset on both is a working state, and
+//                       the only one whose failure mode is otherwise silent
 
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -35,40 +38,53 @@ interface SecretEntry {
 	type: string;
 }
 
-async function checkRequiredSecrets(env: CloudEnv): Promise<CheckResult> {
+// The names of the secrets set on one Worker, or why we couldn't find out.
+// Both secret checks below go through this — `secrets.ssr_trust` has to ask
+// the same question of a second Worker, and two copies of the banner-slicing
+// and parse handling would be two places to fix when wrangler's output shifts.
+type SecretListing =
+	| { ok: true; names: Set<string> }
+	| { ok: false; reason: string };
+
+async function listSecrets(env: CloudEnv, cwd: string): Promise<SecretListing> {
 	const r = await runCaptured(
 		"npx",
 		["wrangler", "secret", "list", ...env.wranglerEnvFlag],
-		{
-			cwd: CLOUD_DIR,
-		},
+		{ cwd },
 	);
 	if (r.code !== 0) {
 		return {
-			name: "secrets.required",
-			status: "fail",
-			blocking: true,
-			details: `wrangler secret list failed: ${r.stderr.trim() || r.stdout.trim()}`,
+			ok: false,
+			reason: `wrangler secret list failed: ${r.stderr.trim() || r.stdout.trim()}`,
 		};
 	}
 	// `wrangler secret list` may print non-JSON banner lines before the
 	// JSON array. Slice from first '['.
 	const idx = r.stdout.indexOf("[");
-	let parsed: SecretEntry[];
 	try {
-		parsed = JSON.parse(
+		const parsed = JSON.parse(
 			idx >= 0 ? r.stdout.slice(idx) : r.stdout,
 		) as SecretEntry[];
+		return { ok: true, names: new Set(parsed.map((s) => s.name)) };
 	} catch {
+		return {
+			ok: false,
+			reason: `Could not parse secret list:\n${r.stdout.slice(0, 300)}`,
+		};
+	}
+}
+
+async function checkRequiredSecrets(env: CloudEnv): Promise<CheckResult> {
+	const listing = await listSecrets(env, CLOUD_DIR);
+	if (!listing.ok) {
 		return {
 			name: "secrets.required",
 			status: "fail",
 			blocking: true,
-			details: `Could not parse secret list:\n${r.stdout.slice(0, 300)}`,
+			details: listing.reason,
 		};
 	}
-	const present = new Set(parsed.map((s) => s.name));
-	const missing = REQUIRED_SECRETS.filter((s) => !present.has(s));
+	const missing = REQUIRED_SECRETS.filter((s) => !listing.names.has(s));
 	if (missing.length > 0) {
 		const envFlag = env.wranglerEnvFlag.length
 			? ` ${env.wranglerEnvFlag.join(" ")}`
@@ -369,11 +385,99 @@ async function checkLeakScan(): Promise<CheckResult> {
 	};
 }
 
+// ─── secrets.ssr_trust ──────────────────────────────────────────────────────
+// SSR_TRUSTED_KEY is the one secret that has to be the same value on *both*
+// Workers, and the only one whose absence is invisible at runtime. The API
+// believes the visitor address the frontend forwards only when both hold it;
+// with either side missing, nothing is forwarded and every per-IP budget
+// silently counts every server-rendered visitor into one bucket again — the
+// 2026-08-05 outage. The logs say nothing, because a Worker with no key has
+// nothing to reject (`ssr_forward_rejected` fires on a *mismatch*).
+//
+// So this is the check that stands in for the missing runtime signal, and it
+// grades the three states differently:
+//
+//   both set      → pass.
+//   neither set   → warn. This is the documented deploy window (§3.2 of
+//                   docs/cloud-deploy-plan.md) and a working state, so it must
+//                   not block. It is also how the window silently becomes
+//                   permanent, so it must not be silent.
+//   exactly one   → fail. Never an intentional state: somebody did half a
+//                   rollout or half a rotation. Non-blocking, because the
+//                   deploy in front of it is probably unrelated and refusing
+//                   to ship is worse than shipping the state we already have.
+//
+// Values aren't compared — `wrangler secret list` returns names only. A
+// mismatch between two set values is the case `ssr_forward_rejected` does
+// cover.
+const SSR_TRUST_SECRET = "SSR_TRUSTED_KEY";
+
+export async function checkSsrTrustKey(env: CloudEnv): Promise<CheckResult> {
+	const [api, frontend] = await Promise.all([
+		listSecrets(env, CLOUD_DIR),
+		listSecrets(env, REPO_ROOT),
+	]);
+	if (!api.ok || !frontend.ok) {
+		return {
+			name: "secrets.ssr_trust",
+			status: "warn",
+			blocking: false,
+			details:
+				`${SSR_TRUST_SECRET} must be set, with the same value, on the API ` +
+				"Worker (cloud/) and the frontend Worker (repo root). Could not " +
+				`check: ${(api.ok ? frontend : api).reason}`,
+		};
+	}
+
+	const onApi = api.names.has(SSR_TRUST_SECRET);
+	const onFrontend = frontend.names.has(SSR_TRUST_SECRET);
+	if (onApi && onFrontend) {
+		return { name: "secrets.ssr_trust", status: "pass", blocking: false };
+	}
+
+	const envFlag = env.wranglerEnvFlag.length
+		? ` ${env.wranglerEnvFlag.join(" ")}`
+		: "";
+	const howTo =
+		`Set the same value on both:\n` +
+		`  cd cloud && npx wrangler secret put ${SSR_TRUST_SECRET}${envFlag}\n` +
+		`  npx wrangler secret put ${SSR_TRUST_SECRET}${envFlag}   # repo root`;
+
+	if (!onApi && !onFrontend) {
+		return {
+			name: "secrets.ssr_trust",
+			status: "warn",
+			blocking: false,
+			details:
+				`${SSR_TRUST_SECRET} is set on neither Worker, so SSR visitor ` +
+				"forwarding is off: every server-rendered request counts against " +
+				"Cloudflare's egress address instead of the visitor, and one " +
+				"crawler can spend the whole site's per-IP budget.\n" +
+				howTo,
+		};
+	}
+
+	const missing = onApi
+		? "the frontend Worker (repo root)"
+		: "the API Worker (cloud/)";
+	return {
+		name: "secrets.ssr_trust",
+		status: "fail",
+		blocking: false,
+		details:
+			`${SSR_TRUST_SECRET} is set on only one of the two Workers — missing ` +
+			`on ${missing}. Forwarding needs both, so it is currently off and ` +
+			"every server-rendered visitor shares one rate-limit bucket.\n" +
+			howTo,
+	};
+}
+
 export async function runSecretChecks(env: CloudEnv): Promise<CheckResult[]> {
 	return [
 		await checkVarsHygiene(),
 		await checkVarsParity(),
 		await checkLeakScan(),
 		await checkRequiredSecrets(env),
+		await checkSsrTrustKey(env),
 	];
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -12,6 +12,7 @@
 // Other hardening — XFO, Referrer-Policy, Permissions-Policy, X-Content-
 // Type-Options — applies regardless of the request type.
 
+import { env as privateEnv } from "$env/dynamic/private";
 import type { Handle, HandleFetch } from "@sveltejs/kit";
 
 // Build-time API base — the same var the API client reads
@@ -86,10 +87,35 @@ const reportToHeader = JSON.stringify({
 // Pairs with cloud/src/session.ts setting Domain=per-ankh.app on the
 // session cookie — that's what makes the cookie visible on the frontend
 // hostname (where SSR reads it) in the first place.
+//
+// The visitor's address needs forwarding for the same reason and doesn't
+// survive the hop either: this fetch leaves as a fresh request from
+// Cloudflare's egress, so the API sees one address for every SSR visitor at
+// once and its per-IP rate limits count the whole site into one bucket (the
+// 2026-08-05 outage). SSR_TRUSTED_KEY is what lets the API believe the
+// address we send instead — a caller who can't present it gets these headers
+// stripped, so nothing here lets a visitor claim someone else's IP. Unset on
+// either side means no forwarding, which is exactly the old behaviour, so the
+// two Workers can be deployed in either order.
+//
+// Header names are duplicated from cloud/src/util.ts — separate builds, no
+// shared module between them.
 export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
 	if (new URL(request.url).origin === API_ORIGIN) {
 		const cookie = event.request.headers.get("cookie");
 		if (cookie) request.headers.set("cookie", cookie);
+
+		const ssrKey = privateEnv.SSR_TRUSTED_KEY;
+		if (ssrKey) {
+			request.headers.set("X-SSR-Key", ssrKey);
+			// CF-Connecting-IP is what the API reads for everyone else; falling
+			// back to getClientAddress() keeps `vite dev` (no edge headers) on the
+			// same path rather than leaving it untested until production.
+			const clientIp =
+				event.request.headers.get("CF-Connecting-IP") ??
+				event.getClientAddress();
+			if (clientIp) request.headers.set("X-SSR-Client-IP", clientIp);
+		}
 	}
 	return fetch(request);
 };

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -98,6 +98,13 @@ const reportToHeader = JSON.stringify({
 // either side means no forwarding, which is exactly the old behaviour, so the
 // two Workers can be deployed in either order.
 //
+// The User-Agent rides along for the same reason, and it is the *only* way the
+// API can see one: SvelteKit copies cookie/origin/authorization/accept onto a
+// server-side fetch and nothing else. The read limiters exempt link-preview
+// scrapers by UA, and an unfurl is always a server-rendered load — so without
+// this the exemption covers nothing and Discord's crawler is metered as an
+// ordinary visitor until it 429s and every preview card breaks.
+//
 // Header names are duplicated from cloud/src/util.ts — separate builds, no
 // shared module between them.
 export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
@@ -115,6 +122,8 @@ export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
 				event.request.headers.get("CF-Connecting-IP") ??
 				event.getClientAddress();
 			if (clientIp) request.headers.set("X-SSR-Client-IP", clientIp);
+			const clientUa = event.request.headers.get("User-Agent");
+			if (clientUa) request.headers.set("X-SSR-Client-UA", clientUa);
 		}
 	}
 	return fetch(request);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -98,12 +98,14 @@ const reportToHeader = JSON.stringify({
 // either side means no forwarding, which is exactly the old behaviour, so the
 // two Workers can be deployed in either order.
 //
-// The User-Agent rides along for the same reason, and it is the *only* way the
-// API can see one: SvelteKit copies cookie/origin/authorization/accept onto a
-// server-side fetch and nothing else. The read limiters exempt link-preview
-// scrapers by UA, and an unfurl is always a server-rendered load — so without
-// this the exemption covers nothing and Discord's crawler is metered as an
-// ordinary visitor until it 429s and every preview card breaks.
+// The address is all we forward. The visitor's User-Agent doesn't survive the
+// hop either, and sending it would switch on the API's scraper exemption
+// (isScraperUA in cloud/src/games.ts) for ordinary site traffic — an exemption
+// keyed on a string the caller types, granted before both the rate-limit gate
+// and its audit row. Anyone sending `User-Agent: Discordbot/2.0` here would
+// become unmetered and invisible at once. Forwarding the address alone already
+// leaves link-preview crawlers better off than they were: metered against
+// their own IP instead of pooled onto the egress with everyone else.
 //
 // Header names are duplicated from cloud/src/util.ts — separate builds, no
 // shared module between them.
@@ -121,9 +123,13 @@ export const handleFetch: HandleFetch = ({ event, request, fetch }) => {
 			const clientIp =
 				event.request.headers.get("CF-Connecting-IP") ??
 				event.getClientAddress();
+			// Deleted, not just conditionally set: the key goes out unconditionally
+			// above, so a request that reached this subrequest carrying an address
+			// we didn't put there would go out keyed and believed. Nothing copies
+			// visitor headers onto a cross-origin server fetch today — this is what
+			// keeps that from being load-bearing.
+			request.headers.delete("X-SSR-Client-IP");
 			if (clientIp) request.headers.set("X-SSR-Client-IP", clientIp);
-			const clientUa = event.request.headers.get("User-Agent");
-			if (clientUa) request.headers.set("X-SSR-Client-UA", clientUa);
 		}
 	}
 	return fetch(request);

--- a/src/lib/users/profile-load.ts
+++ b/src/lib/users/profile-load.ts
@@ -13,6 +13,7 @@ import {
 	type CollectionsListResponse,
 	type UserProfile,
 } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import { loginBounce } from "$lib/utils/safe-next";
 import type { ChartBundle, UserScope } from "$lib/stats/types";
 
@@ -154,13 +155,18 @@ export async function buildProfilePage(args: {
 export type ProfilePageData = Awaited<ReturnType<typeof buildProfilePage>>;
 
 // Shared failure mapping for both routes: an anonymous visitor hitting a
-// session-required sub-fetch bounces to login, a missing user is a 404, and
-// everything else — including SvelteKit's own redirect()/error() throws, which
-// is what carries the id route's 307 out — propagates untouched.
+// session-required sub-fetch bounces to login, a spent read budget is a 429, a
+// missing user is a 404, and everything else — including SvelteKit's own
+// redirect()/error() throws, which is what carries the id route's 307 out —
+// propagates untouched.
+//
+// The 429 reaches here through the Tournaments tab: getUserTournaments draws on
+// the per-IP tournament_view budget, the same one the /tournaments pages spend.
 export function rethrowProfileLoadError(err: unknown, url: URL): never {
 	if (err instanceof UnauthorizedError) {
 		throw redirect(303, loginBounce(url));
 	}
+	rethrowRateLimit(err);
 	if (err instanceof ApiError && err.status === 404) {
 		throw error(404, "User not found");
 	}

--- a/src/lib/utils/load-errors.ts
+++ b/src/lib/utils/load-errors.ts
@@ -1,0 +1,26 @@
+// Error mapping shared by SvelteKit `load` functions.
+//
+// Loaders own their own 404/403 wording — "Game not found" and "Tournament
+// not found" are different pages. The 429 case is the one every rate-limited
+// loader answers identically, so it lives here rather than being re-derived
+// (or, as on the tournament loaders before #196, forgotten).
+
+import { error } from "@sveltejs/kit";
+import { ApiError } from "$lib/api-cloud";
+
+// Re-throw a spent per-IP read budget as a SvelteKit 429.
+//
+// Every Worker read limiter (anon_read, tournament_view,
+// tournament_link_view) answers 429 once an IP's hourly bucket is full. A
+// loader with no branch for it lets the ApiError fall through unhandled,
+// which SvelteKit renders as a 500 — and a 500 gets cached by CDNs where a
+// 429 doesn't, so the error outlives the rolling window that clears the
+// limit. Reloading is the user's only remedy, so the status has to say so.
+//
+// No-op for anything else; call it first and let the caller's own branches
+// (and final `throw err`) handle the rest.
+export function rethrowRateLimit(err: unknown): void {
+	if (err instanceof ApiError && err.status === 429) {
+		throw error(429, "Too many requests. Try again in a few minutes.");
+	}
+}

--- a/src/lib/utils/load-errors.ts
+++ b/src/lib/utils/load-errors.ts
@@ -10,12 +10,13 @@ import { ApiError } from "$lib/api-cloud";
 
 // Re-throw a spent per-IP read budget as a SvelteKit 429.
 //
-// Every Worker read limiter (anon_read, tournament_view,
+// Every Worker read limiter (anon_read, tournament_view, tournament_list_view,
 // tournament_link_view) answers 429 once an IP's hourly bucket is full. A
-// loader with no branch for it lets the ApiError fall through unhandled,
-// which SvelteKit renders as a 500 — and a 500 gets cached by CDNs where a
-// 429 doesn't, so the error outlives the rolling window that clears the
-// limit. Reloading is the user's only remedy, so the status has to say so.
+// loader with no branch for it lets the ApiError fall through unhandled, and
+// SvelteKit renders that as a 500 — "Something went wrong", which is both
+// untrue and unactionable. Waiting out the rolling hour is the whole remedy,
+// so the status and the copy have to say that; a 500 tells the visitor to
+// give up and tells us to go looking for a bug that isn't there.
 //
 // No-op for anything else; call it first and let the caller's own branches
 // (and final `throw err`) handle the rest.

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -15,9 +15,11 @@
 				? "Not allowed"
 				: status === 401
 					? "Sign in required"
-					: status >= 500
-						? "Something went wrong"
-						: "Error",
+					: status === 429
+						? "Too many requests"
+						: status >= 500
+							? "Something went wrong"
+							: "Error",
 	);
 
 	// Only offer "Go back" when this tab has a prior history entry —

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -5,6 +5,7 @@
 import { redirect } from "@sveltejs/kit";
 import { cloudApi } from "$lib/api-cloud";
 import type { CreatorVideo, TournamentVideo } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import { safeNext } from "$lib/utils/safe-next";
 import type { PageLoad } from "./$types";
 
@@ -61,14 +62,34 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	// All fetches are best-effort: a transient worker hiccup shouldn't
 	// blank the home page. Failures fall through to empty — the section
 	// just shows its empty-state copy.
+	//
+	// A spent read budget is the exception, on every one of them. The empty
+	// state reads as "there are no tournaments and nothing has been shared
+	// lately", which is a different and wrong answer to "you've made too many
+	// requests" — and it hides the thing an operator most needs to see, since
+	// this page is the busiest reader of both the tournament_list_view and
+	// anon_read budgets. Same rule as every sibling loader, via
+	// rethrowRateLimit.
 	const [recentRes, tournamentsRes, creatorVideos, tournamentVideos] =
 		await Promise.all([
-			cloudApi.listPublicRecent({ fetch }).catch(() => ({ games: [] })),
+			cloudApi.listPublicRecent({ fetch }).catch((err: unknown) => {
+				rethrowRateLimit(err);
+				return { games: [] };
+			}),
 			cloudApi
 				.listTournaments({ limit: 50 }, { fetch })
-				.catch(() => ({ tournaments: [], limit: 0, offset: 0 })),
-			cloudApi.getCreatorVideos({ fetch }).catch(() => []),
-			cloudApi.getTournamentVideos({ fetch }).catch(() => []),
+				.catch((err: unknown) => {
+					rethrowRateLimit(err);
+					return { tournaments: [], limit: 0, offset: 0 };
+				}),
+			cloudApi.getCreatorVideos({ fetch }).catch((err: unknown) => {
+				rethrowRateLimit(err);
+				return [];
+			}),
+			cloudApi.getTournamentVideos({ fetch }).catch((err: unknown) => {
+				rethrowRateLimit(err);
+				return [];
+			}),
 		]);
 
 	return {

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -63,13 +63,17 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 	// blank the home page. Failures fall through to empty — the section
 	// just shows its empty-state copy.
 	//
-	// A spent read budget is the exception, on every one of them. The empty
+	// A spent read budget is the exception, on the two that have one. The empty
 	// state reads as "there are no tournaments and nothing has been shared
 	// lately", which is a different and wrong answer to "you've made too many
 	// requests" — and it hides the thing an operator most needs to see, since
 	// this page is the busiest reader of both the tournament_list_view and
 	// anon_read budgets. Same rule as every sibling loader, via
 	// rethrowRateLimit.
+	//
+	// The two video feeds are deliberately outside the read budgets and answer
+	// 200 by construction — each handler swallows its own upstream failures to
+	// an empty list — so there is no 429 for them to re-throw.
 	const [recentRes, tournamentsRes, creatorVideos, tournamentVideos] =
 		await Promise.all([
 			cloudApi.listPublicRecent({ fetch }).catch((err: unknown) => {
@@ -82,14 +86,8 @@ export const load: PageLoad = async ({ fetch, parent, url }) => {
 					rethrowRateLimit(err);
 					return { tournaments: [], limit: 0, offset: 0 };
 				}),
-			cloudApi.getCreatorVideos({ fetch }).catch((err: unknown) => {
-				rethrowRateLimit(err);
-				return [];
-			}),
-			cloudApi.getTournamentVideos({ fetch }).catch((err: unknown) => {
-				rethrowRateLimit(err);
-				return [];
-			}),
+			cloudApi.getCreatorVideos({ fetch }).catch(() => []),
+			cloudApi.getTournamentVideos({ fetch }).catch(() => []),
 		]);
 
 	return {

--- a/src/routes/games/[id]/+page.ts
+++ b/src/routes/games/[id]/+page.ts
@@ -7,6 +7,7 @@ import {
 } from "$lib/api-cloud";
 import type { PageMeta } from "$lib/page-meta";
 import { formatEnum, formatGameTitle } from "$lib/utils/formatting";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import { loginBounce } from "$lib/utils/safe-next";
 import type { PageLoad } from "./$types";
 
@@ -67,12 +68,9 @@ function mapApiErrorToPage(err: unknown): never {
 	if (err instanceof ApiError && err.status === 403) {
 		throw error(403, "You don't have access to this game");
 	}
-	if (err instanceof ApiError && err.status === 429) {
-		// Per-IP read limiter exhausted. Surface as 429 (not 500) so re-load
-		// is the user's only remedy and CDNs respect the limit instead of
-		// caching a 500.
-		throw error(429, "Too many requests. Try again in a few minutes.");
-	}
+	// Per-IP read limiter exhausted — one shared rule across every
+	// rate-limited loader.
+	rethrowRateLimit(err);
 	throw err;
 }
 

--- a/src/routes/tournaments/+page.ts
+++ b/src/routes/tournaments/+page.ts
@@ -1,5 +1,6 @@
 import { error } from "@sveltejs/kit";
 import { ApiError, cloudApi } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import type { PageLoad } from "./$types";
 
 export const load: PageLoad = async ({ fetch }) => {
@@ -17,6 +18,7 @@ export const load: PageLoad = async ({ fetch }) => {
 			},
 		};
 	} catch (err) {
+		rethrowRateLimit(err);
 		// Surface a real 404 as a SvelteKit 404 so the page renders the
 		// not-found view rather than a generic "Internal Error."
 		if (err instanceof ApiError && err.status === 404) {

--- a/src/routes/tournaments/[slug]/+layout.ts
+++ b/src/routes/tournaments/[slug]/+layout.ts
@@ -1,5 +1,6 @@
 import { error } from "@sveltejs/kit";
 import { ApiError, cloudApi } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import type { LayoutLoad } from "./$types";
 
 // Shared tournament data for every page under /tournaments/[slug] (the overview
@@ -8,29 +9,35 @@ import type { LayoutLoad } from "./$types";
 // only its own page meta. SvelteKit merges this layout data into page data.
 export const load: LayoutLoad = async ({ params, fetch }) => {
 	// Public — shared tournament URLs render for anonymous visitors.
-	let tournament;
+	//
+	// All four reads draw on the same per-IP tournament_view budget, so an
+	// exhausted budget fails them together — the parallel block is inside the
+	// try for that reason, not just getTournament. A 404 from one of the three
+	// (the tournament vanished between calls) lands on the not-found page too,
+	// which is the honest answer for that race.
 	try {
-		tournament = await cloudApi.getTournament(params.slug, { fetch });
+		const tournament = await cloudApi.getTournament(params.slug, { fetch });
+
+		// Parallel reads — standings + bracket + recent matches are independent.
+		// Bracket is empty until championship phase; that's fine, the component
+		// renders a placeholder.
+		const [standings, bracket, matches] = await Promise.all([
+			cloudApi.getTournamentStandings(tournament.tournament_id, { fetch }),
+			cloudApi.getTournamentBracket(tournament.tournament_id, { fetch }),
+			cloudApi.getTournamentMatches(tournament.tournament_id, {}, { fetch }),
+		]);
+
+		return {
+			tournament,
+			standings,
+			bracket,
+			matches: matches.matches,
+		};
 	} catch (err) {
+		rethrowRateLimit(err);
 		if (err instanceof ApiError && err.status === 404) {
 			throw error(404, "Tournament not found");
 		}
 		throw err;
 	}
-
-	// Parallel reads — standings + bracket + recent matches are independent.
-	// Bracket is empty until championship phase; that's fine, the component
-	// renders a placeholder.
-	const [standings, bracket, matches] = await Promise.all([
-		cloudApi.getTournamentStandings(tournament.tournament_id, { fetch }),
-		cloudApi.getTournamentBracket(tournament.tournament_id, { fetch }),
-		cloudApi.getTournamentMatches(tournament.tournament_id, {}, { fetch }),
-	]);
-
-	return {
-		tournament,
-		standings,
-		bracket,
-		matches: matches.matches,
-	};
 };

--- a/src/routes/tournaments/[slug]/stats/+page.ts
+++ b/src/routes/tournaments/[slug]/stats/+page.ts
@@ -1,4 +1,5 @@
 import { cloudApi } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import type { PageLoad } from "./$types";
 
 // Tournament stats view. The tournament itself comes from the [slug] layout
@@ -8,16 +9,25 @@ import type { PageLoad } from "./$types";
 // stats. Both reads are independent → fetched in parallel.
 export const load: PageLoad = async ({ parent, fetch }) => {
 	const { tournament } = await parent();
-	const [competition, games] = await Promise.all([
-		cloudApi.getTournamentStats(tournament.tournament_id, { fetch }),
-		cloudApi.getTournamentGamesStats(tournament.tournament_id, { fetch }),
-	]);
-	return {
-		competition,
-		games,
-		meta: {
-			title: `${tournament.name} · Stats - Per-Ankh`,
-			description: `Statistics for ${tournament.name} on Per-Ankh.`,
-		},
-	};
+	// Both reads draw on the per-IP tournament_view budget. The layout's own
+	// reads got there first, so in practice this only fires when the budget
+	// runs out between the two loads — still a 429, not a 500. Everything else
+	// propagates unchanged.
+	try {
+		const [competition, games] = await Promise.all([
+			cloudApi.getTournamentStats(tournament.tournament_id, { fetch }),
+			cloudApi.getTournamentGamesStats(tournament.tournament_id, { fetch }),
+		]);
+		return {
+			competition,
+			games,
+			meta: {
+				title: `${tournament.name} · Stats - Per-Ankh`,
+				description: `Statistics for ${tournament.name} on Per-Ankh.`,
+			},
+		};
+	} catch (err) {
+		rethrowRateLimit(err);
+		throw err;
+	}
 };

--- a/src/routes/tournaments/[slug]/videos/+page.ts
+++ b/src/routes/tournaments/[slug]/videos/+page.ts
@@ -1,4 +1,5 @@
 import { cloudApi } from "$lib/api-cloud";
+import { rethrowRateLimit } from "$lib/utils/load-errors";
 import type { PageLoad } from "./$types";
 
 // Videos view — the uploads from the tournament's admin-set YouTube playlist.
@@ -8,12 +9,21 @@ import type { PageLoad } from "./$types";
 // set, so a direct visit is the only way to reach an unconfigured tournament's
 // Videos view — it renders the empty state rather than 404ing. Best-effort like
 // the home creator feed: an upstream hiccup yields an empty grid, not an error.
+//
+// A spent read budget is the one exception, and it's why this can't be a bare
+// `.catch(() => [])`: the empty grid is indistinguishable from a tournament
+// with no playlist, so the visitor is told there are no videos rather than to
+// come back later. Every sibling tournament loader answers a 429 with the 429
+// page; this one has to as well.
 export const load: PageLoad = async ({ parent, fetch }) => {
 	const { tournament } = await parent();
 	const videos = tournament.youtube_playlist_url
 		? await cloudApi
 				.getTournamentPlaylistVideos(tournament.tournament_id, { fetch })
-				.catch(() => [])
+				.catch((err: unknown) => {
+					rethrowRateLimit(err);
+					return [];
+				})
 		: [];
 	return {
 		videos,


### PR DESCRIPTION
On 2026-08-05, `/tournaments/2026-community-tournament` returned 500 for about an hour. Nobody was looking at tournaments. A crawler was walking `/games/[id]` at ~270 pages/minute, and that was enough to close the tournament pages for everyone.

Two independent defects had to line up for that, and this branch fixes both — plus the reasons the failure was invisible while it was happening.

## 1. Budgets shared by unrelated readers

Every game-page render calls `GET /v1/games/:id/tournament-link`, and that handler charged the **tournament view** budget — before it even checked whether the game is linked to a tournament. So 600 game pages/hour spent the tournament pages' entire hourly allowance, and the tournament pages then 429'd against a budget nothing about tournaments had touched.

The same relationship held for `GET /v1/tournaments`, which the **home page** fetches on every render. That one hadn't caused an outage yet, but it is the busiest surface on the site drawing on the budget that gates `/tournaments/[slug]`.

So there are now three budgets, split by **the surface that spends them, not the feature they belong to**:

| Bucket | Ceiling | Spent by |
| --- | --- | --- |
| `tournament_view` | 2400 reads/hr | the tournament pages — detail, standings, bracket, rounds, matches, match detail, both stats reads, profile Tournaments tab |
| `tournament_list_view` | 600 reads/hr | `GET /v1/tournaments` — the home page's tournament strip, and `/tournaments` |
| `tournament_link_view` | 600 reads/hr | `GET /v1/games/:id/tournament-link` — every `/games/[id]` render |

None of them folds into `anon_read`: the game page calls both `anon_read` and the link read, and the home page calls both `anon_read` and the list read, so sharing would halve one visitor's ceiling on the page they're actually on. That's the same coupling, relocated. Dropping either call was also out — an unrecorded reader makes the limit a no-op on that path.

`enforceTournamentViewRateLimit` generalizes to `enforceReadRateLimit`, so the gate and the recording INSERT stay in one place for all three. The rule the split encodes is written down in `limits.ts`: **a read a busy page makes on every render must not share a budget with the pages it could take down.**

## 2. SSR collapsed every visitor into one address

`per-ankh.app` renders in a Worker, and that Worker's subrequests reach the API from Cloudflare's SSR egress — **one address standing in for every visitor at once**. So *every* per-IP budget (`anon_read`, the three tournament budgets, uploads, downloads, search) was counting the whole site into a single bucket for server-rendered traffic. That's the mechanism that let one crawler's traffic land on everyone else.

The frontend now forwards the visitor's edge address and proves it's ours with a shared `SSR_TRUSTED_KEY`. `adoptTrustedFrontend` settles it once at the top of `fetch`: strip the SSR headers off every inbound request, check the key, then swap `CF-Connecting-IP` for the forwarded address. One chokepoint — so `getClientIp` and every one of its call sites, plus the security-event tee, get the real visitor without a branch.

A trusted request skips the `CF-RAY` test rather than failing it. That test asks whether the caller reached us through the edge; the shared key answers that better, and `CF-RAY` isn't ours to guarantee on a Worker-to-Worker subrequest.

**The address is the only thing forwarded, and the only thing the key buys.**

- **Not the User-Agent.** Carrying it would switch on the scraper exemption (`isScraperUA`) for ordinary site traffic — an exemption keyed on a string the caller types, granted before *both* the gate and the audit INSERT. `User-Agent: Discordbot/2.0` to `per-ankh.app` would then be unmetered **and** absent from the `events` table the incident query in `docs/cloudflare-waf.md` reads. It has also never once applied to a real unfurl: every unfurl arrives as a page fetch the API only ever sees as an SSR subrequest, so `isScraperUA` has seen `null` for the entire SSR era and preview cards worked anyway. Forwarding the address alone leaves link-preview crawlers *better* off than before — metered against their own IPs instead of pooled on the egress. UA-based throttling belongs at the edge, where Cloudflare can tell you whether the bot is verified; that's Recipe 2 in the runbook.
- **Not a discount on reads.** Every read is gated and charged for every caller. See §3.
- `cf` is carried across the request rewrite explicitly — the constructor doesn't inherit it, and the rewrite runs for anyone presenting an SSR header *including a junk one*, so without this `X-SSR-Key: anything` was a one-header way to delete your own country/ASN/bot-score before a handler could read it. Nothing reads `request.cf` downstream today, which is exactly why it's pinned now rather than after something starts.

## 3. One page load charged four to six times

A cold `/tournaments/[slug]` charged the per-IP budget **four** times — tournament, standings, bracket, matches — for one visitor action. The stats page, six. At 600/hour that's ~150 page loads before the tournament pages start refusing, which is not a ceiling anyone should reach by browsing.

The fix is arithmetic, not machinery: **`TOURNAMENT_VIEW_PER_HOUR` goes 600 → 2400**, and every read still charges. That's ~600 tournament page loads an hour, ~400 of the stats page, and it means the same thing whether the visitor arrived by a server-rendered load or clicked through a hydrated one.

An earlier revision of this branch did it the other way — a sub-resource behind `loadViewableTournament` skipped the gate and the count when the caller proved it was our SSR Worker, so a page load cost one slot. That saved three to five cross-region `COUNT(*)` per render and cost more than it saved: the same page charged 1 via SSR and 4–6 via a hydrated navigation, the ceiling meant *reads* to one caller and *page loads* to another, and the rate limiter had a branch on who was asking. Multiplying the number buys the same headroom with none of that, and leaves the shared key answering exactly one question.

The ceilings are therefore stated in **reads** everywhere, with the fan-out given as the conversion factor — `wrangler.toml` says so where an operator retuning mid-event will read it, because the three numbers differ by fan-out and not by generosity.

## 4. The limit rendered as a 500

The tournament loaders had no branch for a 429, so an exhausted budget fell through as an unhandled `ApiError` and SvelteKit rendered a 500 — "Something went wrong", which is both untrue and unactionable when waiting out the rolling hour is the entire remedy.

That lesson was already in the game-detail loader and nowhere else. It's extracted to `rethrowRateLimit()` and wired to **every** rate-limited surface: the tournament list, `[slug]` layout, stats, videos, both profile routes (the Tournaments tab draws on the same budget and had branches for 401/404 only), and the **home page**, whose four `.catch(() => empty)` turned a spent budget into "there are no tournaments and nothing has been shared lately" — the busiest reader of two budgets, silently reporting an empty site.

Loaders keep their own 404/403 wording, which differs per page. The `[slug]` layout also moves its standings/bracket/matches `Promise.all` inside the `try` — all four reads share one budget, so they fail together, and covering only `getTournament` left the common case uncovered. `+error.svelte` gets a 429 heading; it rendered "429 — Error".

## 5. Operability — the failure modes that were silent

- **All three ceilings are wrangler vars**, retunable mid-event without a redeploy. All three share one parse helper so they can't drift on a mangled value, and that helper now **logs `read_ceiling_unparseable`** when it discards one. Falling back to the default is correct; doing it silently means an operator who mistypes a ceiling during an incident sees the change land and nothing happen — and `0`, the value most plausibly reached for under load, is one of the discarded ones. (The var-vs-secret collision, and the fact that an incident-time secret only survives until the next deploy, is documented in `wrangler.toml`.)
- **`secrets.ssr_trust` preflight check.** `SSR_TRUSTED_KEY` missing on either Worker is the one config state with no runtime signal at all: `ssr_forward_rejected` fires on a *mismatched* key, and a Worker with no key has nothing to reject. So a half-finished rollout silently restores 2026-08-05 conditions. Excluding it from the required-secrets list is right for exactly one deploy window, and nothing was going to close that window — so the check grades the three states instead: both set passes, **neither set warns** (the documented window, so it must not block), **exactly one fails non-blockingly** (never intentional, but the deploy in front of it is probably unrelated). The `wrangler secret list` parsing is extracted rather than copied, since this asks the same question of a second Worker.
- **Read-audit failures log under `audit_event_log_failed`** like every other audit-insert catch in the Worker (nine sites in games.ts, plus auth.ts, online-ids.ts and share-legacy.ts). This helper minted a name per budget, so one condition reached the log sinks under names no query joins.
- **A WAF runbook** (`docs/cloudflare-waf.md`) for the no-deploy lever this incident didn't have — including the constraint that makes edge rules here non-obvious: an IP-keyed rule on the *API* hostname throttles every visitor at once, so client-keyed rules must match `per-ankh.app`. Also records that `robots.txt` is Cloudflare Managed content, which is why it isn't in this repo.
- **Docs match what shipped.** The runbook's diagnostic query filtered on `tournament_view` alone — it would have come back clean during exactly the incident it exists for. It now groups all four read buckets, says what a Cloudflare egress address at the top means *today* (forwarding is broken, not "this is SSR"), and warns that a **quiet** result during visible load is a signal rather than an all-clear, since an exempt read leaves no `events` row at all. `docs/api-reference.md` gains what "per IP" now means for server-rendered traffic and states every ceiling in reads.

## Deploying

`SSR_TRUSTED_KEY` is one value on **both** Workers (frontend and API) — see §3.2 of `docs/cloud-deploy-plan.md`. It's deliberately *not* in the preflight's required list: both sides check the key, so until both hold it nothing is forwarded and every counter behaves exactly as it does today. That means **the two Workers deploy in either order**, and an unset key is a working state rather than an outage. It is now *checked* rather than merely documented — `secrets.ssr_trust` prints the state on every preflight, so the window can't quietly become permanent.

`TOURNAMENT_VIEW_PER_HOUR` changes value in this PR (600 → 2400). It ships in both `[vars]` blocks, so no operator action is needed — but an override set with `wrangler secret put` during an incident will be replaced by this number on deploy, same as before.

Locally, copying `cloud/.dev.vars.example` to `cloud/.dev.vars` exercises the same path — the example's value matches the committed `.env.development`.

## Testing

New: `cloud/test/integration/ssr-trust.test.ts` — header stripping, key mismatch, blank-key handling, the adopted address reaching `getClientIp` and the security tee, body and `cf` survival across the rewrite, that a claimed UA buys nothing, and that a trusted caller and a browser are charged **identically** for the same four reads. Plus the three budgets' independent wiring in `rate-limit-view.test.ts` and `limits.test.ts` — own var, own fallback, own error code, draining one leaves the others serving.

`npm run lint` clean, `svelte-check` 0 errors / 0 warnings across 1301 files, `tsc --noEmit` clean for the Worker and frontend, `prettier --check .` clean, `cloud/` suite 758 passing. The 4 failures in `canonical-map-options.test.ts` are the pre-existing DOTA schema drift on `main` (#115/#141) — untouched by this branch.

## Deliberately not in scope

`handleUserTournaments` (`/u/[slug]?tab=tournaments`) still draws on `tournament_view`. It's a lazy fetch — only when that tab is open — so it isn't a per-render caller like the list and link reads, and it reads the same tables the tournament pages do. Worth revisiting if profile traffic ever grows into the same shape; noted here so it's a decision rather than an omission.
